### PR TITLE
Harden directory traversal, CLI safety, and release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
   release:
     runs-on: windows-latest
 
+    env:
+      CODE_SIGNING_CERT: ${{ secrets.CODE_SIGNING_CERT }}
+      CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -32,10 +36,7 @@ jobs:
         run: dotnet publish sources\EncodingChecker\EncodingChecker.csproj -p:PublishProfile=SelfContainedRelease
 
       - name: Code-sign executables
-        if: ${{ secrets.CODE_SIGNING_CERT != '' && secrets.CODE_SIGNING_CERT_PASSWORD != '' }}
-        env:
-          CODE_SIGNING_CERT: ${{ secrets.CODE_SIGNING_CERT }}
-          CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+        if: ${{ env.CODE_SIGNING_CERT != '' && env.CODE_SIGNING_CERT_PASSWORD != '' }}
         shell: pwsh
         run: |
           $certPath = Join-Path $env:RUNNER_TEMP "codesign.pfx"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,52 @@ jobs:
       - name: Test
         run: dotnet test sources\EncodingChecker.sln --configuration Release --no-build
 
-      - name: Publish single-file executable
+      - name: Publish framework-dependent single-file executable
         run: dotnet publish sources\EncodingChecker\EncodingChecker.csproj -p:PublishProfile=FolderProfile
+
+      - name: Publish self-contained single-file executable
+        run: dotnet publish sources\EncodingChecker\EncodingChecker.csproj -p:PublishProfile=SelfContainedRelease
+
+      - name: Code-sign executables
+        if: ${{ secrets.CODE_SIGNING_CERT != '' && secrets.CODE_SIGNING_CERT_PASSWORD != '' }}
+        env:
+          CODE_SIGNING_CERT: ${{ secrets.CODE_SIGNING_CERT }}
+          CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+        shell: pwsh
+        run: |
+          $certPath = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+          [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:CODE_SIGNING_CERT))
+
+          try {
+            $signtool = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter "signtool.exe" |
+              Where-Object { $_.FullName -like "*\x64\*" } |
+              Select-Object -First 1 -ExpandProperty FullName
+
+            if (-not $signtool) {
+              throw "signtool.exe not found on this runner image."
+            }
+
+            & $signtool sign /f $certPath /p $env:CODE_SIGNING_CERT_PASSWORD /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 `
+              "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64\EncodingChecker.exe" `
+              "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64-selfcontained\EncodingChecker.exe"
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool exited with code $LASTEXITCODE."
+            }
+          } finally {
+            Remove-Item $certPath -Force -ErrorAction SilentlyContinue
+          }
 
       - name: Package
         shell: pwsh
         run: |
           Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64\*" -DestinationPath "EncodingChecker.zip"
+          Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64-selfcontained\*" -DestinationPath "EncodingChecker-selfcontained.zip"
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
-          gh release create "${{ github.ref_name }}" EncodingChecker.zip
+          gh release create "${{ github.ref_name }}" EncodingChecker.zip EncodingChecker-selfcontained.zip
           --title "${{ github.ref_name }}"
           --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -265,6 +265,7 @@ publish/
 *.pubxml
 # Used by the release workflow; contains no secrets.
 !sources/EncodingChecker/Properties/PublishProfiles/FolderProfile.pubxml
+!sources/EncodingChecker/Properties/PublishProfiles/SelfContainedRelease.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ File Encoding Checker detects, validates, and converts the text encoding of one 
 
 Requires the [.NET 10 Desktop Runtime](https://dotnet.microsoft.com/download) (Windows only).
 
+Each [release](https://github.com/amrali-eg/EncodingChecker/releases) publishes two single-file builds: `EncodingChecker.zip` (framework-dependent, requires the .NET 10 Desktop Runtime above) and `EncodingChecker-selfcontained.zip` (larger, but runs on a machine with no .NET runtime installed).
+
 ![form image](./form.png "File Encoding Checker Form Preview")
 
 ## Highlights

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ EncodingChecker.exe
                                    # -Validate, fails) conversion — useful as a CI gate
 ```
 
-`-Include`/`-Exclude` are comma-separated wildcard file-name patterns; `.git`, `.svn`, `.hg`, `.vs`, `.idea`, `bin`, `obj`, `node_modules`, `packages`, `dist`, `build`, and `target` directories are always skipped. Convert, Validate, and Detect-only are mutually exclusive modes.
+`-Include`/`-Exclude` are comma-separated wildcard patterns. A pattern with no `/` or `\` matches just the filename (e.g. `*.cs` matches at any depth); a pattern containing a separator matches the path relative to `-BasePath` instead (e.g. `src/*.cs` matches only under `src`, `\` and `/` behave the same way). `.git`, `.svn`, `.hg`, `.vs`, `.idea`, `bin`, `obj`, `node_modules`, `packages`, `dist`, `build`, and `target` directories are always skipped. Convert, Validate, and Detect-only are mutually exclusive modes.
 
 Exit codes: `0` clean, `1` usage/argument error, `2` `-FailOnChanges` triggered, `3` one or more files failed to process, `4` cancelled (Ctrl+C).
 

--- a/sources/EncodingChecker.Tests/AssemblySetup.cs
+++ b/sources/EncodingChecker.Tests/AssemblySetup.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// One-time test-assembly setup, run automatically before any test executes.
+/// </summary>
+internal static class AssemblySetup
+{
+    /// <summary>
+    /// Registers legacy code-page support once for the whole test run, instead of every
+    /// test class that needs a legacy encoding (windows-1252, etc.) repeating the call in
+    /// its own constructor.
+    /// </summary>
+    [ModuleInitializer]
+    internal static void RegisterCodePagesProvider()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+}

--- a/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
+++ b/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
@@ -60,6 +60,33 @@ public sealed class BackupIntegrityTests : IDisposable
     }
 
     [Fact]
+    public void Backup_SuccessfulConversion_LeavesNoTempArtifactBehind()
+    {
+        // The backup is now written via a temp-file-then-atomic-replace sequence
+        // (matching LineEndingNormalizer's LosslessFileWriter.CreateBackup), not a
+        // plain File.Copy - confirm the "*.bak.<guid>.tmp" sibling never survives.
+        string path = Path.Combine(_root, "convert-me.txt");
+        File.WriteAllText(path, TestContent.Multilingual, new UTF8Encoding(false));
+
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Convert,
+            TargetCharset = "utf-16",
+            TargetWriteBom = true,
+            Backup = true,
+        };
+
+        var entries = new List<ConversionReportEntry>();
+        ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
+
+        Assert.Equal(ConversionRowResult.Converted, Assert.Single(entries).Result);
+        Assert.True(File.Exists(path + ".bak"));
+        // Temp filename shape: "<name>.<guid>.bak.tmp" - the guid precedes ".bak.tmp".
+        Assert.Empty(Directory.GetFiles(_root, "*.bak.tmp"));
+    }
+
+    [Fact]
     public void Backup_OverwritesAnyPreviousBackupFile()
     {
         string path = Path.Combine(_root, "convert-me.txt");

--- a/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
+++ b/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
@@ -61,9 +61,8 @@ public sealed class BackupIntegrityTests : IDisposable
     [Fact]
     public void Backup_SuccessfulConversion_LeavesNoTempArtifactBehind()
     {
-        // The backup is now written via a temp-file-then-atomic-replace sequence
-        // (matching LineEndingNormalizer's LosslessFileWriter.CreateBackup), not a
-        // plain File.Copy - confirm the "*.bak.<guid>.tmp" sibling never survives.
+        // Backup is now temp-file-then-atomic-replace, not a plain File.Copy -
+        // confirm the "*.bak.<guid>.tmp" sibling never survives.
         string path = Path.Combine(_root, "convert-me.txt");
         File.WriteAllText(path, TestContent.Multilingual, new UTF8Encoding(false));
 
@@ -115,10 +114,8 @@ public sealed class BackupIntegrityTests : IDisposable
     [Fact]
     public void Backup_WildcardInclude_NeverScansItsOwnBakOrTempFiles()
     {
-        // Regression test: -Include "*" combined with -Backup must not re-scan the
-        // .bak files it just created, across repeated runs - doing so used to cascade
-        // (.bak, .bak.bak, ...) and race a file's own backup write against another
-        // worker independently reading/converting that same .bak as its own entry.
+        // Regression test: -Include "*" with -Backup must not re-scan its own .bak
+        // output - that used to cascade (.bak.bak, ...) and race backup writes.
         string path = Path.Combine(_root, "convert-me.txt");
         File.WriteAllText(path, TestContent.Multilingual, new UnicodeEncoding(false, true));
 

--- a/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
+++ b/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
@@ -10,7 +10,6 @@ public sealed class BackupIntegrityTests : IDisposable
     public BackupIntegrityTests()
     {
         _root = Directory.CreateTempSubdirectory("ec_backup_").FullName;
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
     }
 
     public void Dispose()

--- a/sources/EncodingChecker.Tests/DirectoryTraversalWarningTests.cs
+++ b/sources/EncodingChecker.Tests/DirectoryTraversalWarningTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace EncodingChecker.Tests;
@@ -33,6 +34,83 @@ public sealed class DirectoryTraversalWarningTests
         string warning = Assert.Single(warnings);
         Assert.Contains("cannot list", warning, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(ghostRoot, warning);
+    }
+
+    [Fact]
+    public void AclDeniedSubdirectory_ReportsWarning_ScanContinuesPastIt()
+    {
+        // Regression test for a real gap: EnumerationOptions.IgnoreInaccessible
+        // defaults to true, so without explicitly setting it false, an
+        // access-denied subdirectory was silently dropped with no warning at
+        // all, instead of hitting the catch block below that reports one.
+        string root = Directory.CreateTempSubdirectory("ec_traversal_acl_").FullName;
+
+        try
+        {
+            string deniedDir = Path.Combine(root, "denied");
+            Directory.CreateDirectory(deniedDir);
+            File.WriteAllText(Path.Combine(deniedDir, "secret.txt"), "x");
+            File.WriteAllText(Path.Combine(root, "visible.txt"), "x");
+
+            string user = $"{Environment.UserDomainName}\\{Environment.UserName}";
+
+            var denyPsi = new ProcessStartInfo(
+                "icacls",
+                $"\"{deniedDir}\" /deny \"{user}:(OI)(CI)(RX)\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using var denyProc = Process.Start(denyPsi)!;
+            denyProc.WaitForExit(10000);
+
+            if (denyProc.ExitCode != 0)
+            {
+                // icacls unavailable/blocked in this environment; nothing to
+                // verify, but don't fail the suite over an environment gap.
+                return;
+            }
+
+            try
+            {
+                List<Regex> matchAll = DirectoryTraversal.CompilePatterns(["*"], defaultToMatchAll: true);
+
+                var warnings = new List<string>();
+
+                var found = DirectoryTraversal.EnumerateFiles(
+                    root,
+                    includeSubdirectories: true,
+                    matchAll,
+                    [],
+                    excludedFullPath: null,
+                    onWarning: warnings.Add).ToList();
+
+                if (warnings.Count == 0 && found.Count == 2)
+                {
+                    // The deny didn't actually take effect (e.g. running elevated
+                    // as an account the DACL doesn't restrict) - environment gap,
+                    // not a product defect.
+                    return;
+                }
+
+                string found1 = Assert.Single(found);
+                Assert.Contains("visible.txt", found1);
+
+                string warning = Assert.Single(warnings);
+                Assert.Contains("cannot list", warning, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains(deniedDir, warning);
+            }
+            finally
+            {
+                Process.Start("icacls", $"\"{deniedDir}\" /reset")?.WaitForExit(5000);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/DirectoryTraversalWarningTests.cs
+++ b/sources/EncodingChecker.Tests/DirectoryTraversalWarningTests.cs
@@ -1,0 +1,67 @@
+using System.Text.RegularExpressions;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A directory-listing failure (access denied, vanished mid-scan) must be reported through
+/// the onWarning callback instead of being silently swallowed, without aborting the scan.
+/// </summary>
+public sealed class DirectoryTraversalWarningTests
+{
+    [Fact]
+    public void UnlistableBaseDirectory_ReportsWarning_ReturnsEmptyRatherThanThrowing()
+    {
+        string ghostRoot = Path.Combine(
+            Path.GetTempPath(),
+            "ec-tests-ghost-" + Guid.NewGuid().ToString("N"));
+
+        List<Regex> matchAll = DirectoryTraversal.CompilePatterns(["*"], defaultToMatchAll: true);
+
+        var warnings = new List<string>();
+
+        // Never created, so listing it fails with DirectoryNotFoundException.
+        var found = DirectoryTraversal.EnumerateFiles(
+            ghostRoot,
+            includeSubdirectories: true,
+            matchAll,
+            [],
+            excludedFullPath: null,
+            onWarning: warnings.Add).ToList();
+
+        Assert.Empty(found);
+
+        string warning = Assert.Single(warnings);
+        Assert.Contains("cannot list", warning, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(ghostRoot, warning);
+    }
+
+    [Fact]
+    public void AccessibleBaseDirectory_ReportsNoWarnings()
+    {
+        string root = Directory.CreateTempSubdirectory("ec_traversal_warning_").FullName;
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "a.txt"), "x");
+
+            List<Regex> matchAll = DirectoryTraversal.CompilePatterns(["*"], defaultToMatchAll: true);
+
+            var warnings = new List<string>();
+
+            var found = DirectoryTraversal.EnumerateFiles(
+                root,
+                includeSubdirectories: true,
+                matchAll,
+                [],
+                excludedFullPath: null,
+                onWarning: warnings.Add).ToList();
+
+            Assert.Single(found);
+            Assert.Empty(warnings);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/sources/EncodingChecker.Tests/EncodingConverterRobustnessTests.cs
+++ b/sources/EncodingChecker.Tests/EncodingConverterRobustnessTests.cs
@@ -14,7 +14,6 @@ public sealed class EncodingConverterRobustnessTests : IDisposable
     public EncodingConverterRobustnessTests()
     {
         _root = Directory.CreateTempSubdirectory("ec_converter_").FullName;
-        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
     }
 
     public void Dispose()

--- a/sources/EncodingChecker.Tests/ListViewColumnSorterTests.cs
+++ b/sources/EncodingChecker.Tests/ListViewColumnSorterTests.cs
@@ -64,36 +64,43 @@ public sealed class ListViewColumnSorterTests
     }
 
     [Fact]
-    public void PrimaryColumnCaseOnlyDifference_IsNotTreatedAsATie()
+    public void PrimaryColumnCaseOnlyDifference_IsTreatedAsATie()
     {
-        // Documents a real bug, not a design choice (flagged separately for a fix):
-        // the primary comparison is case-insensitive, but CompareRemainingColumns'
-        // tiebreak loop starts at index 0 instead of after SortColumn, so it
-        // redundantly re-compares column 0 ordinally and never truly ties.
+        // The primary comparison is case-insensitive, so "Apple"/"apple" tie on column 0.
+        // The tiebreak must skip column 0 (already compared), not redundantly re-compare
+        // it ordinally - otherwise a case-only difference would decide the order.
         var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
 
         ListViewItem x = Row("Apple", "same");
         ListViewItem y = Row("apple", "same");
 
-        int result = sorter.Compare(x, y);
-
-        Assert.NotEqual(0, result);
-        Assert.Equal(string.CompareOrdinal("Apple", "apple") < 0, result < 0);
+        Assert.Equal(0, sorter.Compare(x, y));
     }
 
     [Fact]
-    public void PrimaryColumnCaseOnlyDifference_WinsOverARealDifferenceInALaterColumn()
+    public void PrimaryColumnCaseOnlyDifference_FallsThroughToRealDifferenceInLaterColumn()
     {
-        // Same bug: column 1 genuinely differs, but the redundant column-0 recheck
-        // fires first and decides the result before column 1 is ever reached.
         var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
 
-        ListViewItem x = Row("Apple", "zzz");
-        ListViewItem y = Row("apple", "aaa");
+        // Column 0 ties (case-insensitive); column 1 genuinely differs and must decide.
+        ListViewItem x = Row("Apple", "aaa");
+        ListViewItem y = Row("apple", "zzz");
 
-        int result = sorter.Compare(x, y);
+        Assert.True(sorter.Compare(x, y) < 0);
+        Assert.True(sorter.Compare(y, x) > 0);
+    }
 
-        Assert.Equal(string.CompareOrdinal("Apple", "apple") < 0, result < 0);
+    [Fact]
+    public void TiebreakSkipsSortColumnWhenNotFirst()
+    {
+        // Same case-only-tie check with SortColumn = 1, to confirm the tiebreak skips
+        // whichever column was already compared, not always index 0.
+        var sorter = new ListViewColumnSorter { SortColumn = 1, Order = SortOrder.Ascending };
+
+        ListViewItem x = Row("same", "Apple");
+        ListViewItem y = Row("same", "apple");
+
+        Assert.Equal(0, sorter.Compare(x, y));
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/ListViewColumnSorterTests.cs
+++ b/sources/EncodingChecker.Tests/ListViewColumnSorterTests.cs
@@ -1,0 +1,114 @@
+using System.Windows.Forms;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// ListViewColumnSorter.Compare is pure logic over ListViewItem/SubItems text - no real
+/// ListView or Form is needed to construct and compare items standalone.
+/// </summary>
+public sealed class ListViewColumnSorterTests
+{
+    private static ListViewItem Row(params string[] columns) => new(columns);
+
+    [Fact]
+    public void Ascending_OrdersLowerValueFirst()
+    {
+        var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
+
+        ListViewItem a = Row("apple");
+        ListViewItem b = Row("banana");
+
+        Assert.True(sorter.Compare(a, b) < 0);
+        Assert.True(sorter.Compare(b, a) > 0);
+    }
+
+    [Fact]
+    public void Descending_InvertsAscendingResult()
+    {
+        var ascending = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
+        var descending = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Descending };
+
+        ListViewItem a = Row("apple");
+        ListViewItem b = Row("banana");
+
+        int ascendingResult = ascending.Compare(a, b);
+        int descendingResult = descending.Compare(a, b);
+
+        Assert.True(ascendingResult < 0);
+        Assert.True(descendingResult > 0);
+        Assert.Equal(-ascendingResult, descendingResult);
+    }
+
+    [Fact]
+    public void TieOnSortColumn_BreaksOnFirstDifferingSubsequentColumn()
+    {
+        var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
+
+        // Column 0 ties ("same"); column 1 differs and must decide the order.
+        ListViewItem x = Row("same", "aaa");
+        ListViewItem y = Row("same", "bbb");
+
+        Assert.True(sorter.Compare(x, y) < 0);
+        Assert.True(sorter.Compare(y, x) > 0);
+    }
+
+    [Fact]
+    public void AllColumnsEqual_ReturnsZero()
+    {
+        var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
+
+        ListViewItem x = Row("same", "also-same", "still-same");
+        ListViewItem y = Row("same", "also-same", "still-same");
+
+        Assert.Equal(0, sorter.Compare(x, y));
+    }
+
+    [Fact]
+    public void PrimaryColumnCaseOnlyDifference_IsNotTreatedAsATie()
+    {
+        // Documents a real, verified quirk (found while writing this test, not a
+        // deliberate design choice - see the code review flag raised alongside this
+        // suite): the primary-column comparison itself IS case-insensitive
+        // (CaseInsensitiveComparer judges "Apple"/"apple" equal), but
+        // CompareRemainingColumns' tiebreak loop starts at index 0 instead of the
+        // column after SortColumn. It redundantly re-compares the primary column
+        // too, this time via string.CompareOrdinal (case-sensitive), so a
+        // primary-column difference that's only a case difference is NOT actually
+        // treated as a tie end-to-end - it resolves ordinally instead of falling
+        // through to genuinely compare the next column.
+        var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
+
+        ListViewItem x = Row("Apple", "same");
+        ListViewItem y = Row("apple", "same");
+
+        int result = sorter.Compare(x, y);
+
+        Assert.NotEqual(0, result);
+        Assert.Equal(string.CompareOrdinal("Apple", "apple") < 0, result < 0);
+    }
+
+    [Fact]
+    public void PrimaryColumnCaseOnlyDifference_WinsOverARealDifferenceInALaterColumn()
+    {
+        // Same quirk, made concrete: column 1 genuinely differs ("aaa" vs "zzz"), but
+        // the tiebreak's redundant re-check of column 0 fires first and decides the
+        // result, so the later column's real difference is never even reached.
+        var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
+
+        ListViewItem x = Row("Apple", "zzz");
+        ListViewItem y = Row("apple", "aaa");
+
+        int result = sorter.Compare(x, y);
+
+        Assert.Equal(string.CompareOrdinal("Apple", "apple") < 0, result < 0);
+    }
+
+    [Fact]
+    public void NonListViewItemArguments_Throw()
+    {
+        var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
+
+        Assert.Throws<ArgumentNullException>(() => sorter.Compare("not a ListViewItem", Row("x")));
+        Assert.Throws<ArgumentNullException>(() => sorter.Compare(Row("x"), "not a ListViewItem"));
+    }
+}

--- a/sources/EncodingChecker.Tests/ListViewColumnSorterTests.cs
+++ b/sources/EncodingChecker.Tests/ListViewColumnSorterTests.cs
@@ -66,16 +66,10 @@ public sealed class ListViewColumnSorterTests
     [Fact]
     public void PrimaryColumnCaseOnlyDifference_IsNotTreatedAsATie()
     {
-        // Documents a real, verified quirk (found while writing this test, not a
-        // deliberate design choice - see the code review flag raised alongside this
-        // suite): the primary-column comparison itself IS case-insensitive
-        // (CaseInsensitiveComparer judges "Apple"/"apple" equal), but
-        // CompareRemainingColumns' tiebreak loop starts at index 0 instead of the
-        // column after SortColumn. It redundantly re-compares the primary column
-        // too, this time via string.CompareOrdinal (case-sensitive), so a
-        // primary-column difference that's only a case difference is NOT actually
-        // treated as a tie end-to-end - it resolves ordinally instead of falling
-        // through to genuinely compare the next column.
+        // Documents a real bug, not a design choice (flagged separately for a fix):
+        // the primary comparison is case-insensitive, but CompareRemainingColumns'
+        // tiebreak loop starts at index 0 instead of after SortColumn, so it
+        // redundantly re-compares column 0 ordinally and never truly ties.
         var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
 
         ListViewItem x = Row("Apple", "same");
@@ -90,9 +84,8 @@ public sealed class ListViewColumnSorterTests
     [Fact]
     public void PrimaryColumnCaseOnlyDifference_WinsOverARealDifferenceInALaterColumn()
     {
-        // Same quirk, made concrete: column 1 genuinely differs ("aaa" vs "zzz"), but
-        // the tiebreak's redundant re-check of column 0 fires first and decides the
-        // result, so the later column's real difference is never even reached.
+        // Same bug: column 1 genuinely differs, but the redundant column-0 recheck
+        // fires first and decides the result before column 1 is ever reached.
         var sorter = new ListViewColumnSorter { SortColumn = 0, Order = SortOrder.Ascending };
 
         ListViewItem x = Row("Apple", "zzz");

--- a/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
+++ b/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
@@ -1,0 +1,87 @@
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// -Include/-Exclude patterns: a mask with no separator matches the bare filename at any
+/// depth (backward compatible); one containing a separator matches the path relative to
+/// the scan root instead, with "/" and "\" treated identically.
+/// </summary>
+public sealed class PathAwarePatternTests : IDisposable
+{
+    private readonly string _root;
+
+    public PathAwarePatternTests()
+    {
+        _root = Directory.CreateTempSubdirectory("ec_path_patterns_").FullName;
+
+        Directory.CreateDirectory(Path.Combine(_root, "src"));
+        Directory.CreateDirectory(Path.Combine(_root, "src", "nested"));
+        Directory.CreateDirectory(Path.Combine(_root, "other"));
+
+        File.WriteAllText(Path.Combine(_root, "root.cs"), "x");
+        File.WriteAllText(Path.Combine(_root, "src", "a.cs"), "x");
+        File.WriteAllText(Path.Combine(_root, "src", "nested", "b.cs"), "x");
+        File.WriteAllText(Path.Combine(_root, "other", "c.cs"), "x");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private HashSet<string> Scan(string includePattern)
+    {
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            IncludePatterns = [includePattern],
+            Action = ScanAction.Detect,
+        };
+
+        var entries = new List<ConversionReportEntry>();
+        ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
+
+        return
+        [
+            .. entries.Select(e =>
+                Path.GetRelativePath(_root, e.FilePath).Replace('\\', '/'))
+        ];
+    }
+
+    [Fact]
+    public void SeparatorFreePattern_StillMatchesAtEveryDepth()
+    {
+        // Regression guard: this must keep matching every *.cs file regardless of depth,
+        // exactly as it did before path-aware matching was introduced.
+        HashSet<string> found = Scan("*.cs");
+
+        Assert.Equal(
+            new HashSet<string> { "root.cs", "src/a.cs", "src/nested/b.cs", "other/c.cs" },
+            found);
+    }
+
+    [Fact]
+    public void PathQualifiedPattern_MatchesOnlyTheIntendedSubtree()
+    {
+        HashSet<string> found = Scan("src/*.cs");
+
+        Assert.Equal(new HashSet<string> { "src/a.cs", "src/nested/b.cs" }, found);
+        Assert.DoesNotContain("root.cs", found);
+        Assert.DoesNotContain("other/c.cs", found);
+    }
+
+    [Fact]
+    public void PathQualifiedPattern_WithBackslash_MatchesIdenticallyToForwardSlash()
+    {
+        HashSet<string> withSlash = Scan("src/*.cs");
+        HashSet<string> withBackslash = Scan(@"src\*.cs");
+
+        Assert.Equal(withSlash, withBackslash);
+    }
+}

--- a/sources/EncodingChecker.Tests/ReparsePointRootTests.cs
+++ b/sources/EncodingChecker.Tests/ReparsePointRootTests.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// ScanEngine.ValidateOptions and Program.TryValidateOptions must both reject a
+/// -BasePath that is itself a symlink/junction, rather than silently scanning through it.
+/// </summary>
+public sealed class ReparsePointRootTests
+{
+    [Fact]
+    public void ReparsePointBaseDirectory_IsRejectedByEngineAndCli_NotSilentlyFollowed()
+    {
+        string root = Directory.CreateTempSubdirectory("ec_reparse_root_").FullName;
+
+        try
+        {
+            string real = Path.Combine(root, "real");
+            Directory.CreateDirectory(real);
+            File.WriteAllText(Path.Combine(real, "file.txt"), "hello");
+
+            string junction = Path.Combine(root, "link");
+
+            var psi = new ProcessStartInfo("cmd.exe", $"/c mklink /J \"{junction}\" \"{real}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using var proc = Process.Start(psi)!;
+            proc.WaitForExit(10000);
+
+            if (proc.ExitCode != 0 || !Directory.Exists(junction))
+            {
+                // mklink unavailable/blocked in this environment; nothing to
+                // verify, but don't fail the suite over an environment gap.
+                return;
+            }
+
+            try
+            {
+                Assert.True(DirectoryTraversal.IsReparsePointDirectory(junction));
+
+                var options = new ScanDirectoryOptions
+                {
+                    BaseDirectory = junction,
+                    Action = ScanAction.Detect,
+                };
+
+                var entries = new List<ConversionReportEntry>();
+
+                Assert.Throws<ArgumentException>(() =>
+                    ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None));
+
+                Assert.Empty(entries);
+
+                var cliOptions = new Program.CliOptions
+                {
+                    BasePath = junction,
+                    Target = "utf-8",
+                };
+
+                bool valid = Program.TryValidateOptions(cliOptions, out string? error);
+
+                Assert.False(valid);
+                Assert.Contains("reparse point", error, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                Process.Start("cmd.exe", $"/c rmdir \"{junction}\"")?.WaitForExit(5000);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsReparsePointDirectory_RealDirectory_ReturnsFalse()
+    {
+        string dir = Directory.CreateTempSubdirectory("ec_reparse_check_").FullName;
+
+        try
+        {
+            Assert.False(DirectoryTraversal.IsReparsePointDirectory(dir));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/sources/EncodingChecker.Tests/ReportSelfExclusionTests.cs
+++ b/sources/EncodingChecker.Tests/ReportSelfExclusionTests.cs
@@ -1,0 +1,84 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A -Report output path inside the scanned tree must never be picked up as an
+/// ordinary scan candidate, even with a broad -Include "*", across repeated runs.
+/// </summary>
+public sealed class ReportSelfExclusionTests : IDisposable
+{
+    private readonly string _root;
+
+    public ReportSelfExclusionTests()
+    {
+        _root = Directory.CreateTempSubdirectory("ec_report_exclusion_").FullName;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    [Fact]
+    public void ReportInsideScannedTree_IsExcludedFromItsOwnAndLaterScans()
+    {
+        string sourcePath = Path.Combine(_root, "source.txt");
+        File.WriteAllText(sourcePath, TestContent.Multilingual, new UTF8Encoding(false));
+
+        string reportPath = Path.Combine(_root, "report.csv");
+
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            IncludePatterns = ["*"],
+            ExcludedFullPath = reportPath,
+            Action = ScanAction.Detect,
+        };
+
+        // Run 1: the report doesn't exist yet, but the path is already excluded.
+        var firstRun = new List<ConversionReportEntry>();
+        ScanEngine.ScanDirectory(options, firstRun.Add, CancellationToken.None);
+        Assert.Equal(sourcePath, Assert.Single(firstRun).FilePath);
+
+        File.WriteAllText(reportPath, "File,Encoding,BOM,Target,BOM,Result\r\n", new UTF8Encoding(false));
+
+        // Run 2: the report file now exists in the scanned tree; a broad -Include "*"
+        // must still not pick it up, since it's excluded by exact full path.
+        var secondRun = new List<ConversionReportEntry>();
+        ScanEngine.ScanDirectory(options, secondRun.Add, CancellationToken.None);
+        Assert.Equal(sourcePath, Assert.Single(secondRun).FilePath);
+    }
+
+    [Fact]
+    public void ReportOutsideScannedTree_ExcludedFullPathHasNoEffect()
+    {
+        string sourcePath = Path.Combine(_root, "source.txt");
+        File.WriteAllText(sourcePath, TestContent.Multilingual, new UTF8Encoding(false));
+
+        string unrelatedPath = Path.Combine(_root, "not-the-report.csv");
+        File.WriteAllText(unrelatedPath, "irrelevant", new UTF8Encoding(false));
+
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            IncludePatterns = ["*"],
+            ExcludedFullPath = Path.Combine(_root, "report.csv"), // never created
+            Action = ScanAction.Detect,
+        };
+
+        var entries = new List<ConversionReportEntry>();
+        ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
+
+        Assert.Equal(2, entries.Count);
+        Assert.Contains(entries, e => e.FilePath == sourcePath);
+        Assert.Contains(entries, e => e.FilePath == unrelatedPath);
+    }
+}

--- a/sources/EncodingChecker.Tests/ScanEngineValidationTests.cs
+++ b/sources/EncodingChecker.Tests/ScanEngineValidationTests.cs
@@ -135,7 +135,7 @@ public sealed class ScanEngineValidationTests : IDisposable
     }
 
     [Fact]
-    public void ScanDirectory_EmptyFile_IsUnknownAndUnchanged_NotAnError()
+    public void ScanDirectory_EmptyFile_IsUnknownAndSkipped_NotAnError()
     {
         File.WriteAllBytes(Path.Combine(_root, "empty.txt"), []);
 
@@ -150,7 +150,9 @@ public sealed class ScanEngineValidationTests : IDisposable
 
         ConversionReportEntry entry = Assert.Single(entries);
         Assert.Equal("(Unknown)", entry.SourceEncoding);
-        Assert.Equal(ConversionRowResult.Unchanged, entry.Result);
+        // Undetectable encoding is Skipped, not Unchanged - "Unchanged" would misleadingly
+        // imply the file was compared against a target and already matched it.
+        Assert.Equal(ConversionRowResult.Skipped, entry.Result);
     }
 
     [Fact]
@@ -172,6 +174,49 @@ public sealed class ScanEngineValidationTests : IDisposable
 
         ConversionReportEntry entry = Assert.Single(entries);
         Assert.Equal("(Unknown)", entry.SourceEncoding);
+        Assert.Equal(ConversionRowResult.Skipped, entry.Result);
+    }
+
+    [Fact]
+    public void ConvertFiles_BinaryFile_IsSkipped_NotConvertedAndBytesUnchanged()
+    {
+        var random = new Random(5678);
+        byte[] randomBytes = new byte[4096];
+        random.NextBytes(randomBytes);
+        string path = Path.Combine(_root, "binary.dat");
+        File.WriteAllBytes(path, randomBytes);
+
+        // Convert mode over a file whose encoding couldn't be detected: must be Skipped,
+        // not silently Unchanged (which would misleadingly imply it already matched
+        // "utf-8"), and must never be written to.
+        var scanOptions = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Convert,
+            TargetCharset = "utf-8",
+        };
+
+        var scanned = new List<ConversionReportEntry>();
+        ScanEngine.ScanDirectory(scanOptions, scanned.Add, CancellationToken.None);
+
+        ConversionReportEntry scanEntry = Assert.Single(scanned);
+        Assert.Equal(ConversionRowResult.Skipped, scanEntry.Result);
+        Assert.Equal(randomBytes, File.ReadAllBytes(path));
+
+        // ConvertFiles (the GUI's "convert previously-scanned entries" path) must reach
+        // the same conclusion independently, not just inherit it from the prior scan.
+        var converted = new ConcurrentBag<ConversionReportEntry>();
+        ScanEngine.ConvertFiles(
+            [scanEntry],
+            "utf-8",
+            targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            converted.Add,
+            CancellationToken.None);
+
+        ConversionReportEntry convertEntry = Assert.Single(converted);
+        Assert.Equal(ConversionRowResult.Skipped, convertEntry.Result);
+        Assert.Equal(randomBytes, File.ReadAllBytes(path));
     }
 
     [Fact]

--- a/sources/EncodingChecker/AboutForm.Designer.cs
+++ b/sources/EncodingChecker/AboutForm.Designer.cs
@@ -1,208 +1,207 @@
-﻿namespace EncodingChecker
+﻿namespace EncodingChecker;
+
+partial class AboutForm
 {
-    partial class AboutForm
+    /// <summary>
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
     {
-        /// <summary>
-        /// Required designer variable.
-        /// </summary>
-        private System.ComponentModel.IContainer components = null;
-
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
+        if (disposing && (components != null))
         {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
+            components.Dispose();
         }
-
-        #region Windows Form Designer generated code
-
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
-        private void InitializeComponent()
-        {
-            System.Windows.Forms.Label lblProductName;
-            System.Windows.Forms.Label lblCredits;
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutForm));
-            this.btnClose = new System.Windows.Forms.Button();
-            this.lblHomepage = new System.Windows.Forms.LinkLabel();
-            this.lblAuthor = new System.Windows.Forms.LinkLabel();
-            this.lblLicense = new System.Windows.Forms.LinkLabel();
-            this.lblCreditsUde = new System.Windows.Forms.LinkLabel();
-            this.lblCreditsCodePlex = new System.Windows.Forms.LinkLabel();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            lblProductName = new System.Windows.Forms.Label();
-            lblVersion = new System.Windows.Forms.Label();
-            lblCredits = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // lblProductName
-            // 
-            lblProductName.AutoSize = true;
-            lblProductName.Font = new System.Drawing.Font("Tahoma", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            lblProductName.Location = new System.Drawing.Point(5, 10);
-            lblProductName.Name = "lblProductName";
-            lblProductName.Size = new System.Drawing.Size(312, 33);
-            lblProductName.TabIndex = 0;
-            lblProductName.Text = "File Encoding Checker";
-            // 
-            // lblVersion
-            // 
-            lblVersion.AutoSize = true;
-            lblVersion.Location = new System.Drawing.Point(15, 48);
-            lblVersion.Name = "lblVersion";
-            lblVersion.Size = new System.Drawing.Size(60, 18);
-            lblVersion.TabIndex = 1;
-            lblVersion.Text = "Version 3.0";
-            lblVersion.UseCompatibleTextRendering = true;
-            // 
-            // lblCredits
-            // 
-            lblCredits.AutoSize = true;
-            lblCredits.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            lblCredits.Location = new System.Drawing.Point(15, 130);
-            lblCredits.Name = "lblCredits";
-            lblCredits.Size = new System.Drawing.Size(49, 18);
-            lblCredits.TabIndex = 5;
-            lblCredits.Text = "Credits:";
-            lblCredits.UseCompatibleTextRendering = true;
-            // 
-            // btnClose
-            // 
-            this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnClose.Location = new System.Drawing.Point(501, 224);
-            this.btnClose.Name = "btnClose";
-            this.btnClose.Size = new System.Drawing.Size(75, 23);
-            this.btnClose.TabIndex = 8;
-            this.btnClose.Text = "Close";
-            this.btnClose.UseVisualStyleBackColor = true;
-            // 
-            // lblHomepage
-            // 
-            this.lblHomepage.AutoSize = true;
-            this.lblHomepage.Location = new System.Drawing.Point(15, 66);
-            this.lblHomepage.Name = "lblHomepage";
-            this.lblHomepage.Size = new System.Drawing.Size(58, 18);
-            this.lblHomepage.TabIndex = 2;
-            this.lblHomepage.TabStop = true;
-            this.lblHomepage.Text = "Homepage";
-            this.lblHomepage.UseCompatibleTextRendering = true;
-            this.lblHomepage.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
-            // 
-            // lblAuthor
-            // 
-            this.lblAuthor.AutoSize = true;
-            this.lblAuthor.LinkArea = new System.Windows.Forms.LinkArea(11, 12);
-            this.lblAuthor.Location = new System.Drawing.Point(15, 89);
-            this.lblAuthor.Name = "lblAuthor";
-            this.lblAuthor.Size = new System.Drawing.Size(131, 18);
-            this.lblAuthor.TabIndex = 3;
-            this.lblAuthor.TabStop = true;
-            this.lblAuthor.Text = "Created by Jeevan James";
-            this.lblAuthor.UseCompatibleTextRendering = true;
-            this.lblAuthor.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
-            // 
-            // lblLicense
-            // 
-            this.lblLicense.AutoSize = true;
-            this.lblLicense.LinkArea = new System.Windows.Forms.LinkArea(19, 26);
-            this.lblLicense.Location = new System.Drawing.Point(15, 107);
-            this.lblLicense.Name = "lblLicense";
-            this.lblLicense.Size = new System.Drawing.Size(229, 18);
-            this.lblLicense.TabIndex = 4;
-            this.lblLicense.TabStop = true;
-            this.lblLicense.Text = "Licensed under the Mozilla Public License 1.1";
-            this.lblLicense.UseCompatibleTextRendering = true;
-            this.lblLicense.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
-            // 
-            // lblCreditsUde
-            // 
-            this.lblCreditsUde.AutoSize = true;
-            this.lblCreditsUde.LinkArea = new System.Windows.Forms.LinkArea(0, 3);
-            this.lblCreditsUde.Location = new System.Drawing.Point(25, 148);
-            this.lblCreditsUde.Name = "lblCreditsUde";
-            this.lblCreditsUde.Size = new System.Drawing.Size(265, 18);
-            this.lblCreditsUde.TabIndex = 6;
-            this.lblCreditsUde.TabStop = true;
-            this.lblCreditsUde.Text = "ude, a C# port of Mozilla Universal Charset Detector";
-            this.lblCreditsUde.UseCompatibleTextRendering = true;
-            this.lblCreditsUde.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
-            // 
-            // lblCreditsCodePlex
-            // 
-            this.lblCreditsCodePlex.AutoSize = true;
-            this.lblCreditsCodePlex.LinkArea = new System.Windows.Forms.LinkArea(0, 8);
-            this.lblCreditsCodePlex.Location = new System.Drawing.Point(25, 166);
-            this.lblCreditsCodePlex.Name = "lblCreditsCodePlex";
-            this.lblCreditsCodePlex.Size = new System.Drawing.Size(149, 18);
-            this.lblCreditsCodePlex.TabIndex = 7;
-            this.lblCreditsCodePlex.TabStop = true;
-            this.lblCreditsCodePlex.Text = "CodePlex, for project hosting";
-            this.lblCreditsCodePlex.UseCompatibleTextRendering = true;
-            this.lblCreditsCodePlex.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
-            this.pictureBox1.Location = new System.Drawing.Point(323, 1);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(256, 256);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
-            this.pictureBox1.TabIndex = 9;
-            this.pictureBox1.TabStop = false;
-            // 
-            // AboutForm
-            // 
-            this.AcceptButton = this.btnClose;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.btnClose;
-            this.ClientSize = new System.Drawing.Size(586, 257);
-            this.Controls.Add(this.lblCreditsCodePlex);
-            this.Controls.Add(this.lblCreditsUde);
-            this.Controls.Add(lblCredits);
-            this.Controls.Add(this.lblLicense);
-            this.Controls.Add(this.lblAuthor);
-            this.Controls.Add(lblVersion);
-            this.Controls.Add(this.lblHomepage);
-            this.Controls.Add(this.btnClose);
-            this.Controls.Add(lblProductName);
-            this.Controls.Add(this.pictureBox1);
-            this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "AboutForm";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
-            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "About";
-            this.Load += new System.EventHandler(this.OnFormLoad);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
-        }
-
-        #endregion
-
-        private System.Windows.Forms.Button btnClose;
-        private System.Windows.Forms.Label lblVersion;
-        private System.Windows.Forms.LinkLabel lblHomepage;
-        private System.Windows.Forms.LinkLabel lblAuthor;
-        private System.Windows.Forms.LinkLabel lblLicense;
-        private System.Windows.Forms.LinkLabel lblCreditsUde;
-        private System.Windows.Forms.LinkLabel lblCreditsCodePlex;
-        private System.Windows.Forms.PictureBox pictureBox1;
+        base.Dispose(disposing);
     }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    /// Required method for Designer support - do not modify
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        System.Windows.Forms.Label lblProductName;
+        System.Windows.Forms.Label lblCredits;
+        System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutForm));
+        this.btnClose = new System.Windows.Forms.Button();
+        this.lblHomepage = new System.Windows.Forms.LinkLabel();
+        this.lblAuthor = new System.Windows.Forms.LinkLabel();
+        this.lblLicense = new System.Windows.Forms.LinkLabel();
+        this.lblCreditsUde = new System.Windows.Forms.LinkLabel();
+        this.lblCreditsCodePlex = new System.Windows.Forms.LinkLabel();
+        this.pictureBox1 = new System.Windows.Forms.PictureBox();
+        lblProductName = new System.Windows.Forms.Label();
+        lblVersion = new System.Windows.Forms.Label();
+        lblCredits = new System.Windows.Forms.Label();
+        ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+        this.SuspendLayout();
+        // 
+        // lblProductName
+        // 
+        lblProductName.AutoSize = true;
+        lblProductName.Font = new System.Drawing.Font("Tahoma", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        lblProductName.Location = new System.Drawing.Point(5, 10);
+        lblProductName.Name = "lblProductName";
+        lblProductName.Size = new System.Drawing.Size(312, 33);
+        lblProductName.TabIndex = 0;
+        lblProductName.Text = "File Encoding Checker";
+        // 
+        // lblVersion
+        // 
+        lblVersion.AutoSize = true;
+        lblVersion.Location = new System.Drawing.Point(15, 48);
+        lblVersion.Name = "lblVersion";
+        lblVersion.Size = new System.Drawing.Size(60, 18);
+        lblVersion.TabIndex = 1;
+        lblVersion.Text = "Version 3.0";
+        lblVersion.UseCompatibleTextRendering = true;
+        // 
+        // lblCredits
+        // 
+        lblCredits.AutoSize = true;
+        lblCredits.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        lblCredits.Location = new System.Drawing.Point(15, 130);
+        lblCredits.Name = "lblCredits";
+        lblCredits.Size = new System.Drawing.Size(49, 18);
+        lblCredits.TabIndex = 5;
+        lblCredits.Text = "Credits:";
+        lblCredits.UseCompatibleTextRendering = true;
+        // 
+        // btnClose
+        // 
+        this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+        this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+        this.btnClose.Location = new System.Drawing.Point(501, 224);
+        this.btnClose.Name = "btnClose";
+        this.btnClose.Size = new System.Drawing.Size(75, 23);
+        this.btnClose.TabIndex = 8;
+        this.btnClose.Text = "Close";
+        this.btnClose.UseVisualStyleBackColor = true;
+        // 
+        // lblHomepage
+        // 
+        this.lblHomepage.AutoSize = true;
+        this.lblHomepage.Location = new System.Drawing.Point(15, 66);
+        this.lblHomepage.Name = "lblHomepage";
+        this.lblHomepage.Size = new System.Drawing.Size(58, 18);
+        this.lblHomepage.TabIndex = 2;
+        this.lblHomepage.TabStop = true;
+        this.lblHomepage.Text = "Homepage";
+        this.lblHomepage.UseCompatibleTextRendering = true;
+        this.lblHomepage.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
+        // 
+        // lblAuthor
+        // 
+        this.lblAuthor.AutoSize = true;
+        this.lblAuthor.LinkArea = new System.Windows.Forms.LinkArea(11, 12);
+        this.lblAuthor.Location = new System.Drawing.Point(15, 89);
+        this.lblAuthor.Name = "lblAuthor";
+        this.lblAuthor.Size = new System.Drawing.Size(131, 18);
+        this.lblAuthor.TabIndex = 3;
+        this.lblAuthor.TabStop = true;
+        this.lblAuthor.Text = "Created by Jeevan James";
+        this.lblAuthor.UseCompatibleTextRendering = true;
+        this.lblAuthor.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
+        // 
+        // lblLicense
+        // 
+        this.lblLicense.AutoSize = true;
+        this.lblLicense.LinkArea = new System.Windows.Forms.LinkArea(19, 26);
+        this.lblLicense.Location = new System.Drawing.Point(15, 107);
+        this.lblLicense.Name = "lblLicense";
+        this.lblLicense.Size = new System.Drawing.Size(229, 18);
+        this.lblLicense.TabIndex = 4;
+        this.lblLicense.TabStop = true;
+        this.lblLicense.Text = "Licensed under the Mozilla Public License 1.1";
+        this.lblLicense.UseCompatibleTextRendering = true;
+        this.lblLicense.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
+        // 
+        // lblCreditsUde
+        // 
+        this.lblCreditsUde.AutoSize = true;
+        this.lblCreditsUde.LinkArea = new System.Windows.Forms.LinkArea(0, 3);
+        this.lblCreditsUde.Location = new System.Drawing.Point(25, 148);
+        this.lblCreditsUde.Name = "lblCreditsUde";
+        this.lblCreditsUde.Size = new System.Drawing.Size(265, 18);
+        this.lblCreditsUde.TabIndex = 6;
+        this.lblCreditsUde.TabStop = true;
+        this.lblCreditsUde.Text = "ude, a C# port of Mozilla Universal Charset Detector";
+        this.lblCreditsUde.UseCompatibleTextRendering = true;
+        this.lblCreditsUde.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
+        // 
+        // lblCreditsCodePlex
+        // 
+        this.lblCreditsCodePlex.AutoSize = true;
+        this.lblCreditsCodePlex.LinkArea = new System.Windows.Forms.LinkArea(0, 8);
+        this.lblCreditsCodePlex.Location = new System.Drawing.Point(25, 166);
+        this.lblCreditsCodePlex.Name = "lblCreditsCodePlex";
+        this.lblCreditsCodePlex.Size = new System.Drawing.Size(149, 18);
+        this.lblCreditsCodePlex.TabIndex = 7;
+        this.lblCreditsCodePlex.TabStop = true;
+        this.lblCreditsCodePlex.Text = "CodePlex, for project hosting";
+        this.lblCreditsCodePlex.UseCompatibleTextRendering = true;
+        this.lblCreditsCodePlex.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
+        // 
+        // pictureBox1
+        // 
+        this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+        this.pictureBox1.Location = new System.Drawing.Point(323, 1);
+        this.pictureBox1.Name = "pictureBox1";
+        this.pictureBox1.Size = new System.Drawing.Size(256, 256);
+        this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
+        this.pictureBox1.TabIndex = 9;
+        this.pictureBox1.TabStop = false;
+        // 
+        // AboutForm
+        // 
+        this.AcceptButton = this.btnClose;
+        this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.CancelButton = this.btnClose;
+        this.ClientSize = new System.Drawing.Size(586, 257);
+        this.Controls.Add(this.lblCreditsCodePlex);
+        this.Controls.Add(this.lblCreditsUde);
+        this.Controls.Add(lblCredits);
+        this.Controls.Add(this.lblLicense);
+        this.Controls.Add(this.lblAuthor);
+        this.Controls.Add(lblVersion);
+        this.Controls.Add(this.lblHomepage);
+        this.Controls.Add(this.btnClose);
+        this.Controls.Add(lblProductName);
+        this.Controls.Add(this.pictureBox1);
+        this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+        this.MaximizeBox = false;
+        this.MinimizeBox = false;
+        this.Name = "AboutForm";
+        this.ShowIcon = false;
+        this.ShowInTaskbar = false;
+        this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+        this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+        this.Text = "About";
+        this.Load += new System.EventHandler(this.OnFormLoad);
+        ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+        this.ResumeLayout(false);
+        this.PerformLayout();
+
+    }
+
+    #endregion
+
+    private System.Windows.Forms.Button btnClose;
+    private System.Windows.Forms.Label lblVersion;
+    private System.Windows.Forms.LinkLabel lblHomepage;
+    private System.Windows.Forms.LinkLabel lblAuthor;
+    private System.Windows.Forms.LinkLabel lblLicense;
+    private System.Windows.Forms.LinkLabel lblCreditsUde;
+    private System.Windows.Forms.LinkLabel lblCreditsCodePlex;
+    private System.Windows.Forms.PictureBox pictureBox1;
 }

--- a/sources/EncodingChecker/AboutForm.cs
+++ b/sources/EncodingChecker/AboutForm.cs
@@ -2,34 +2,33 @@
 using System.Reflection;
 using System.Windows.Forms;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+public partial class AboutForm : Form
 {
-    public partial class AboutForm : Form
+    public AboutForm()
     {
-        public AboutForm()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
+    }
 
-        private void OnFormLoad(object? sender, System.EventArgs e)
-        {
-            // Overrides the designer's static text so this can't drift from the real version.
-            var version = Assembly.GetExecutingAssembly().GetName().Version;
-            if (version is not null)
-                lblVersion.Text = $"Version {version.Major}.{version.Minor}";
+    private void OnFormLoad(object? sender, System.EventArgs e)
+    {
+        // Overrides the designer's static text so this can't drift from the real version.
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        if (version is not null)
+            lblVersion.Text = $"Version {version.Major}.{version.Minor}";
 
-            lblHomepage.Links[0].LinkData = "https://github.com/amrali-eg/EncodingChecker";
-            lblAuthor.Links[0].LinkData = "https://github.com/JeevanJames";
-            lblLicense.Links[0].LinkData = "https://www.mozilla.org/en-US/MPL/2.0/";
-            lblCreditsUde.Links[0].LinkData = "https://github.com/CharsetDetector/UTF-unknown";
-            lblCreditsCodePlex.Links[0].LinkData = "http://encodingchecker.codeplex.com";
-        }
+        lblHomepage.Links[0].LinkData = "https://github.com/amrali-eg/EncodingChecker";
+        lblAuthor.Links[0].LinkData = "https://github.com/JeevanJames";
+        lblLicense.Links[0].LinkData = "https://www.mozilla.org/en-US/MPL/2.0/";
+        lblCreditsUde.Links[0].LinkData = "https://github.com/CharsetDetector/UTF-unknown";
+        lblCreditsCodePlex.Links[0].LinkData = "http://encodingchecker.codeplex.com";
+    }
 
-        private void OnLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
-        {
-            string url = (string)e.Link!.LinkData!;
-            var startInfo = new ProcessStartInfo(url) {UseShellExecute = true};
-            Process.Start(startInfo);
-        }
+    private void OnLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
+    {
+        string url = (string)e.Link!.LinkData!;
+        var startInfo = new ProcessStartInfo(url) {UseShellExecute = true};
+        Process.Start(startInfo);
     }
 }

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -11,6 +11,9 @@ namespace EncodingChecker
         /// <summary>No change was needed.</summary>
         Unchanged,
 
+        /// <summary>Encoding could not be determined, so no action was attempted.</summary>
+        Skipped,
+
         /// <summary>Successfully converted, or would be under a dry run.</summary>
         Converted,
 

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -3,104 +3,103 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+/// <summary>Processing outcome for one file.</summary>
+internal enum ConversionRowResult
 {
-    /// <summary>Processing outcome for one file.</summary>
-    internal enum ConversionRowResult
+    /// <summary>No change was needed.</summary>
+    Unchanged,
+
+    /// <summary>Encoding could not be determined, so no action was attempted.</summary>
+    Skipped,
+
+    /// <summary>Successfully converted, or would be under a dry run.</summary>
+    Converted,
+
+    /// <summary>Validate mode: encoding is not in the accepted set.</summary>
+    Invalid,
+
+    /// <summary>Processing failed.</summary>
+    Error,
+}
+
+/// <summary>Encoding detection/conversion result for one file.</summary>
+internal sealed class ConversionReportEntry
+{
+    internal required string FilePath { get; init; }
+
+    internal required string SourceEncoding { get; init; }
+
+    internal bool SourceHasBom { get; init; }
+
+    internal required string TargetEncoding { get; set; }
+
+    internal bool TargetHasBom { get; set; }
+
+    internal ConversionRowResult Result { get; set; }
+
+    /// <summary>Additional error detail; not included in CSV output.</summary>
+    internal string? Diagnostic { get; set; }
+}
+
+/// <summary>Writes the application's standard comma-delimited CSV report.</summary>
+internal static class ConversionReport
+{
+    private const char DELIMITER = ',';
+
+    internal static void WriteCsv(
+        IEnumerable<ConversionReportEntry> entries,
+        TextWriter writer)
     {
-        /// <summary>No change was needed.</summary>
-        Unchanged,
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(writer);
 
-        /// <summary>Encoding could not be determined, so no action was attempted.</summary>
-        Skipped,
+        writer.WriteLine("File,Encoding,BOM,Target,BOM,Result");
 
-        /// <summary>Successfully converted, or would be under a dry run.</summary>
-        Converted,
+        foreach (ConversionReportEntry entry in entries)
+        {
+            WriteField(writer, entry.FilePath);
+            writer.Write(DELIMITER);
 
-        /// <summary>Validate mode: encoding is not in the accepted set.</summary>
-        Invalid,
+            WriteField(writer, entry.SourceEncoding);
+            writer.Write(DELIMITER);
 
-        /// <summary>Processing failed.</summary>
-        Error,
+            WriteField(writer, entry.SourceHasBom ? "Yes" : "No");
+            writer.Write(DELIMITER);
+
+            WriteField(writer, entry.TargetEncoding);
+            writer.Write(DELIMITER);
+
+            WriteField(writer, entry.TargetHasBom ? "Yes" : "No");
+            writer.Write(DELIMITER);
+
+            writer.WriteLine(entry.Result);
+        }
     }
 
-    /// <summary>Encoding detection/conversion result for one file.</summary>
-    internal sealed class ConversionReportEntry
+    internal static string ToCsvString(IEnumerable<ConversionReportEntry> entries)
     {
-        internal required string FilePath { get; init; }
+        var builder = new StringBuilder();
 
-        internal required string SourceEncoding { get; init; }
+        using var writer = new StringWriter(builder);
+        WriteCsv(entries, writer);
 
-        internal bool SourceHasBom { get; init; }
-
-        internal required string TargetEncoding { get; set; }
-
-        internal bool TargetHasBom { get; set; }
-
-        internal ConversionRowResult Result { get; set; }
-
-        /// <summary>Additional error detail; not included in CSV output.</summary>
-        internal string? Diagnostic { get; set; }
+        return builder.ToString();
     }
 
-    /// <summary>Writes the application's standard comma-delimited CSV report.</summary>
-    internal static class ConversionReport
+    private static void WriteField(TextWriter writer, string? value)
     {
-        private const char DELIMITER = ',';
+        value ??= string.Empty;
 
-        internal static void WriteCsv(
-            IEnumerable<ConversionReportEntry> entries,
-            TextWriter writer)
+        if (value.IndexOfAny([DELIMITER, '"', '\r', '\n']) < 0)
         {
-            ArgumentNullException.ThrowIfNull(entries);
-            ArgumentNullException.ThrowIfNull(writer);
-
-            writer.WriteLine("File,Encoding,BOM,Target,BOM,Result");
-
-            foreach (ConversionReportEntry entry in entries)
-            {
-                WriteField(writer, entry.FilePath);
-                writer.Write(DELIMITER);
-
-                WriteField(writer, entry.SourceEncoding);
-                writer.Write(DELIMITER);
-
-                WriteField(writer, entry.SourceHasBom ? "Yes" : "No");
-                writer.Write(DELIMITER);
-
-                WriteField(writer, entry.TargetEncoding);
-                writer.Write(DELIMITER);
-
-                WriteField(writer, entry.TargetHasBom ? "Yes" : "No");
-                writer.Write(DELIMITER);
-
-                writer.WriteLine(entry.Result);
-            }
+            writer.Write(value);
+            return;
         }
 
-        internal static string ToCsvString(IEnumerable<ConversionReportEntry> entries)
-        {
-            var builder = new StringBuilder();
-
-            using var writer = new StringWriter(builder);
-            WriteCsv(entries, writer);
-
-            return builder.ToString();
-        }
-
-        private static void WriteField(TextWriter writer, string? value)
-        {
-            value ??= string.Empty;
-
-            if (value.IndexOfAny([DELIMITER, '"', '\r', '\n']) < 0)
-            {
-                writer.Write(value);
-                return;
-            }
-
-            writer.Write('"');
-            writer.Write(value.Replace("\"", "\"\""));
-            writer.Write('"');
-        }
+        writer.Write('"');
+        writer.Write(value.Replace("\"", "\"\""));
+        writer.Write('"');
     }
 }

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -218,7 +218,7 @@ internal static class DirectoryTraversal
                         .Replace(@"\*", ".*")
                         .Replace(@"\?", ".") +
                     "$",
-                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled))
         ];
     }
 }

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -47,6 +47,23 @@ internal static class DirectoryTraversal
         fileName.EndsWith("." + EncodingConverter.TEMP_FILE_SUFFIX, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Returns true for symlink, junction, or other reparse-point directories.
+    /// Attribute-read failures are treated conservatively (unsafe to walk).
+    /// </summary>
+    internal static bool IsReparsePointDirectory(string dir)
+    {
+        try
+        {
+            return (File.GetAttributes(dir) & FileAttributes.ReparsePoint) != 0;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Enumerates matching files while skipping excluded directories and reparse points.
     /// Inaccessible directories are skipped.
     /// </summary>

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -33,6 +33,11 @@ internal static class DirectoryTraversal
     {
         // Do not traverse symlinks or junctions.
         AttributesToSkip = FileAttributes.ReparsePoint,
+
+        // Default (true) silently drops access-denied entries instead of throwing,
+        // which would defeat the onWarning reporting below for the most common
+        // real-world enumeration failure (an ACL-denied subdirectory).
+        IgnoreInaccessible = false,
     };
 
     /// <summary>

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace EncodingChecker;
+
+/// <summary>
+/// Directory-tree walking and file-pattern matching shared by the scan engine.
+/// </summary>
+internal static class DirectoryTraversal
+{
+    // Never descend into these directories.
+    private static readonly HashSet<string> ExcludedDirectoryNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".git",
+            ".svn",
+            ".hg",
+            ".vs",
+            ".idea",
+            "bin",
+            "obj",
+            "node_modules",
+            "packages",
+            "dist",
+            "build",
+            "target"
+        };
+
+    private static readonly EnumerationOptions DirectoryWalkOptions = new()
+    {
+        // Do not traverse symlinks or junctions.
+        AttributesToSkip = FileAttributes.ReparsePoint,
+    };
+
+    /// <summary>
+    /// Always excluded, regardless of -Include/-Exclude: the tool's own backup and
+    /// temporary-file artifacts. Without this, a broad include pattern (e.g. "*")
+    /// combined with -Backup re-scans previous runs' ".bak" files as ordinary input,
+    /// which cascades (.bak, .bak.bak, ...) and can race against another file's
+    /// concurrent backup write to the same path.
+    /// </summary>
+    private static bool IsAlwaysExcludedFile(string fileName) =>
+        fileName.EndsWith(".bak", StringComparison.OrdinalIgnoreCase) ||
+        fileName.EndsWith("." + EncodingConverter.TEMP_FILE_SUFFIX, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Enumerates matching files while skipping excluded directories and reparse points.
+    /// Inaccessible directories are skipped.
+    /// </summary>
+    internal static IEnumerable<string> EnumerateFiles(
+        string baseDirectory,
+        bool includeSubdirectories,
+        List<Regex> includePatterns,
+        List<Regex> excludePatterns)
+    {
+        var pending = new Stack<string>();
+        pending.Push(baseDirectory);
+
+        while (pending.Count > 0)
+        {
+            string dir = pending.Pop();
+
+            List<string> files;
+
+            try
+            {
+                // Force enumeration here so access errors stay inside the try block.
+                files =
+                [
+                    .. Directory.EnumerateFiles(
+                        dir,
+                        "*",
+                        DirectoryWalkOptions)
+                ];
+            }
+            catch (Exception ex) when (
+                ex is IOException or UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            foreach (string file in files)
+            {
+                string fileName = Path.GetFileName(file);
+
+                if (IsAlwaysExcludedFile(fileName))
+                    continue;
+
+                if (MatchesAny(fileName, includePatterns) &&
+                    !MatchesAny(fileName, excludePatterns))
+                {
+                    yield return file;
+                }
+            }
+
+            if (!includeSubdirectories)
+                continue;
+
+            List<string> subdirectories;
+
+            try
+            {
+                subdirectories =
+                [
+                    .. Directory.EnumerateDirectories(
+                        dir,
+                        "*",
+                        DirectoryWalkOptions)
+                ];
+            }
+            catch (Exception ex) when (
+                ex is IOException or UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            foreach (string subdirectory in subdirectories)
+            {
+                if (!ExcludedDirectoryNames.Contains(
+                    Path.GetFileName(subdirectory)))
+                {
+                    pending.Push(subdirectory);
+                }
+            }
+        }
+    }
+
+    private static bool MatchesAny(
+        string fileName,
+        List<Regex> patterns)
+    {
+        foreach (Regex pattern in patterns)
+        {
+            if (pattern.IsMatch(fileName))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Converts wildcard masks to case-insensitive regexes.
+    /// </summary>
+    internal static List<Regex> CompilePatterns(
+        IReadOnlyList<string>? patterns,
+        bool defaultToMatchAll)
+    {
+        var effectivePatterns = (patterns ?? [])
+            .Select(p => p.Trim())
+            .Where(p => p.Length > 0)
+            .ToList();
+
+        if (effectivePatterns.Count == 0)
+        {
+            if (!defaultToMatchAll)
+                return [];
+
+            effectivePatterns.Add("*");
+        }
+
+        return
+        [
+            .. effectivePatterns.Select(mask =>
+                new Regex(
+                    "^" +
+                    Regex.Escape(mask)
+                        .Replace(@"\*", ".*")
+                        .Replace(@"\?", ".") +
+                    "$",
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+        ];
+    }
+}

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -36,11 +36,9 @@ internal static class DirectoryTraversal
     };
 
     /// <summary>
-    /// Always excluded, regardless of -Include/-Exclude: the tool's own backup and
-    /// temporary-file artifacts. Without this, a broad include pattern (e.g. "*")
-    /// combined with -Backup re-scans previous runs' ".bak" files as ordinary input,
-    /// which cascades (.bak, .bak.bak, ...) and can race against another file's
-    /// concurrent backup write to the same path.
+    /// Always excluded, even with a broad -Include like "*" - otherwise -Backup would
+    /// rescan its own ".bak" output on a later run, cascading (.bak.bak, ...) and
+    /// racing concurrent backup writes.
     /// </summary>
     private static bool IsAlwaysExcludedFile(string fileName) =>
         fileName.EndsWith(".bak", StringComparison.OrdinalIgnoreCase) ||
@@ -121,9 +119,8 @@ internal static class DirectoryTraversal
                     continue;
                 }
 
-                // A pattern with no separator matches just the filename (unchanged,
-                // backward-compatible); one containing a separator matches the path
-                // relative to baseDirectory instead - see CompilePatterns.
+                // No separator -> match bare filename (backward-compatible); with a
+                // separator -> match path relative to baseDirectory (see CompilePatterns).
                 string relativePath =
                     Path.GetRelativePath(baseDirectory, file).Replace('\\', '/');
 
@@ -188,9 +185,8 @@ internal static class DirectoryTraversal
 
     /// <summary>
     /// Converts wildcard masks to case-insensitive regexes. A mask with no "/" or "\"
-    /// matches against a candidate's bare filename; one containing a separator matches
-    /// against its path relative to the scan root instead (see <see cref="EnumerateFiles"/>).
-    /// Separators are normalized to "/" so a mask written with either matches the same way.
+    /// matches the bare filename; one with a separator matches the path relative to the
+    /// scan root instead (see <see cref="EnumerateFiles"/>). "\" is normalized to "/".
     /// </summary>
     internal static List<Regex> CompilePatterns(
         IReadOnlyList<string>? patterns,

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -72,7 +72,8 @@ internal static class DirectoryTraversal
         bool includeSubdirectories,
         List<Regex> includePatterns,
         List<Regex> excludePatterns,
-        string? excludedFullPath = null)
+        string? excludedFullPath = null,
+        Action<string>? onWarning = null)
     {
         var pending = new Stack<string>();
         pending.Push(baseDirectory);
@@ -97,6 +98,13 @@ internal static class DirectoryTraversal
             catch (Exception ex) when (
                 ex is IOException or UnauthorizedAccessException)
             {
+                onWarning?.Invoke(
+                    string.Format(
+                        "Skipping directory (cannot list): {0}{1}    {2}",
+                        dir,
+                        Environment.NewLine,
+                        ex.Message));
+
                 continue;
             }
 
@@ -138,6 +146,13 @@ internal static class DirectoryTraversal
             catch (Exception ex) when (
                 ex is IOException or UnauthorizedAccessException)
             {
+                onWarning?.Invoke(
+                    string.Format(
+                        "Skipping directory (cannot list): {0}{1}    {2}",
+                        dir,
+                        Environment.NewLine,
+                        ex.Message));
+
                 continue;
             }
 

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -71,7 +71,8 @@ internal static class DirectoryTraversal
         string baseDirectory,
         bool includeSubdirectories,
         List<Regex> includePatterns,
-        List<Regex> excludePatterns)
+        List<Regex> excludePatterns,
+        string? excludedFullPath = null)
     {
         var pending = new Stack<string>();
         pending.Push(baseDirectory);
@@ -105,6 +106,12 @@ internal static class DirectoryTraversal
 
                 if (IsAlwaysExcludedFile(fileName))
                     continue;
+
+                if (excludedFullPath is not null &&
+                    string.Equals(file, excludedFullPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
 
                 if (MatchesAny(fileName, includePatterns) &&
                     !MatchesAny(fileName, excludePatterns))

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -121,8 +121,14 @@ internal static class DirectoryTraversal
                     continue;
                 }
 
-                if (MatchesAny(fileName, includePatterns) &&
-                    !MatchesAny(fileName, excludePatterns))
+                // A pattern with no separator matches just the filename (unchanged,
+                // backward-compatible); one containing a separator matches the path
+                // relative to baseDirectory instead - see CompilePatterns.
+                string relativePath =
+                    Path.GetRelativePath(baseDirectory, file).Replace('\\', '/');
+
+                if (MatchesAny(relativePath, includePatterns) &&
+                    !MatchesAny(relativePath, excludePatterns))
                 {
                     yield return file;
                 }
@@ -181,7 +187,10 @@ internal static class DirectoryTraversal
     }
 
     /// <summary>
-    /// Converts wildcard masks to case-insensitive regexes.
+    /// Converts wildcard masks to case-insensitive regexes. A mask with no "/" or "\"
+    /// matches against a candidate's bare filename; one containing a separator matches
+    /// against its path relative to the scan root instead (see <see cref="EnumerateFiles"/>).
+    /// Separators are normalized to "/" so a mask written with either matches the same way.
     /// </summary>
     internal static List<Regex> CompilePatterns(
         IReadOnlyList<string>? patterns,
@@ -205,7 +214,7 @@ internal static class DirectoryTraversal
             .. effectivePatterns.Select(mask =>
                 new Regex(
                     "^" +
-                    Regex.Escape(mask)
+                    Regex.Escape(mask.Replace('\\', '/'))
                         .Replace(@"\*", ".*")
                         .Replace(@"\?", ".") +
                     "$",

--- a/sources/EncodingChecker/EncodingConverter.cs
+++ b/sources/EncodingChecker/EncodingConverter.cs
@@ -283,9 +283,8 @@ internal static class EncodingConverter
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Sanity-check that the source did not change during conversion.
-            // A point-in-time race check, not a complete TOCTOU guarantee: the source
-            // could still change between this check and installation below.
+            // Point-in-time check only, not a full TOCTOU guarantee - the source
+            // could still change between here and the install below.
             FileInfo recheckInfo = new(sourcePath);
 
             if (IsReparsePoint(recheckInfo))

--- a/sources/EncodingChecker/EncodingConverter.cs
+++ b/sources/EncodingChecker/EncodingConverter.cs
@@ -284,7 +284,23 @@ internal static class EncodingConverter
             cancellationToken.ThrowIfCancellationRequested();
 
             // Sanity-check that the source did not change during conversion.
+            // A point-in-time race check, not a complete TOCTOU guarantee: the source
+            // could still change between this check and installation below.
             FileInfo recheckInfo = new(sourcePath);
+
+            if (IsReparsePoint(recheckInfo))
+            {
+                return Failure(
+                    ConversionErrorCode.ReparsePointRejected,
+                    "The source became a symbolic link or other reparse point during " +
+                    "conversion; installation was rejected.",
+                    sourceEncoding,
+                    targetEncoding) with
+                {
+                    SourceBytes = sourceBytesProcessed,
+                    TargetBytes = targetBytesWritten,
+                };
+            }
 
             if (recheckInfo.Length != capturedLength ||
                 recheckInfo.LastWriteTimeUtc != capturedLastWriteUtc)

--- a/sources/EncodingChecker/EncodingConverter.cs
+++ b/sources/EncodingChecker/EncodingConverter.cs
@@ -1144,27 +1144,7 @@ internal static class EncodingConverter
                         clearedAttributes.Value & ~FileAttributes.ReadOnly);
                 }
 
-                if (destinationExists)
-                {
-                    try
-                    {
-                        // Ignore metadata outside this converter's preservation contract.
-                        File.Replace(
-                            tempPath,
-                            destinationPath,
-                            destinationBackupFileName: null,
-                            ignoreMetadataErrors: true);
-                    }
-                    catch (PlatformNotSupportedException)
-                    {
-                        // Fallback is not guaranteed to be atomic.
-                        File.Move(tempPath, destinationPath, overwrite: true);
-                    }
-                }
-                else
-                {
-                    File.Move(tempPath, destinationPath);
-                }
+                ReplaceOrMove(tempPath, destinationPath, destinationExists);
             }
             catch (Exception replaceEx) when (
                 replaceEx is IOException or UnauthorizedAccessException
@@ -1243,6 +1223,77 @@ internal static class EncodingConverter
         {
             errorMessage = $"Failed to install the converted file: {ex.Message}";
             return ConversionErrorCode.ReplacementError;
+        }
+    }
+
+    /// <summary>
+    /// Replaces <paramref name="destinationPath"/> with <paramref name="tempPath"/> using
+    /// <see cref="File.Replace(string, string, string?, bool)"/> when the destination
+    /// exists (falling back to <see cref="File.Move(string, string, bool)"/> only if the
+    /// platform doesn't support File.Replace), or a plain move when it doesn't.
+    /// </summary>
+    private static void ReplaceOrMove(
+        string tempPath,
+        string destinationPath,
+        bool destinationExists)
+    {
+        if (destinationExists)
+        {
+            try
+            {
+                // Ignore metadata outside this converter's preservation contract.
+                File.Replace(
+                    tempPath,
+                    destinationPath,
+                    destinationBackupFileName: null,
+                    ignoreMetadataErrors: true);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Fallback is not guaranteed to be atomic.
+                File.Move(tempPath, destinationPath, overwrite: true);
+            }
+        }
+        else
+        {
+            File.Move(tempPath, destinationPath);
+        }
+    }
+
+    /// <summary>
+    /// Atomically installs a backup file: replaces (or creates) <paramref name="destinationPath"/>
+    /// with the already-written <paramref name="tempPath"/>, reusing the same
+    /// <see cref="ReplaceOrMove"/> logic as the main conversion's install step, temporarily
+    /// clearing and restoring a ReadOnly destination attribute if needed. Unlike
+    /// <see cref="AtomicReplace"/>, failures propagate as ordinary exceptions rather than a
+    /// <see cref="ConversionErrorCode"/> - backup writes don't need that richer contract, since
+    /// the caller already has its own simple "backup failed" error path.
+    /// </summary>
+    internal static void AtomicReplaceForBackup(string tempPath, string destinationPath)
+    {
+        var destinationInfo = new FileInfo(destinationPath);
+        bool destinationExists = destinationInfo.Exists;
+
+        FileAttributes? clearedAttributes =
+            destinationExists && destinationInfo.Attributes.HasFlag(FileAttributes.ReadOnly)
+                ? destinationInfo.Attributes
+                : null;
+
+        if (clearedAttributes is not null)
+        {
+            File.SetAttributes(
+                destinationPath,
+                clearedAttributes.Value & ~FileAttributes.ReadOnly);
+        }
+
+        try
+        {
+            ReplaceOrMove(tempPath, destinationPath, destinationExists);
+        }
+        finally
+        {
+            if (clearedAttributes is not null && File.Exists(destinationPath))
+                File.SetAttributes(destinationPath, clearedAttributes.Value);
         }
     }
 

--- a/sources/EncodingChecker/ListViewColumnSorter.cs
+++ b/sources/EncodingChecker/ListViewColumnSorter.cs
@@ -2,54 +2,53 @@
 using System.Collections;
 using System.Windows.Forms;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+public class ListViewColumnSorter : IComparer
 {
-    public class ListViewColumnSorter : IComparer
+    private readonly CaseInsensitiveComparer _objectCompare = new();
+
+    public int SortColumn { get; set; }
+
+    public SortOrder Order { get; set; }
+
+    public int Compare(object? x, object? y)
     {
-        private readonly CaseInsensitiveComparer _objectCompare = new();
+        if (x is not ListViewItem item1)
+            throw new ArgumentNullException(nameof(x));
 
-        public int SortColumn { get; set; }
+        if (y is not ListViewItem item2)
+            throw new ArgumentNullException(nameof(y));
 
-        public SortOrder Order { get; set; }
+        int result = _objectCompare.Compare(
+            item1.SubItems[SortColumn].Text,
+            item2.SubItems[SortColumn].Text);
 
-        public int Compare(object? x, object? y)
+        // Files are added in non-deterministic (parallel-scan) completion order, so
+        // ties on the sort column need a stable tiebreaker across the other columns -
+        // otherwise equal rows reshuffle between runs even though the sort is applied.
+        if (result == 0)
+            result = CompareRemainingColumns(item1, item2);
+
+        return Order switch
         {
-            if (x is not ListViewItem item1)
-                throw new ArgumentNullException(nameof(x));
+            SortOrder.Ascending => result,
+            SortOrder.Descending => -result,
+            _ => 0,
+        };
+    }
 
-            if (y is not ListViewItem item2)
-                throw new ArgumentNullException(nameof(y));
+    private static int CompareRemainingColumns(ListViewItem x, ListViewItem y)
+    {
+        int count = Math.Min(x.SubItems.Count, y.SubItems.Count);
 
-            int result = _objectCompare.Compare(
-                item1.SubItems[SortColumn].Text,
-                item2.SubItems[SortColumn].Text);
-
-            // Files are added in non-deterministic (parallel-scan) completion order, so
-            // ties on the sort column need a stable tiebreaker across the other columns -
-            // otherwise equal rows reshuffle between runs even though the sort is applied.
-            if (result == 0)
-                result = CompareRemainingColumns(item1, item2);
-
-            return Order switch
-            {
-                SortOrder.Ascending => result,
-                SortOrder.Descending => -result,
-                _ => 0,
-            };
+        for (int i = 0; i < count; i++)
+        {
+            int result = string.CompareOrdinal(x.SubItems[i].Text, y.SubItems[i].Text);
+            if (result != 0)
+                return result;
         }
 
-        private static int CompareRemainingColumns(ListViewItem x, ListViewItem y)
-        {
-            int count = Math.Min(x.SubItems.Count, y.SubItems.Count);
-
-            for (int i = 0; i < count; i++)
-            {
-                int result = string.CompareOrdinal(x.SubItems[i].Text, y.SubItems[i].Text);
-                if (result != 0)
-                    return result;
-            }
-
-            return 0;
-        }
+        return 0;
     }
 }

--- a/sources/EncodingChecker/ListViewColumnSorter.cs
+++ b/sources/EncodingChecker/ListViewColumnSorter.cs
@@ -28,7 +28,7 @@ public class ListViewColumnSorter : IComparer
         // ties on the sort column need a stable tiebreaker across the other columns -
         // otherwise equal rows reshuffle between runs even though the sort is applied.
         if (result == 0)
-            result = CompareRemainingColumns(item1, item2);
+            result = CompareRemainingColumns(item1, item2, SortColumn);
 
         return Order switch
         {
@@ -38,12 +38,15 @@ public class ListViewColumnSorter : IComparer
         };
     }
 
-    private static int CompareRemainingColumns(ListViewItem x, ListViewItem y)
+    private static int CompareRemainingColumns(ListViewItem x, ListViewItem y, int sortColumn)
     {
         int count = Math.Min(x.SubItems.Count, y.SubItems.Count);
 
         for (int i = 0; i < count; i++)
         {
+            if (i == sortColumn)
+                continue;
+
             int result = string.CompareOrdinal(x.SubItems[i].Text, y.SubItems[i].Text);
             if (result != 0)
                 return result;

--- a/sources/EncodingChecker/ListViewExtensions.cs
+++ b/sources/EncodingChecker/ListViewExtensions.cs
@@ -4,96 +4,95 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class ListViewExtensions
 {
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class ListViewExtensions
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Hditem
     {
-        [StructLayout(LayoutKind.Sequential)]
-        public struct Hditem
+        public Mask mask;
+        public int cxy;
+        [MarshalAs(UnmanagedType.LPTStr)] public string pszText;
+        public IntPtr hbm;
+        public int cchTextMax;
+        public Format fmt;
+        public IntPtr lParam;
+        // _WIN32_IE >= 0x0300
+        public int iImage;
+        public int iOrder;
+        // _WIN32_IE >= 0x0500
+        public uint type;
+        public IntPtr pvFilter;
+        // _WIN32_WINNT >= 0x0600
+        public uint state;
+
+        [Flags]
+        public enum Mask
         {
-            public Mask mask;
-            public int cxy;
-            [MarshalAs(UnmanagedType.LPTStr)] public string pszText;
-            public IntPtr hbm;
-            public int cchTextMax;
-            public Format fmt;
-            public IntPtr lParam;
-            // _WIN32_IE >= 0x0300
-            public int iImage;
-            public int iOrder;
-            // _WIN32_IE >= 0x0500
-            public uint type;
-            public IntPtr pvFilter;
-            // _WIN32_WINNT >= 0x0600
-            public uint state;
-
-            [Flags]
-            public enum Mask
-            {
-                Format = 0x4,       // HDI_FORMAT
-            };
-
-            [Flags]
-            public enum Format
-            {
-                SortDown = 0x200,   // HDF_SORTDOWN
-                SortUp = 0x400,     // HDF_SORTUP
-            };
+            Format = 0x4,       // HDI_FORMAT
         };
 
-        public const int LVM_FIRST = 0x1000;
-        public const int LVM_GETHEADER = LVM_FIRST + 31;
-
-        public const int HDM_FIRST = 0x1200;
-        public const int HDM_GETITEM = HDM_FIRST + 11;
-        public const int HDM_SETITEM = HDM_FIRST + 12;
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern IntPtr SendMessage(this IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam);
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern IntPtr SendMessage(this IntPtr hWnd, UInt32 msg, IntPtr wParam, ref Hditem lParam);
-
-        public static void SetSortIcon(this ListView listViewControl, int columnIndex, SortOrder order)
+        [Flags]
+        public enum Format
         {
-            IntPtr columnHeader = SendMessage(listViewControl.Handle, LVM_GETHEADER, IntPtr.Zero, IntPtr.Zero);
-            for (int columnNumber = 0; columnNumber <= listViewControl.Columns.Count - 1; columnNumber++)
+            SortDown = 0x200,   // HDF_SORTDOWN
+            SortUp = 0x400,     // HDF_SORTUP
+        };
+    };
+
+    public const int LVM_FIRST = 0x1000;
+    public const int LVM_GETHEADER = LVM_FIRST + 31;
+
+    public const int HDM_FIRST = 0x1200;
+    public const int HDM_GETITEM = HDM_FIRST + 11;
+    public const int HDM_SETITEM = HDM_FIRST + 12;
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern IntPtr SendMessage(this IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern IntPtr SendMessage(this IntPtr hWnd, UInt32 msg, IntPtr wParam, ref Hditem lParam);
+
+    public static void SetSortIcon(this ListView listViewControl, int columnIndex, SortOrder order)
+    {
+        IntPtr columnHeader = SendMessage(listViewControl.Handle, LVM_GETHEADER, IntPtr.Zero, IntPtr.Zero);
+        for (int columnNumber = 0; columnNumber <= listViewControl.Columns.Count - 1; columnNumber++)
+        {
+            var columnPtr = new IntPtr(columnNumber);
+            var lvColumn = new Hditem
             {
-                var columnPtr = new IntPtr(columnNumber);
-                var lvColumn = new Hditem
-                {
-                    mask = Hditem.Mask.Format
-                };
+                mask = Hditem.Mask.Format
+            };
 
-                if (SendMessage(columnHeader, HDM_GETITEM, columnPtr, ref lvColumn) == IntPtr.Zero)
-                {
-                    throw new Win32Exception();
-                }
+            if (SendMessage(columnHeader, HDM_GETITEM, columnPtr, ref lvColumn) == IntPtr.Zero)
+            {
+                throw new Win32Exception();
+            }
 
-                if (order != SortOrder.None && columnNumber == columnIndex)
+            if (order != SortOrder.None && columnNumber == columnIndex)
+            {
+                switch (order)
                 {
-                    switch (order)
-                    {
-                        case SortOrder.Ascending:
-                            lvColumn.fmt &= ~Hditem.Format.SortDown;
-                            lvColumn.fmt |= Hditem.Format.SortUp;
-                            break;
-                        case SortOrder.Descending:
-                            lvColumn.fmt &= ~Hditem.Format.SortUp;
-                            lvColumn.fmt |= Hditem.Format.SortDown;
-                            break;
-                    }
+                    case SortOrder.Ascending:
+                        lvColumn.fmt &= ~Hditem.Format.SortDown;
+                        lvColumn.fmt |= Hditem.Format.SortUp;
+                        break;
+                    case SortOrder.Descending:
+                        lvColumn.fmt &= ~Hditem.Format.SortUp;
+                        lvColumn.fmt |= Hditem.Format.SortDown;
+                        break;
                 }
-                else
-                {
-                    lvColumn.fmt &= ~Hditem.Format.SortDown & ~Hditem.Format.SortUp;
-                }
+            }
+            else
+            {
+                lvColumn.fmt &= ~Hditem.Format.SortDown & ~Hditem.Format.SortUp;
+            }
 
-                if (SendMessage(columnHeader, HDM_SETITEM, columnPtr, ref lvColumn) == IntPtr.Zero)
-                {
-                    throw new Win32Exception();
-                }
+            if (SendMessage(columnHeader, HDM_SETITEM, columnPtr, ref lvColumn) == IntPtr.Zero)
+            {
+                throw new Win32Exception();
             }
         }
     }

--- a/sources/EncodingChecker/MainForm.Designer.cs
+++ b/sources/EncodingChecker/MainForm.Designer.cs
@@ -1,322 +1,321 @@
-﻿namespace EncodingChecker
+﻿namespace EncodingChecker;
+
+partial class MainForm
 {
-    partial class MainForm
+    /// <summary>
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
     {
-        /// <summary>
-        /// Required designer variable.
-        /// </summary>
-        private System.ComponentModel.IContainer components = null;
-
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
+        if (disposing && (components != null))
         {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
+            components.Dispose();
         }
-
-        #region Windows Form Designer generated code
-
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
-        private void InitializeComponent()
-        {
-            components = new System.ComponentModel.Container();
-            System.Windows.Forms.Label lblBaseDirectory;
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-            System.Windows.Forms.Label lblFileMasks;
-            System.Windows.Forms.Label lblValidCharsets;
-            System.Windows.Forms.ColumnHeader colEncoding;
-            System.Windows.Forms.ColumnHeader colFileName;
-            System.Windows.Forms.ColumnHeader colFileExt;
-            System.Windows.Forms.ColumnHeader colDirectory;
-            btnBrowseDirectories = new System.Windows.Forms.Button();
-            chkIncludeSubdirectories = new System.Windows.Forms.CheckBox();
-            txtFileMasks = new System.Windows.Forms.TextBox();
-            lstValidCharsets = new System.Windows.Forms.CheckedListBox();
-            btnValidate = new System.Windows.Forms.Button();
-            lstResults = new System.Windows.Forms.ListView();
-            imgsResults = new System.Windows.Forms.ImageList(components);
-            dlgBrowseDirectories = new System.Windows.Forms.FolderBrowserDialog();
-            statusBar = new System.Windows.Forms.StatusStrip();
-            tlnkHelp = new System.Windows.Forms.ToolStripStatusLabel();
-            tlnkAbout = new System.Windows.Forms.ToolStripStatusLabel();
-            tlnkExport = new System.Windows.Forms.ToolStripStatusLabel();
-            btnExportReport = new System.Windows.Forms.ToolStripDropDownButton();
-            actionProgress = new System.Windows.Forms.ToolStripProgressBar();
-            actionStatus = new System.Windows.Forms.ToolStripStatusLabel();
-            btnView = new System.Windows.Forms.Button();
-            lstBaseDirectory = new System.Windows.Forms.ComboBox();
-            lblConvert = new System.Windows.Forms.Label();
-            lstConvert = new System.Windows.Forms.ComboBox();
-            btnConvert = new System.Windows.Forms.Button();
-            chkSelectDeselectAll = new System.Windows.Forms.CheckBox();
-            btnCancel = new System.Windows.Forms.Button();
-            lblBaseDirectory = new System.Windows.Forms.Label();
-            lblFileMasks = new System.Windows.Forms.Label();
-            lblValidCharsets = new System.Windows.Forms.Label();
-            colEncoding = new System.Windows.Forms.ColumnHeader();
-            colFileName = new System.Windows.Forms.ColumnHeader();
-            colFileExt = new System.Windows.Forms.ColumnHeader();
-            colDirectory = new System.Windows.Forms.ColumnHeader();
-            statusBar.SuspendLayout();
-            SuspendLayout();
-            // 
-            // lblBaseDirectory
-            // 
-            resources.ApplyResources(lblBaseDirectory, "lblBaseDirectory");
-            lblBaseDirectory.Name = "lblBaseDirectory";
-            // 
-            // lblFileMasks
-            // 
-            resources.ApplyResources(lblFileMasks, "lblFileMasks");
-            lblFileMasks.Name = "lblFileMasks";
-            // 
-            // lblValidCharsets
-            // 
-            resources.ApplyResources(lblValidCharsets, "lblValidCharsets");
-            lblValidCharsets.Name = "lblValidCharsets";
-            // 
-            // colEncoding
-            // 
-            resources.ApplyResources(colEncoding, "colEncoding");
-            // 
-            // colFileName
-            // 
-            resources.ApplyResources(colFileName, "colFileName");
-            // 
-            // colFileExt
-            // 
-            resources.ApplyResources(colFileExt, "colFileExt");
-            // 
-            // colDirectory
-            // 
-            resources.ApplyResources(colDirectory, "colDirectory");
-            // 
-            // btnBrowseDirectories
-            // 
-            resources.ApplyResources(btnBrowseDirectories, "btnBrowseDirectories");
-            btnBrowseDirectories.Name = "btnBrowseDirectories";
-            btnBrowseDirectories.UseVisualStyleBackColor = true;
-            btnBrowseDirectories.Click += OnBrowseDirectories;
-            // 
-            // chkIncludeSubdirectories
-            // 
-            resources.ApplyResources(chkIncludeSubdirectories, "chkIncludeSubdirectories");
-            chkIncludeSubdirectories.Name = "chkIncludeSubdirectories";
-            chkIncludeSubdirectories.UseVisualStyleBackColor = true;
-            // 
-            // txtFileMasks
-            // 
-            txtFileMasks.AcceptsReturn = true;
-            resources.ApplyResources(txtFileMasks, "txtFileMasks");
-            txtFileMasks.Name = "txtFileMasks";
-            // 
-            // lstValidCharsets
-            // 
-            lstValidCharsets.CheckOnClick = true;
-            lstValidCharsets.FormattingEnabled = true;
-            resources.ApplyResources(lstValidCharsets, "lstValidCharsets");
-            lstValidCharsets.Name = "lstValidCharsets";
-            // 
-            // btnValidate
-            // 
-            resources.ApplyResources(btnValidate, "btnValidate");
-            btnValidate.Name = "btnValidate";
-            btnValidate.UseVisualStyleBackColor = true;
-            btnValidate.Click += OnAction;
-            // 
-            // lstResults
-            // 
-            resources.ApplyResources(lstResults, "lstResults");
-            lstResults.CheckBoxes = true;
-            lstResults.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { colEncoding, colFileName, colFileExt, colDirectory });
-            lstResults.FullRowSelect = true;
-            lstResults.GridLines = true;
-            lstResults.Name = "lstResults";
-            lstResults.SmallImageList = imgsResults;
-            lstResults.UseCompatibleStateImageBehavior = false;
-            lstResults.View = System.Windows.Forms.View.Details;
-            lstResults.ColumnClick += OnResultColumnClick;
-            lstResults.ItemChecked += OnResultItemChecked;
-            // 
-            // imgsResults
-            // 
-            imgsResults.ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit;
-            imgsResults.ImageStream = (System.Windows.Forms.ImageListStreamer)resources.GetObject("imgsResults.ImageStream");
-            imgsResults.TransparentColor = System.Drawing.Color.Transparent;
-            imgsResults.Images.SetKeyName(0, "Successful");
-            imgsResults.Images.SetKeyName(1, "Failed");
-            imgsResults.Images.SetKeyName(2, "Warning");
-            // 
-            // dlgBrowseDirectories
-            // 
-            resources.ApplyResources(dlgBrowseDirectories, "dlgBrowseDirectories");
-            // 
-            // statusBar
-            // 
-            statusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tlnkHelp, tlnkAbout, tlnkExport, btnExportReport, actionProgress, actionStatus });
-            resources.ApplyResources(statusBar, "statusBar");
-            statusBar.Name = "statusBar";
-            // 
-            // tlnkHelp
-            // 
-            tlnkHelp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            tlnkHelp.IsLink = true;
-            tlnkHelp.Name = "tlnkHelp";
-            resources.ApplyResources(tlnkHelp, "tlnkHelp");
-            tlnkHelp.Click += OnHelp;
-            // 
-            // tlnkAbout
-            // 
-            tlnkAbout.IsLink = true;
-            tlnkAbout.Name = "tlnkAbout";
-            resources.ApplyResources(tlnkAbout, "tlnkAbout");
-            tlnkAbout.Click += OnAbout;
-            // 
-            // tlnkExport
-            // 
-            tlnkExport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            tlnkExport.IsLink = true;
-            tlnkExport.Name = "tlnkExport";
-            resources.ApplyResources(tlnkExport, "tlnkExport");
-            tlnkExport.Click += OnExport;
-            // 
-            // btnExportReport
-            // 
-            btnExportReport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            resources.ApplyResources(btnExportReport, "btnExportReport");
-            btnExportReport.ForeColor = System.Drawing.Color.Blue;
-            btnExportReport.Name = "btnExportReport";
-            btnExportReport.ShowDropDownArrow = false;
-            btnExportReport.Click += OnExportReport;
-            // 
-            // actionProgress
-            // 
-            actionProgress.Name = "actionProgress";
-            resources.ApplyResources(actionProgress, "actionProgress");
-            actionProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-            // 
-            // actionStatus
-            // 
-            actionStatus.Name = "actionStatus";
-            resources.ApplyResources(actionStatus, "actionStatus");
-            // 
-            // btnView
-            // 
-            resources.ApplyResources(btnView, "btnView");
-            btnView.Name = "btnView";
-            btnView.UseVisualStyleBackColor = true;
-            btnView.Click += OnAction;
-            // 
-            // lstBaseDirectory
-            // 
-            lstBaseDirectory.AllowDrop = true;
-            resources.ApplyResources(lstBaseDirectory, "lstBaseDirectory");
-            lstBaseDirectory.FormattingEnabled = true;
-            lstBaseDirectory.Name = "lstBaseDirectory";
-            lstBaseDirectory.DragDrop += OnBaseDirectoryDragDrop;
-            lstBaseDirectory.DragEnter += OnBaseDirectoryDragEnter;
-            // 
-            // lblConvert
-            // 
-            resources.ApplyResources(lblConvert, "lblConvert");
-            lblConvert.Name = "lblConvert";
-            // 
-            // lstConvert
-            // 
-            lstConvert.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            resources.ApplyResources(lstConvert, "lstConvert");
-            lstConvert.FormattingEnabled = true;
-            lstConvert.Name = "lstConvert";
-            // 
-            // btnConvert
-            // 
-            resources.ApplyResources(btnConvert, "btnConvert");
-            btnConvert.Name = "btnConvert";
-            btnConvert.UseVisualStyleBackColor = true;
-            btnConvert.Click += OnConvert;
-            // 
-            // chkSelectDeselectAll
-            // 
-            resources.ApplyResources(chkSelectDeselectAll, "chkSelectDeselectAll");
-            chkSelectDeselectAll.Name = "chkSelectDeselectAll";
-            chkSelectDeselectAll.UseVisualStyleBackColor = true;
-            chkSelectDeselectAll.CheckedChanged += OnSelectDeselectAll;
-            // 
-            // btnCancel
-            // 
-            resources.ApplyResources(btnCancel, "btnCancel");
-            btnCancel.Name = "btnCancel";
-            btnCancel.UseVisualStyleBackColor = true;
-            btnCancel.Click += OnCancelAction;
-            // 
-            // MainForm
-            // 
-            AllowDrop = true;
-            resources.ApplyResources(this, "$this");
-            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            Controls.Add(btnCancel);
-            Controls.Add(chkSelectDeselectAll);
-            Controls.Add(btnConvert);
-            Controls.Add(lstConvert);
-            Controls.Add(lblConvert);
-            Controls.Add(lstBaseDirectory);
-            Controls.Add(btnView);
-            Controls.Add(statusBar);
-            Controls.Add(lstResults);
-            Controls.Add(btnValidate);
-            Controls.Add(lstValidCharsets);
-            Controls.Add(lblValidCharsets);
-            Controls.Add(txtFileMasks);
-            Controls.Add(lblFileMasks);
-            Controls.Add(chkIncludeSubdirectories);
-            Controls.Add(btnBrowseDirectories);
-            Controls.Add(lblBaseDirectory);
-            DoubleBuffered = true;
-            Name = "MainForm";
-            FormClosing += OnFormClosing;
-            Load += OnFormLoad;
-            DragDrop += OnBaseDirectoryDragDrop;
-            DragEnter += OnBaseDirectoryDragEnter;
-            statusBar.ResumeLayout(false);
-            statusBar.PerformLayout();
-            ResumeLayout(false);
-            PerformLayout();
-
-        }
-
-        #endregion
-
-        private System.Windows.Forms.Button btnBrowseDirectories;
-        private System.Windows.Forms.CheckBox chkIncludeSubdirectories;
-        private System.Windows.Forms.TextBox txtFileMasks;
-        private System.Windows.Forms.CheckedListBox lstValidCharsets;
-        private System.Windows.Forms.Button btnValidate;
-        private System.Windows.Forms.ListView lstResults;
-        private System.Windows.Forms.FolderBrowserDialog dlgBrowseDirectories;
-        private System.Windows.Forms.ToolStripProgressBar actionProgress;
-        private System.Windows.Forms.ToolStripStatusLabel actionStatus;
-        private System.Windows.Forms.StatusStrip statusBar;
-        private System.Windows.Forms.Button btnView;
-        private System.Windows.Forms.ComboBox lstBaseDirectory;
-        private System.Windows.Forms.Label lblConvert;
-        private System.Windows.Forms.ComboBox lstConvert;
-        private System.Windows.Forms.Button btnConvert;
-        private System.Windows.Forms.CheckBox chkSelectDeselectAll;
-        private System.Windows.Forms.ToolStripStatusLabel tlnkExport;
-        private System.Windows.Forms.ToolStripStatusLabel tlnkAbout;
-        private System.Windows.Forms.Button btnCancel;
-        private System.Windows.Forms.ImageList imgsResults;
-        private System.Windows.Forms.ToolStripStatusLabel tlnkHelp;
-        private System.Windows.Forms.ToolStripDropDownButton btnExportReport;
+        base.Dispose(disposing);
     }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    /// Required method for Designer support - do not modify
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        components = new System.ComponentModel.Container();
+        System.Windows.Forms.Label lblBaseDirectory;
+        System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+        System.Windows.Forms.Label lblFileMasks;
+        System.Windows.Forms.Label lblValidCharsets;
+        System.Windows.Forms.ColumnHeader colEncoding;
+        System.Windows.Forms.ColumnHeader colFileName;
+        System.Windows.Forms.ColumnHeader colFileExt;
+        System.Windows.Forms.ColumnHeader colDirectory;
+        btnBrowseDirectories = new System.Windows.Forms.Button();
+        chkIncludeSubdirectories = new System.Windows.Forms.CheckBox();
+        txtFileMasks = new System.Windows.Forms.TextBox();
+        lstValidCharsets = new System.Windows.Forms.CheckedListBox();
+        btnValidate = new System.Windows.Forms.Button();
+        lstResults = new System.Windows.Forms.ListView();
+        imgsResults = new System.Windows.Forms.ImageList(components);
+        dlgBrowseDirectories = new System.Windows.Forms.FolderBrowserDialog();
+        statusBar = new System.Windows.Forms.StatusStrip();
+        tlnkHelp = new System.Windows.Forms.ToolStripStatusLabel();
+        tlnkAbout = new System.Windows.Forms.ToolStripStatusLabel();
+        tlnkExport = new System.Windows.Forms.ToolStripStatusLabel();
+        btnExportReport = new System.Windows.Forms.ToolStripDropDownButton();
+        actionProgress = new System.Windows.Forms.ToolStripProgressBar();
+        actionStatus = new System.Windows.Forms.ToolStripStatusLabel();
+        btnView = new System.Windows.Forms.Button();
+        lstBaseDirectory = new System.Windows.Forms.ComboBox();
+        lblConvert = new System.Windows.Forms.Label();
+        lstConvert = new System.Windows.Forms.ComboBox();
+        btnConvert = new System.Windows.Forms.Button();
+        chkSelectDeselectAll = new System.Windows.Forms.CheckBox();
+        btnCancel = new System.Windows.Forms.Button();
+        lblBaseDirectory = new System.Windows.Forms.Label();
+        lblFileMasks = new System.Windows.Forms.Label();
+        lblValidCharsets = new System.Windows.Forms.Label();
+        colEncoding = new System.Windows.Forms.ColumnHeader();
+        colFileName = new System.Windows.Forms.ColumnHeader();
+        colFileExt = new System.Windows.Forms.ColumnHeader();
+        colDirectory = new System.Windows.Forms.ColumnHeader();
+        statusBar.SuspendLayout();
+        SuspendLayout();
+        // 
+        // lblBaseDirectory
+        // 
+        resources.ApplyResources(lblBaseDirectory, "lblBaseDirectory");
+        lblBaseDirectory.Name = "lblBaseDirectory";
+        // 
+        // lblFileMasks
+        // 
+        resources.ApplyResources(lblFileMasks, "lblFileMasks");
+        lblFileMasks.Name = "lblFileMasks";
+        // 
+        // lblValidCharsets
+        // 
+        resources.ApplyResources(lblValidCharsets, "lblValidCharsets");
+        lblValidCharsets.Name = "lblValidCharsets";
+        // 
+        // colEncoding
+        // 
+        resources.ApplyResources(colEncoding, "colEncoding");
+        // 
+        // colFileName
+        // 
+        resources.ApplyResources(colFileName, "colFileName");
+        // 
+        // colFileExt
+        // 
+        resources.ApplyResources(colFileExt, "colFileExt");
+        // 
+        // colDirectory
+        // 
+        resources.ApplyResources(colDirectory, "colDirectory");
+        // 
+        // btnBrowseDirectories
+        // 
+        resources.ApplyResources(btnBrowseDirectories, "btnBrowseDirectories");
+        btnBrowseDirectories.Name = "btnBrowseDirectories";
+        btnBrowseDirectories.UseVisualStyleBackColor = true;
+        btnBrowseDirectories.Click += OnBrowseDirectories;
+        // 
+        // chkIncludeSubdirectories
+        // 
+        resources.ApplyResources(chkIncludeSubdirectories, "chkIncludeSubdirectories");
+        chkIncludeSubdirectories.Name = "chkIncludeSubdirectories";
+        chkIncludeSubdirectories.UseVisualStyleBackColor = true;
+        // 
+        // txtFileMasks
+        // 
+        txtFileMasks.AcceptsReturn = true;
+        resources.ApplyResources(txtFileMasks, "txtFileMasks");
+        txtFileMasks.Name = "txtFileMasks";
+        // 
+        // lstValidCharsets
+        // 
+        lstValidCharsets.CheckOnClick = true;
+        lstValidCharsets.FormattingEnabled = true;
+        resources.ApplyResources(lstValidCharsets, "lstValidCharsets");
+        lstValidCharsets.Name = "lstValidCharsets";
+        // 
+        // btnValidate
+        // 
+        resources.ApplyResources(btnValidate, "btnValidate");
+        btnValidate.Name = "btnValidate";
+        btnValidate.UseVisualStyleBackColor = true;
+        btnValidate.Click += OnAction;
+        // 
+        // lstResults
+        // 
+        resources.ApplyResources(lstResults, "lstResults");
+        lstResults.CheckBoxes = true;
+        lstResults.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { colEncoding, colFileName, colFileExt, colDirectory });
+        lstResults.FullRowSelect = true;
+        lstResults.GridLines = true;
+        lstResults.Name = "lstResults";
+        lstResults.SmallImageList = imgsResults;
+        lstResults.UseCompatibleStateImageBehavior = false;
+        lstResults.View = System.Windows.Forms.View.Details;
+        lstResults.ColumnClick += OnResultColumnClick;
+        lstResults.ItemChecked += OnResultItemChecked;
+        // 
+        // imgsResults
+        // 
+        imgsResults.ColorDepth = System.Windows.Forms.ColorDepth.Depth32Bit;
+        imgsResults.ImageStream = (System.Windows.Forms.ImageListStreamer)resources.GetObject("imgsResults.ImageStream");
+        imgsResults.TransparentColor = System.Drawing.Color.Transparent;
+        imgsResults.Images.SetKeyName(0, "Successful");
+        imgsResults.Images.SetKeyName(1, "Failed");
+        imgsResults.Images.SetKeyName(2, "Warning");
+        // 
+        // dlgBrowseDirectories
+        // 
+        resources.ApplyResources(dlgBrowseDirectories, "dlgBrowseDirectories");
+        // 
+        // statusBar
+        // 
+        statusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tlnkHelp, tlnkAbout, tlnkExport, btnExportReport, actionProgress, actionStatus });
+        resources.ApplyResources(statusBar, "statusBar");
+        statusBar.Name = "statusBar";
+        // 
+        // tlnkHelp
+        // 
+        tlnkHelp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+        tlnkHelp.IsLink = true;
+        tlnkHelp.Name = "tlnkHelp";
+        resources.ApplyResources(tlnkHelp, "tlnkHelp");
+        tlnkHelp.Click += OnHelp;
+        // 
+        // tlnkAbout
+        // 
+        tlnkAbout.IsLink = true;
+        tlnkAbout.Name = "tlnkAbout";
+        resources.ApplyResources(tlnkAbout, "tlnkAbout");
+        tlnkAbout.Click += OnAbout;
+        // 
+        // tlnkExport
+        // 
+        tlnkExport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+        tlnkExport.IsLink = true;
+        tlnkExport.Name = "tlnkExport";
+        resources.ApplyResources(tlnkExport, "tlnkExport");
+        tlnkExport.Click += OnExport;
+        // 
+        // btnExportReport
+        // 
+        btnExportReport.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+        resources.ApplyResources(btnExportReport, "btnExportReport");
+        btnExportReport.ForeColor = System.Drawing.Color.Blue;
+        btnExportReport.Name = "btnExportReport";
+        btnExportReport.ShowDropDownArrow = false;
+        btnExportReport.Click += OnExportReport;
+        // 
+        // actionProgress
+        // 
+        actionProgress.Name = "actionProgress";
+        resources.ApplyResources(actionProgress, "actionProgress");
+        actionProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+        // 
+        // actionStatus
+        // 
+        actionStatus.Name = "actionStatus";
+        resources.ApplyResources(actionStatus, "actionStatus");
+        // 
+        // btnView
+        // 
+        resources.ApplyResources(btnView, "btnView");
+        btnView.Name = "btnView";
+        btnView.UseVisualStyleBackColor = true;
+        btnView.Click += OnAction;
+        // 
+        // lstBaseDirectory
+        // 
+        lstBaseDirectory.AllowDrop = true;
+        resources.ApplyResources(lstBaseDirectory, "lstBaseDirectory");
+        lstBaseDirectory.FormattingEnabled = true;
+        lstBaseDirectory.Name = "lstBaseDirectory";
+        lstBaseDirectory.DragDrop += OnBaseDirectoryDragDrop;
+        lstBaseDirectory.DragEnter += OnBaseDirectoryDragEnter;
+        // 
+        // lblConvert
+        // 
+        resources.ApplyResources(lblConvert, "lblConvert");
+        lblConvert.Name = "lblConvert";
+        // 
+        // lstConvert
+        // 
+        lstConvert.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+        resources.ApplyResources(lstConvert, "lstConvert");
+        lstConvert.FormattingEnabled = true;
+        lstConvert.Name = "lstConvert";
+        // 
+        // btnConvert
+        // 
+        resources.ApplyResources(btnConvert, "btnConvert");
+        btnConvert.Name = "btnConvert";
+        btnConvert.UseVisualStyleBackColor = true;
+        btnConvert.Click += OnConvert;
+        // 
+        // chkSelectDeselectAll
+        // 
+        resources.ApplyResources(chkSelectDeselectAll, "chkSelectDeselectAll");
+        chkSelectDeselectAll.Name = "chkSelectDeselectAll";
+        chkSelectDeselectAll.UseVisualStyleBackColor = true;
+        chkSelectDeselectAll.CheckedChanged += OnSelectDeselectAll;
+        // 
+        // btnCancel
+        // 
+        resources.ApplyResources(btnCancel, "btnCancel");
+        btnCancel.Name = "btnCancel";
+        btnCancel.UseVisualStyleBackColor = true;
+        btnCancel.Click += OnCancelAction;
+        // 
+        // MainForm
+        // 
+        AllowDrop = true;
+        resources.ApplyResources(this, "$this");
+        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        Controls.Add(btnCancel);
+        Controls.Add(chkSelectDeselectAll);
+        Controls.Add(btnConvert);
+        Controls.Add(lstConvert);
+        Controls.Add(lblConvert);
+        Controls.Add(lstBaseDirectory);
+        Controls.Add(btnView);
+        Controls.Add(statusBar);
+        Controls.Add(lstResults);
+        Controls.Add(btnValidate);
+        Controls.Add(lstValidCharsets);
+        Controls.Add(lblValidCharsets);
+        Controls.Add(txtFileMasks);
+        Controls.Add(lblFileMasks);
+        Controls.Add(chkIncludeSubdirectories);
+        Controls.Add(btnBrowseDirectories);
+        Controls.Add(lblBaseDirectory);
+        DoubleBuffered = true;
+        Name = "MainForm";
+        FormClosing += OnFormClosing;
+        Load += OnFormLoad;
+        DragDrop += OnBaseDirectoryDragDrop;
+        DragEnter += OnBaseDirectoryDragEnter;
+        statusBar.ResumeLayout(false);
+        statusBar.PerformLayout();
+        ResumeLayout(false);
+        PerformLayout();
+
+    }
+
+    #endregion
+
+    private System.Windows.Forms.Button btnBrowseDirectories;
+    private System.Windows.Forms.CheckBox chkIncludeSubdirectories;
+    private System.Windows.Forms.TextBox txtFileMasks;
+    private System.Windows.Forms.CheckedListBox lstValidCharsets;
+    private System.Windows.Forms.Button btnValidate;
+    private System.Windows.Forms.ListView lstResults;
+    private System.Windows.Forms.FolderBrowserDialog dlgBrowseDirectories;
+    private System.Windows.Forms.ToolStripProgressBar actionProgress;
+    private System.Windows.Forms.ToolStripStatusLabel actionStatus;
+    private System.Windows.Forms.StatusStrip statusBar;
+    private System.Windows.Forms.Button btnView;
+    private System.Windows.Forms.ComboBox lstBaseDirectory;
+    private System.Windows.Forms.Label lblConvert;
+    private System.Windows.Forms.ComboBox lstConvert;
+    private System.Windows.Forms.Button btnConvert;
+    private System.Windows.Forms.CheckBox chkSelectDeselectAll;
+    private System.Windows.Forms.ToolStripStatusLabel tlnkExport;
+    private System.Windows.Forms.ToolStripStatusLabel tlnkAbout;
+    private System.Windows.Forms.Button btnCancel;
+    private System.Windows.Forms.ImageList imgsResults;
+    private System.Windows.Forms.ToolStripStatusLabel tlnkHelp;
+    private System.Windows.Forms.ToolStripDropDownButton btnExportReport;
 }
 

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -11,55 +11,55 @@ using System.Threading;
 using System.Windows.Forms;
 using System.Xml.Serialization;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+public partial class MainForm : Form
 {
-    public partial class MainForm : Form
+    private sealed class WorkerArgs
     {
-        private sealed class WorkerArgs
-        {
-            internal CurrentAction Action;
-            internal required string BaseDirectory;
-            internal bool IncludeSubdirectories;
-            internal required string FileMasks;
-            internal required List<string> ValidCharsets;
-            internal CancellationToken CancellationToken;
-        }
+        internal CurrentAction Action;
+        internal required string BaseDirectory;
+        internal bool IncludeSubdirectories;
+        internal required string FileMasks;
+        internal required List<string> ValidCharsets;
+        internal CancellationToken CancellationToken;
+    }
 
-        private sealed class ConvertWorkerArgs
-        {
-            internal required List<ConversionReportEntry> Entries;
-            internal required string TargetBaseCharset;
-            internal required bool TargetWriteBom;
-            internal CancellationToken CancellationToken;
-        }
+    private sealed class ConvertWorkerArgs
+    {
+        internal required List<ConversionReportEntry> Entries;
+        internal required string TargetBaseCharset;
+        internal required bool TargetWriteBom;
+        internal CancellationToken CancellationToken;
+    }
 
-        private enum CurrentAction
-        {
-            View,
-            Validate,
-            Convert,
-        }
+    private enum CurrentAction
+    {
+        View,
+        Validate,
+        Convert,
+    }
 
-        private readonly ListViewColumnSorter _lvwColumnSorter;
-        private readonly BackgroundWorker _actionWorker;
+    private readonly ListViewColumnSorter _lvwColumnSorter;
+    private readonly BackgroundWorker _actionWorker;
 
-        private CurrentAction _currentAction;
-        private Settings _settings = new();
-        private CancellationTokenSource? _actionCancellation;
-        private bool _closeRequested;
+    private CurrentAction _currentAction;
+    private Settings _settings = new();
+    private CancellationTokenSource? _actionCancellation;
+    private bool _closeRequested;
 
-        // Set by OnConvert, read back by ConvertWorkerCompleted; never touched by the worker thread.
-        private Dictionary<string, ListViewItem>? _convertItemsByPath;
-        private string? _convertTargetLabel;
+    // Set by OnConvert, read back by ConvertWorkerCompleted; never touched by the worker thread.
+    private Dictionary<string, ListViewItem>? _convertItemsByPath;
+    private string? _convertTargetLabel;
 
-        private const int RESULTS_COLUMN_CHARSET = 0;
-        private const int RESULTS_COLUMN_FILE_NAME = 1;
-        private const int RESULTS_COLUMN_FILE_EXT = 2;
-        private const int RESULTS_COLUMN_DIRECTORY = 3;
+    private const int RESULTS_COLUMN_CHARSET = 0;
+    private const int RESULTS_COLUMN_FILE_NAME = 1;
+    private const int RESULTS_COLUMN_FILE_EXT = 2;
+    private const int RESULTS_COLUMN_DIRECTORY = 3;
 
-        public MainForm()
-        {
-            InitializeComponent();
+    public MainForm()
+    {
+        InitializeComponent();
 
 			// Default to deterministic filename sorting instead of parallel completion order.
 			_lvwColumnSorter = new ListViewColumnSorter
@@ -69,1014 +69,1013 @@ namespace EncodingChecker
 			};
 			lstResults.ListViewItemSorter = _lvwColumnSorter;
 
-            _actionWorker = new BackgroundWorker
-            {
-                WorkerReportsProgress = true,
-                WorkerSupportsCancellation = true
-            };
-
-            _actionWorker.DoWork += ActionWorkerDoWork;
-            _actionWorker.ProgressChanged += ActionWorkerProgressChanged;
-            _actionWorker.RunWorkerCompleted += ActionWorkerCompleted;
-        }
-
-        #region Form events
-
-        private void OnFormLoad(object? sender, EventArgs e)
+        _actionWorker = new BackgroundWorker
         {
-            lstConvert.BeginUpdate();
+            WorkerReportsProgress = true,
+            WorkerSupportsCancellation = true
+        };
 
-            IEnumerable<string> validCharsets = GetSupportedCharsets();
+        _actionWorker.DoWork += ActionWorkerDoWork;
+        _actionWorker.ProgressChanged += ActionWorkerProgressChanged;
+        _actionWorker.RunWorkerCompleted += ActionWorkerCompleted;
+    }
 
-            foreach (string validCharset in validCharsets)
-            {
-                try
-                {
-                    // Add only charsets supported by .NET.
-                    var encoding = Encoding.GetEncoding(validCharset);
+    #region Form events
 
-                    lstValidCharsets.Items.Add(encoding.WebName);
-                    lstConvert.Items.Add(encoding.WebName);
+    private void OnFormLoad(object? sender, EventArgs e)
+    {
+        lstConvert.BeginUpdate();
 
-                    // Add BOM variants after UTF-8/16/32.
-                    if (encoding.WebName is "utf-16BE" or "utf-16" or "utf-8" or "utf-32" or "utf-32BE")
-                    {
-                        lstValidCharsets.Items.Add(encoding.WebName + "-bom");
-                        lstConvert.Items.Add(encoding.WebName + "-bom");
-                    }
-                }
-                catch (Exception ex) when (
-                    ex is ArgumentException or NotSupportedException)
-                {
-                    // Ignore unsupported charsets.
-                }
-            }
+        IEnumerable<string> validCharsets = GetSupportedCharsets();
 
-            if (lstConvert.Items.Count > 0)
-                lstConvert.SelectedIndex = 0;
-
-            lstConvert.EndUpdate();
-
-            btnView.Tag = CurrentAction.View;
-            btnValidate.Tag = CurrentAction.Validate;
-            btnConvert.Tag = CurrentAction.Convert;
-
-            LoadSettings();
-
-            // Reflect the default sort column/order set in the constructor.
-            lstResults.SetSortIcon(_lvwColumnSorter.SortColumn, _lvwColumnSorter.Order);
-
-            // Size columns for the initial window size.
-            lstResults.Columns[RESULTS_COLUMN_CHARSET]
-                .AutoResize(ColumnHeaderAutoResizeStyle.HeaderSize);
-
-            int remainingWidth =
-                lstResults.Width - lstResults.Columns[RESULTS_COLUMN_CHARSET].Width;
-
-            lstResults.Columns[RESULTS_COLUMN_FILE_NAME].Width =
-                30 * remainingWidth / 100;
-
-            lstResults.Columns[RESULTS_COLUMN_FILE_EXT]
-                .AutoResize(ColumnHeaderAutoResizeStyle.HeaderSize);
-
-            lstResults.Columns[RESULTS_COLUMN_DIRECTORY]
-                .AutoResize(ColumnHeaderAutoResizeStyle.HeaderSize);
-        }
-
-        private void OnFormClosing(object? sender, FormClosingEventArgs e)
+        foreach (string validCharset in validCharsets)
         {
-            if (_actionWorker.IsBusy)
-            {
-                // Cancel and defer the close until the worker settles, not mid-operation.
-                e.Cancel = true;
-
-                if (!_closeRequested)
-                {
-                    _closeRequested = true;
-                    _actionCancellation?.Cancel();
-                }
-
-                return;
-            }
-
-            SaveSettings();
-        }
-
-        private void OnBrowseDirectories(object? sender, EventArgs e)
-        {
-            if (Directory.Exists(lstBaseDirectory.Text))
-                dlgBrowseDirectories.SelectedPath = lstBaseDirectory.Text;
-
-            if (dlgBrowseDirectories.ShowDialog(this) == DialogResult.OK)
-            {
-                lstBaseDirectory.Text = dlgBrowseDirectories.SelectedPath;
-                lstBaseDirectory.Items.Add(dlgBrowseDirectories.SelectedPath);
-            }
-        }
-
-        private void OnSelectDeselectAll(object? sender, EventArgs e)
-        {
-            lstResults.ItemChecked -= OnResultItemChecked;
-
             try
             {
-                bool isChecked = chkSelectDeselectAll.Checked;
+                // Add only charsets supported by .NET.
+                var encoding = Encoding.GetEncoding(validCharset);
 
-                foreach (ListViewItem item in lstResults.Items)
-                    item.Checked = isChecked;
-            }
-            finally
-            {
-                lstResults.ItemChecked += OnResultItemChecked;
-            }
-        }
+                lstValidCharsets.Items.Add(encoding.WebName);
+                lstConvert.Items.Add(encoding.WebName);
 
-        private void OnResultItemChecked(object? sender, ItemCheckedEventArgs e)
-        {
-            chkSelectDeselectAll.CheckedChanged -= OnSelectDeselectAll;
-
-            try
-            {
-                if (lstResults.CheckedItems.Count == 0)
-                    chkSelectDeselectAll.CheckState = CheckState.Unchecked;
-                else if (lstResults.CheckedItems.Count == lstResults.Items.Count)
-                    chkSelectDeselectAll.CheckState = CheckState.Checked;
-                else
-                    chkSelectDeselectAll.CheckState = CheckState.Indeterminate;
-            }
-            finally
-            {
-                chkSelectDeselectAll.CheckedChanged += OnSelectDeselectAll;
-            }
-        }
-
-        private void OnResultColumnClick(object o, ColumnClickEventArgs e)
-        {
-            if (e.Column == _lvwColumnSorter.SortColumn)
-            {
-                _lvwColumnSorter.Order =
-                    _lvwColumnSorter.Order == SortOrder.Ascending
-                        ? SortOrder.Descending
-                        : SortOrder.Ascending;
-            }
-            else
-            {
-                _lvwColumnSorter.SortColumn = e.Column;
-                _lvwColumnSorter.Order = SortOrder.Ascending;
-            }
-
-            lstResults.Sort();
-            lstResults.SetSortIcon(
-                _lvwColumnSorter.SortColumn,
-                _lvwColumnSorter.Order);
-        }
-
-        private void OnHelp(object? sender, EventArgs e)
-        {
-            var psi = new ProcessStartInfo(
-                "https://github.com/amrali-eg/EncodingChecker")
-            {
-                UseShellExecute = true
-            };
-
-            Process.Start(psi);
-        }
-
-        private void OnAbout(object? sender, EventArgs e)
-        {
-            using var aboutForm = new AboutForm();
-            aboutForm.ShowDialog(this);
-        }
-
-        private void OnExport(object? sender, EventArgs e)
-        {
-            if (lstResults.CheckedItems.Count == 0)
-            {
-                ShowWarning("Select one or more files to export");
-                return;
-            }
-
-            var saveFileDialog = new SaveFileDialog
-            {
-                Title = @"Export to a Text File",
-                Filter = @"Text files (*.txt)|*.txt",
-                FileName = "Encoding.txt",
-                RestoreDirectory = true,
-            };
-
-            if (saveFileDialog.ShowDialog(this) != DialogResult.OK)
-                return;
-
-            try
-            {
-                using var writer = new StreamWriter(saveFileDialog.FileName, false, Encoding.UTF8);
-
-                foreach (ListViewItem item in lstResults.CheckedItems)
+                // Add BOM variants after UTF-8/16/32.
+                if (encoding.WebName is "utf-16BE" or "utf-16" or "utf-8" or "utf-32" or "utf-32BE")
                 {
-                    string charset =
-                        item.SubItems[RESULTS_COLUMN_CHARSET].Text;
-
-                    string fileName =
-                        item.SubItems[RESULTS_COLUMN_FILE_NAME].Text;
-
-                    string directory =
-                        item.SubItems[RESULTS_COLUMN_DIRECTORY].Text;
-
-                    writer.WriteLine(
-                        "{0}\t{1}\\{2}",
-                        charset,
-                        directory,
-                        fileName);
+                    lstValidCharsets.Items.Add(encoding.WebName + "-bom");
+                    lstConvert.Items.Add(encoding.WebName + "-bom");
                 }
             }
             catch (Exception ex) when (
-                ex is IOException or UnauthorizedAccessException)
+                ex is ArgumentException or NotSupportedException)
             {
-                ShowWarning(
-                    "Failed to export the report: {0}",
-                    ex.Message);
+                // Ignore unsupported charsets.
             }
         }
 
-        private void OnExportReport(object? sender, EventArgs e)
+        if (lstConvert.Items.Count > 0)
+            lstConvert.SelectedIndex = 0;
+
+        lstConvert.EndUpdate();
+
+        btnView.Tag = CurrentAction.View;
+        btnValidate.Tag = CurrentAction.Validate;
+        btnConvert.Tag = CurrentAction.Convert;
+
+        LoadSettings();
+
+        // Reflect the default sort column/order set in the constructor.
+        lstResults.SetSortIcon(_lvwColumnSorter.SortColumn, _lvwColumnSorter.Order);
+
+        // Size columns for the initial window size.
+        lstResults.Columns[RESULTS_COLUMN_CHARSET]
+            .AutoResize(ColumnHeaderAutoResizeStyle.HeaderSize);
+
+        int remainingWidth =
+            lstResults.Width - lstResults.Columns[RESULTS_COLUMN_CHARSET].Width;
+
+        lstResults.Columns[RESULTS_COLUMN_FILE_NAME].Width =
+            30 * remainingWidth / 100;
+
+        lstResults.Columns[RESULTS_COLUMN_FILE_EXT]
+            .AutoResize(ColumnHeaderAutoResizeStyle.HeaderSize);
+
+        lstResults.Columns[RESULTS_COLUMN_DIRECTORY]
+            .AutoResize(ColumnHeaderAutoResizeStyle.HeaderSize);
+    }
+
+    private void OnFormClosing(object? sender, FormClosingEventArgs e)
+    {
+        if (_actionWorker.IsBusy)
         {
-            if (lstResults.Items.Count == 0)
+            // Cancel and defer the close until the worker settles, not mid-operation.
+            e.Cancel = true;
+
+            if (!_closeRequested)
             {
-                ShowWarning("There are no results to export");
-                return;
-            }
-
-            var saveFileDialog = new SaveFileDialog
-            {
-                Title = @"Export Conversion Report",
-                Filter = @"CSV files (*.csv)|*.csv",
-                FileName = "Conversion report.csv",
-                RestoreDirectory = true,
-            };
-
-            if (saveFileDialog.ShowDialog(this) != DialogResult.OK)
-                return;
-
-            try
-            {
-                var entries =
-                    new List<ConversionReportEntry>(lstResults.Items.Count);
-
-                // Tag is always set to the entry when the row is added (ActionWorkerProgressChanged).
-                foreach (ListViewItem item in lstResults.Items)
-                    entries.Add((ConversionReportEntry)item.Tag!);
-
-                using var writer =
-                    new StreamWriter(saveFileDialog.FileName, false, Encoding.UTF8);
-
-                ConversionReport.WriteCsv(entries, writer);
-            }
-            catch (Exception ex) when (
-                ex is IOException or UnauthorizedAccessException)
-            {
-                ShowWarning(
-                    "Failed to export the csv report: {0}",
-                    ex.Message);
-            }
-        }
-
-        private void OnBaseDirectoryDragEnter(object? sender, DragEventArgs e)
-        {
-            e.Effect =
-                TryGetDroppedDirectory(e.Data, out _)
-                    ? DragDropEffects.Copy
-                    : DragDropEffects.None;
-        }
-
-        private void OnBaseDirectoryDragDrop(object? sender, DragEventArgs e)
-        {
-            if (!TryGetDroppedDirectory(e.Data, out string? directory))
-                return;
-
-            lstBaseDirectory.Text = directory;
-            lstBaseDirectory.Items.Add(directory);
-        }
-
-        private static bool TryGetDroppedDirectory(
-            IDataObject? data,
-            [NotNullWhen(true)] out string? directory)
-        {
-            directory = null;
-
-            if (data == null ||
-                !data.GetDataPresent(DataFormats.FileDrop))
-            {
-                return false;
-            }
-
-            var paths =
-                data.GetData(DataFormats.FileDrop) as string[];
-
-            string? firstDirectory =
-                paths?.FirstOrDefault(Directory.Exists);
-
-            if (firstDirectory == null)
-                return false;
-
-            directory = firstDirectory;
-            return true;
-        }
-
-        #endregion
-
-        #region Action button handling
-
-        private void OnAction(object? sender, EventArgs e)
-        {
-            // Only btnView/btnValidate are wired to this handler, and both have Tag set below.
-            CurrentAction action =
-                (CurrentAction)((Button)sender!).Tag!;
-
-            StartAction(action);
-        }
-
-        private void StartAction(CurrentAction action)
-        {
-            if (_actionWorker.IsBusy)
-                return;
-
-            string directory = lstBaseDirectory.Text;
-
-            if (string.IsNullOrEmpty(directory))
-            {
-                ShowWarning("Please specify a directory to check");
-                return;
-            }
-
-            if (!Directory.Exists(directory))
-            {
-                ShowWarning(
-                    "The directory you specified '{0}' does not exist",
-                    directory);
-                return;
-            }
-
-            if (action == CurrentAction.Validate &&
-                lstValidCharsets.CheckedItems.Count == 0)
-            {
-                ShowWarning(
-                    "Select one or more valid character sets to proceed with validation");
-                return;
-            }
-
-            _currentAction = action;
-            _settings.AddRecentDirectory(directory);
-
-            UpdateControlsOnActionStart();
-
-            // Suspend redraw until ScanWorkerCompleted, once results stop streaming in.
-            lstResults.BeginUpdate();
-            lstResults.ListViewItemSorter = null;
-            lstResults.ItemChecked -= OnResultItemChecked;
-            lstResults.Items.Clear();
-
-            var validCharsets =
-                new List<string>(lstValidCharsets.CheckedItems.Count);
-
-            foreach (string validCharset in lstValidCharsets.CheckedItems)
-                validCharsets.Add(validCharset);
-
-            _actionCancellation?.Dispose();
-            _actionCancellation = new CancellationTokenSource();
-
-            var args = new WorkerArgs
-            {
-                Action = action,
-                BaseDirectory = directory,
-                IncludeSubdirectories = chkIncludeSubdirectories.Checked,
-                FileMasks = txtFileMasks.Text,
-                ValidCharsets = validCharsets,
-                CancellationToken = _actionCancellation.Token,
-            };
-
-            _actionWorker.RunWorkerAsync(args);
-        }
-
-        private void OnConvert(object? sender, EventArgs e)
-        {
-            if (_actionWorker.IsBusy)
-                return;
-
-            if (lstResults.CheckedItems.Count == 0)
-            {
-                ShowWarning("Select one or more files to convert");
-                return;
-            }
-
-            // BOM is handled separately from the charset name.
-            // lstConvert is DropDownList-style and OnFormLoad selects index 0 once
-            // populated, so SelectedItem is never null here.
-            string targetLabel = (string)lstConvert.SelectedItem!;
-
-            ScanEngine.ParseCharsetLabel(
-                targetLabel,
-                out string targetBaseCharset,
-                out bool writeBom);
-
-            var itemsByPath =
-                new Dictionary<string, ListViewItem>(
-                    StringComparer.OrdinalIgnoreCase);
-
-            var entries =
-                new List<ConversionReportEntry>(
-                    lstResults.CheckedItems.Count);
-
-            // Tag is always set to the entry when the row is added (ActionWorkerProgressChanged).
-            foreach (ListViewItem item in lstResults.CheckedItems)
-            {
-                var entry = (ConversionReportEntry)item.Tag!;
-
-                itemsByPath[entry.FilePath] = item;
-                entries.Add(entry);
-            }
-
-            _convertItemsByPath = itemsByPath;
-            _convertTargetLabel = targetLabel;
-            _currentAction = CurrentAction.Convert;
-
-            UpdateControlsOnActionStart();
-
-            _actionCancellation?.Dispose();
-            _actionCancellation = new CancellationTokenSource();
-
-            var args = new ConvertWorkerArgs
-            {
-                Entries = entries,
-                TargetBaseCharset = targetBaseCharset,
-                TargetWriteBom = writeBom,
-                CancellationToken = _actionCancellation.Token,
-            };
-
-            _actionWorker.RunWorkerAsync(args);
-        }
-
-        private void OnCancelAction(object? sender, EventArgs e)
-        {
-            if (_actionWorker.IsBusy)
-            {
-                btnCancel.Visible = false;
-                _actionWorker.CancelAsync();
+                _closeRequested = true;
                 _actionCancellation?.Cancel();
             }
+
+            return;
         }
 
-        #endregion
+        SaveSettings();
+    }
 
-        #region Background worker event handlers
+    private void OnBrowseDirectories(object? sender, EventArgs e)
+    {
+        if (Directory.Exists(lstBaseDirectory.Text))
+            dlgBrowseDirectories.SelectedPath = lstBaseDirectory.Text;
 
-        private static void ActionWorkerDoWork(
-            object? sender,
-            DoWorkEventArgs e)
+        if (dlgBrowseDirectories.ShowDialog(this) == DialogResult.OK)
         {
-            if (e.Argument is ConvertWorkerArgs convertArgs)
-            {
-                ConvertWorkerDoWork(convertArgs, e);
-                return;
-            }
-
-            var worker = (BackgroundWorker)sender!;
-            var args = (WorkerArgs)e.Argument!;
-
-            List<string> includePatterns =
-                SplitFileMasks(args.FileMasks);
-
-            var scanOptions = new ScanDirectoryOptions
-            {
-                BaseDirectory = args.BaseDirectory,
-                IncludeSubdirectories = args.IncludeSubdirectories,
-                IncludePatterns = includePatterns,
-                Action =
-                    args.Action == CurrentAction.Validate
-                        ? ScanAction.Validate
-                        : ScanAction.Detect,
-                ValidCharsets = args.ValidCharsets,
-            };
-
-            try
-            {
-                ScanEngine.ScanDirectory(
-                    scanOptions,
-                    onEntry: entry =>
-                    {
-                        // Hide files that already pass validation.
-                        if (args.Action == CurrentAction.Validate &&
-                            entry.Result == ConversionRowResult.Unchanged)
-                        {
-                            return;
-                        }
-
-                        worker.ReportProgress(0, entry);
-                    },
-                    args.CancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                e.Cancel = true;
-            }
+            lstBaseDirectory.Text = dlgBrowseDirectories.SelectedPath;
+            lstBaseDirectory.Items.Add(dlgBrowseDirectories.SelectedPath);
         }
+    }
 
-        // No per-file progress to report; results are applied in one batch in ConvertWorkerCompleted.
-        private static void ConvertWorkerDoWork(
-            ConvertWorkerArgs args,
-            DoWorkEventArgs e)
+    private void OnSelectDeselectAll(object? sender, EventArgs e)
+    {
+        lstResults.ItemChecked -= OnResultItemChecked;
+
+        try
         {
-            var completed = new ConcurrentBag<ConversionReportEntry>();
+            bool isChecked = chkSelectDeselectAll.Checked;
 
-            try
-            {
-                ScanEngine.ConvertFiles(
-                    args.Entries,
-                    args.TargetBaseCharset,
-                    args.TargetWriteBom,
-                    ScanEngine.DefaultMaxParallelism,
-                    onEntry: completed.Add,
-                    args.CancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                e.Cancel = true;
-            }
-
-            e.Result = completed;
+            foreach (ListViewItem item in lstResults.Items)
+                item.Checked = isChecked;
         }
-
-        // GUI masks are newline-separated; ScanEngine receives split patterns.
-        private static List<string> SplitFileMasks(string fileMaskString)
+        finally
         {
-            if (string.IsNullOrWhiteSpace(fileMaskString))
-                return [];
-
-            return
-            [
-                .. fileMaskString
-                    .Split(
-                        [Environment.NewLine],
-                        StringSplitOptions.RemoveEmptyEntries)
-                    .Select(mask => mask.Trim())
-                    .Where(mask => mask.Length > 0)
-            ];
-        }
-
-        private void ActionWorkerProgressChanged(
-            object? sender,
-            ProgressChangedEventArgs e)
-        {
-            if (e.UserState is not ConversionReportEntry entry)
-                return;
-
-            string charsetLabel =
-                ScanEngine.FormatCharsetLabel(
-                    entry.SourceEncoding,
-                    entry.SourceHasBom);
-
-            var resultItem = new ListViewItem(
-                [
-                    charsetLabel,
-                    Path.GetFileName(entry.FilePath),
-                    Path.GetExtension(entry.FilePath),
-                    Path.GetDirectoryName(entry.FilePath) ?? string.Empty
-                ],
-                -1)
-            {
-                Tag = entry,
-            };
-
-            lstResults.Items.Add(resultItem);
-            actionStatus.Text = entry.FilePath;
-        }
-
-        private void ActionWorkerCompleted(
-            object? sender,
-            RunWorkerCompletedEventArgs e)
-        {
-            if (_currentAction == CurrentAction.Convert)
-                ConvertWorkerCompleted(e);
-            else
-                ScanWorkerCompleted(e);
-
-            // Deferred from OnFormClosing while this operation was still running.
-            if (_closeRequested)
-                Close();
-        }
-
-        private void ScanWorkerCompleted(RunWorkerCompletedEventArgs e)
-        {
-            if (e.Error != null)
-            {
-                ShowWarning(
-                    "An unexpected error occurred while scanning: {0}",
-                    e.Error.Message);
-            }
-
-            if (lstResults.Items.Count > 0)
-            {
-                foreach (ColumnHeader columnHeader in lstResults.Columns)
-                {
-                    columnHeader.AutoResize(
-                        ColumnHeaderAutoResizeStyle.ColumnContent);
-                }
-            }
-
-            // Redraw was suspended in StartAction; restore sorting and resume now.
-            lstResults.ListViewItemSorter = _lvwColumnSorter;
             lstResults.ItemChecked += OnResultItemChecked;
-            lstResults.Sort();
-            lstResults.EndUpdate();
-
-            string statusMessage = e.Cancelled
-                ? "Cancelled - {0} files processed"
-                : _currentAction == CurrentAction.View
-                    ? "{0} files processed"
-                    : "{0} files do not have the correct encoding";
-
-            UpdateControlsOnActionDone(
-                string.Format(statusMessage, lstResults.Items.Count));
         }
+    }
 
-        private void ConvertWorkerCompleted(RunWorkerCompletedEventArgs e)
+    private void OnResultItemChecked(object? sender, ItemCheckedEventArgs e)
+    {
+        chkSelectDeselectAll.CheckedChanged -= OnSelectDeselectAll;
+
+        try
         {
-            string targetLabel = _convertTargetLabel!;
-            Dictionary<string, ListViewItem> itemsByPath = _convertItemsByPath!;
-
-            _convertItemsByPath = null;
-            _convertTargetLabel = null;
-
-            if (e.Error != null)
-            {
-                ShowWarning(
-                    "An unexpected error occurred while converting: {0}",
-                    e.Error.Message);
-
-                UpdateControlsOnActionDone("Conversion failed.");
-                return;
-            }
-
-            // ConvertWorkerDoWork always assigns e.Result, even when cancelled.
-            var completed = (ConcurrentBag<ConversionReportEntry>)e.Result!;
-
-            int convertedCount = 0;
-            int unchangedCount = 0;
-            int errorCount = 0;
-
-            // Update the UI only after parallel processing completes.
-            lstResults.BeginUpdate();
-            lstResults.ItemChecked -= OnResultItemChecked;
-
-            foreach (ConversionReportEntry entry in completed)
-            {
-                if (!itemsByPath.TryGetValue(
-                        entry.FilePath,
-                        out ListViewItem? item))
-                {
-                    continue;
-                }
-
-                UpdateResultItem(item, entry, targetLabel);
-
-                switch (entry.Result)
-                {
-                    case ConversionRowResult.Converted:
-                        convertedCount++;
-                        break;
-                    case ConversionRowResult.Error:
-                        errorCount++;
-                        break;
-                    default:
-                        unchangedCount++;
-                        break;
-                }
-            }
-
-            // The Charset column changed for converted rows.
-            lstResults.Sort();
-
-            lstResults.ItemChecked += OnResultItemChecked;
-            lstResults.EndUpdate();
-
-            OnResultItemChecked(
-                lstResults,
-                new ItemCheckedEventArgs(lstResults.Items[0]));
-
-            btnExportReport.Visible = lstResults.Items.Count > 0;
-
-            string statusMessage = e.Cancelled
-                ? $"Conversion cancelled: {convertedCount} converted, " +
-                  $"{unchangedCount} unchanged, {errorCount} failed"
-                : $"Conversion complete: {convertedCount} converted, " +
-                  $"{unchangedCount} unchanged, {errorCount} failed";
-
-            UpdateControlsOnActionDone(statusMessage);
-        }
-
-        // Single place that formats a row from its ConversionReportEntry.
-        private static void UpdateResultItem(
-            ListViewItem item,
-            ConversionReportEntry entry,
-            string targetLabel)
-        {
-            if (entry.Result == ConversionRowResult.Converted)
-            {
-                item.Checked = false;
-                item.ImageIndex = 0;
-                item.SubItems[RESULTS_COLUMN_CHARSET].Text = targetLabel;
-            }
-            else if (entry.Result == ConversionRowResult.Error)
-            {
-                Debug.WriteLine(
-                    $"Conversion failed for {entry.FilePath}: {entry.Diagnostic}");
-            }
-            else if (entry.Result == ConversionRowResult.Skipped)
-            {
-                Debug.WriteLine(
-                    $"Conversion skipped for {entry.FilePath}: encoding could not be determined.");
-            }
-            // Unchanged: already matched the target; nothing was written, row stays as-is.
-        }
-
-        #endregion
-
-        #region Loading and saving settings
-
-        private void LoadSettings()
-        {
-            string settingsFileName = GetSettingsFileName();
-
-            if (!File.Exists(settingsFileName))
-                return;
-
-            Settings settings;
-
-            try
-            {
-                using (var settingsFile = new FileStream(
-                    settingsFileName,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read))
-                {
-                    var serializer = new XmlSerializer(typeof(Settings));
-
-                    settings =
-                        serializer.Deserialize(settingsFile) as Settings
-                        ?? new Settings();
-                }
-            }
-            catch (Exception ex) when (
-                ex is IOException or
-                UnauthorizedAccessException or
-                InvalidOperationException)
-            {
-                // Corrupt or unreadable settings shouldn't prevent startup.
-                settings = new Settings();
-            }
-
-            _settings = settings;
-
-            if (settings.RecentDirectories.Count > 0)
-            {
-                foreach (string recentDirectory in
-                         settings.RecentDirectories)
-                {
-                    lstBaseDirectory.Items.Add(recentDirectory);
-                }
-
-                lstBaseDirectory.SelectedIndex = 0;
-            }
+            if (lstResults.CheckedItems.Count == 0)
+                chkSelectDeselectAll.CheckState = CheckState.Unchecked;
+            else if (lstResults.CheckedItems.Count == lstResults.Items.Count)
+                chkSelectDeselectAll.CheckState = CheckState.Checked;
             else
+                chkSelectDeselectAll.CheckState = CheckState.Indeterminate;
+        }
+        finally
+        {
+            chkSelectDeselectAll.CheckedChanged += OnSelectDeselectAll;
+        }
+    }
+
+    private void OnResultColumnClick(object o, ColumnClickEventArgs e)
+    {
+        if (e.Column == _lvwColumnSorter.SortColumn)
+        {
+            _lvwColumnSorter.Order =
+                _lvwColumnSorter.Order == SortOrder.Ascending
+                    ? SortOrder.Descending
+                    : SortOrder.Ascending;
+        }
+        else
+        {
+            _lvwColumnSorter.SortColumn = e.Column;
+            _lvwColumnSorter.Order = SortOrder.Ascending;
+        }
+
+        lstResults.Sort();
+        lstResults.SetSortIcon(
+            _lvwColumnSorter.SortColumn,
+            _lvwColumnSorter.Order);
+    }
+
+    private void OnHelp(object? sender, EventArgs e)
+    {
+        var psi = new ProcessStartInfo(
+            "https://github.com/amrali-eg/EncodingChecker")
+        {
+            UseShellExecute = true
+        };
+
+        Process.Start(psi);
+    }
+
+    private void OnAbout(object? sender, EventArgs e)
+    {
+        using var aboutForm = new AboutForm();
+        aboutForm.ShowDialog(this);
+    }
+
+    private void OnExport(object? sender, EventArgs e)
+    {
+        if (lstResults.CheckedItems.Count == 0)
+        {
+            ShowWarning("Select one or more files to export");
+            return;
+        }
+
+        var saveFileDialog = new SaveFileDialog
+        {
+            Title = @"Export to a Text File",
+            Filter = @"Text files (*.txt)|*.txt",
+            FileName = "Encoding.txt",
+            RestoreDirectory = true,
+        };
+
+        if (saveFileDialog.ShowDialog(this) != DialogResult.OK)
+            return;
+
+        try
+        {
+            using var writer = new StreamWriter(saveFileDialog.FileName, false, Encoding.UTF8);
+
+            foreach (ListViewItem item in lstResults.CheckedItems)
             {
-                lstBaseDirectory.Text =
-                    Environment.CurrentDirectory;
+                string charset =
+                    item.SubItems[RESULTS_COLUMN_CHARSET].Text;
+
+                string fileName =
+                    item.SubItems[RESULTS_COLUMN_FILE_NAME].Text;
+
+                string directory =
+                    item.SubItems[RESULTS_COLUMN_DIRECTORY].Text;
+
+                writer.WriteLine(
+                    "{0}\t{1}\\{2}",
+                    charset,
+                    directory,
+                    fileName);
             }
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException)
+        {
+            ShowWarning(
+                "Failed to export the report: {0}",
+                ex.Message);
+        }
+    }
 
-            chkIncludeSubdirectories.Checked =
-                settings.IncludeSubdirectories;
+    private void OnExportReport(object? sender, EventArgs e)
+    {
+        if (lstResults.Items.Count == 0)
+        {
+            ShowWarning("There are no results to export");
+            return;
+        }
 
-            // Restore CRLF for the multiline textbox; XmlSerializer writes LF.
-            txtFileMasks.Text = settings.FileMasks
-                .Replace("\r\n", "\n")
-                .Replace("\n", "\r\n");
+        var saveFileDialog = new SaveFileDialog
+        {
+            Title = @"Export Conversion Report",
+            Filter = @"CSV files (*.csv)|*.csv",
+            FileName = "Conversion report.csv",
+            RestoreDirectory = true,
+        };
 
-            if (settings.ValidCharsets.Length > 0)
-            {
-                for (int i = 0;
-                     i < lstValidCharsets.Items.Count;
-                     i++)
+        if (saveFileDialog.ShowDialog(this) != DialogResult.OK)
+            return;
+
+        try
+        {
+            var entries =
+                new List<ConversionReportEntry>(lstResults.Items.Count);
+
+            // Tag is always set to the entry when the row is added (ActionWorkerProgressChanged).
+            foreach (ListViewItem item in lstResults.Items)
+                entries.Add((ConversionReportEntry)item.Tag!);
+
+            using var writer =
+                new StreamWriter(saveFileDialog.FileName, false, Encoding.UTF8);
+
+            ConversionReport.WriteCsv(entries, writer);
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException)
+        {
+            ShowWarning(
+                "Failed to export the csv report: {0}",
+                ex.Message);
+        }
+    }
+
+    private void OnBaseDirectoryDragEnter(object? sender, DragEventArgs e)
+    {
+        e.Effect =
+            TryGetDroppedDirectory(e.Data, out _)
+                ? DragDropEffects.Copy
+                : DragDropEffects.None;
+    }
+
+    private void OnBaseDirectoryDragDrop(object? sender, DragEventArgs e)
+    {
+        if (!TryGetDroppedDirectory(e.Data, out string? directory))
+            return;
+
+        lstBaseDirectory.Text = directory;
+        lstBaseDirectory.Items.Add(directory);
+    }
+
+    private static bool TryGetDroppedDirectory(
+        IDataObject? data,
+        [NotNullWhen(true)] out string? directory)
+    {
+        directory = null;
+
+        if (data == null ||
+            !data.GetDataPresent(DataFormats.FileDrop))
+        {
+            return false;
+        }
+
+        var paths =
+            data.GetData(DataFormats.FileDrop) as string[];
+
+        string? firstDirectory =
+            paths?.FirstOrDefault(Directory.Exists);
+
+        if (firstDirectory == null)
+            return false;
+
+        directory = firstDirectory;
+        return true;
+    }
+
+    #endregion
+
+    #region Action button handling
+
+    private void OnAction(object? sender, EventArgs e)
+    {
+        // Only btnView/btnValidate are wired to this handler, and both have Tag set below.
+        CurrentAction action =
+            (CurrentAction)((Button)sender!).Tag!;
+
+        StartAction(action);
+    }
+
+    private void StartAction(CurrentAction action)
+    {
+        if (_actionWorker.IsBusy)
+            return;
+
+        string directory = lstBaseDirectory.Text;
+
+        if (string.IsNullOrEmpty(directory))
+        {
+            ShowWarning("Please specify a directory to check");
+            return;
+        }
+
+        if (!Directory.Exists(directory))
+        {
+            ShowWarning(
+                "The directory you specified '{0}' does not exist",
+                directory);
+            return;
+        }
+
+        if (action == CurrentAction.Validate &&
+            lstValidCharsets.CheckedItems.Count == 0)
+        {
+            ShowWarning(
+                "Select one or more valid character sets to proceed with validation");
+            return;
+        }
+
+        _currentAction = action;
+        _settings.AddRecentDirectory(directory);
+
+        UpdateControlsOnActionStart();
+
+        // Suspend redraw until ScanWorkerCompleted, once results stop streaming in.
+        lstResults.BeginUpdate();
+        lstResults.ListViewItemSorter = null;
+        lstResults.ItemChecked -= OnResultItemChecked;
+        lstResults.Items.Clear();
+
+        var validCharsets =
+            new List<string>(lstValidCharsets.CheckedItems.Count);
+
+        foreach (string validCharset in lstValidCharsets.CheckedItems)
+            validCharsets.Add(validCharset);
+
+        _actionCancellation?.Dispose();
+        _actionCancellation = new CancellationTokenSource();
+
+        var args = new WorkerArgs
+        {
+            Action = action,
+            BaseDirectory = directory,
+            IncludeSubdirectories = chkIncludeSubdirectories.Checked,
+            FileMasks = txtFileMasks.Text,
+            ValidCharsets = validCharsets,
+            CancellationToken = _actionCancellation.Token,
+        };
+
+        _actionWorker.RunWorkerAsync(args);
+    }
+
+    private void OnConvert(object? sender, EventArgs e)
+    {
+        if (_actionWorker.IsBusy)
+            return;
+
+        if (lstResults.CheckedItems.Count == 0)
+        {
+            ShowWarning("Select one or more files to convert");
+            return;
+        }
+
+        // BOM is handled separately from the charset name.
+        // lstConvert is DropDownList-style and OnFormLoad selects index 0 once
+        // populated, so SelectedItem is never null here.
+        string targetLabel = (string)lstConvert.SelectedItem!;
+
+        ScanEngine.ParseCharsetLabel(
+            targetLabel,
+            out string targetBaseCharset,
+            out bool writeBom);
+
+        var itemsByPath =
+            new Dictionary<string, ListViewItem>(
+                StringComparer.OrdinalIgnoreCase);
+
+        var entries =
+            new List<ConversionReportEntry>(
+                lstResults.CheckedItems.Count);
+
+        // Tag is always set to the entry when the row is added (ActionWorkerProgressChanged).
+        foreach (ListViewItem item in lstResults.CheckedItems)
+        {
+            var entry = (ConversionReportEntry)item.Tag!;
+
+            itemsByPath[entry.FilePath] = item;
+            entries.Add(entry);
+        }
+
+        _convertItemsByPath = itemsByPath;
+        _convertTargetLabel = targetLabel;
+        _currentAction = CurrentAction.Convert;
+
+        UpdateControlsOnActionStart();
+
+        _actionCancellation?.Dispose();
+        _actionCancellation = new CancellationTokenSource();
+
+        var args = new ConvertWorkerArgs
+        {
+            Entries = entries,
+            TargetBaseCharset = targetBaseCharset,
+            TargetWriteBom = writeBom,
+            CancellationToken = _actionCancellation.Token,
+        };
+
+        _actionWorker.RunWorkerAsync(args);
+    }
+
+    private void OnCancelAction(object? sender, EventArgs e)
+    {
+        if (_actionWorker.IsBusy)
+        {
+            btnCancel.Visible = false;
+            _actionWorker.CancelAsync();
+            _actionCancellation?.Cancel();
+        }
+    }
+
+    #endregion
+
+    #region Background worker event handlers
+
+    private static void ActionWorkerDoWork(
+        object? sender,
+        DoWorkEventArgs e)
+    {
+        if (e.Argument is ConvertWorkerArgs convertArgs)
+        {
+            ConvertWorkerDoWork(convertArgs, e);
+            return;
+        }
+
+        var worker = (BackgroundWorker)sender!;
+        var args = (WorkerArgs)e.Argument!;
+
+        List<string> includePatterns =
+            SplitFileMasks(args.FileMasks);
+
+        var scanOptions = new ScanDirectoryOptions
+        {
+            BaseDirectory = args.BaseDirectory,
+            IncludeSubdirectories = args.IncludeSubdirectories,
+            IncludePatterns = includePatterns,
+            Action =
+                args.Action == CurrentAction.Validate
+                    ? ScanAction.Validate
+                    : ScanAction.Detect,
+            ValidCharsets = args.ValidCharsets,
+        };
+
+        try
+        {
+            ScanEngine.ScanDirectory(
+                scanOptions,
+                onEntry: entry =>
                 {
-                    if (Array.Exists(
-                        settings.ValidCharsets,
-                        charset => charset.Equals(
-                            (string)lstValidCharsets.Items[i],
-                            StringComparison.OrdinalIgnoreCase)))
+                    // Hide files that already pass validation.
+                    if (args.Action == CurrentAction.Validate &&
+                        entry.Result == ConversionRowResult.Unchanged)
                     {
-                        lstValidCharsets.SetItemChecked(i, true);
+                        return;
                     }
-                }
-            }
 
-            settings.WindowPosition.ApplyTo(this);
+                    worker.ReportProgress(0, entry);
+                },
+                args.CancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            e.Cancel = true;
+        }
+    }
+
+    // No per-file progress to report; results are applied in one batch in ConvertWorkerCompleted.
+    private static void ConvertWorkerDoWork(
+        ConvertWorkerArgs args,
+        DoWorkEventArgs e)
+    {
+        var completed = new ConcurrentBag<ConversionReportEntry>();
+
+        try
+        {
+            ScanEngine.ConvertFiles(
+                args.Entries,
+                args.TargetBaseCharset,
+                args.TargetWriteBom,
+                ScanEngine.DefaultMaxParallelism,
+                onEntry: completed.Add,
+                args.CancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            e.Cancel = true;
         }
 
-        private void SaveSettings()
+        e.Result = completed;
+    }
+
+    // GUI masks are newline-separated; ScanEngine receives split patterns.
+    private static List<string> SplitFileMasks(string fileMaskString)
+    {
+        if (string.IsNullOrWhiteSpace(fileMaskString))
+            return [];
+
+        return
+        [
+            .. fileMaskString
+                .Split(
+                    [Environment.NewLine],
+                    StringSplitOptions.RemoveEmptyEntries)
+                .Select(mask => mask.Trim())
+                .Where(mask => mask.Length > 0)
+        ];
+    }
+
+    private void ActionWorkerProgressChanged(
+        object? sender,
+        ProgressChangedEventArgs e)
+    {
+        if (e.UserState is not ConversionReportEntry entry)
+            return;
+
+        string charsetLabel =
+            ScanEngine.FormatCharsetLabel(
+                entry.SourceEncoding,
+                entry.SourceHasBom);
+
+        var resultItem = new ListViewItem(
+            [
+                charsetLabel,
+                Path.GetFileName(entry.FilePath),
+                Path.GetExtension(entry.FilePath),
+                Path.GetDirectoryName(entry.FilePath) ?? string.Empty
+            ],
+            -1)
         {
-            _settings.IncludeSubdirectories =
-                chkIncludeSubdirectories.Checked;
+            Tag = entry,
+        };
 
-            _settings.FileMasks =
-                txtFileMasks.Text;
+        lstResults.Items.Add(resultItem);
+        actionStatus.Text = entry.FilePath;
+    }
 
-            _settings.ValidCharsets =
-                new string[lstValidCharsets.CheckedItems.Count];
+    private void ActionWorkerCompleted(
+        object? sender,
+        RunWorkerCompletedEventArgs e)
+    {
+        if (_currentAction == CurrentAction.Convert)
+            ConvertWorkerCompleted(e);
+        else
+            ScanWorkerCompleted(e);
 
+        // Deferred from OnFormClosing while this operation was still running.
+        if (_closeRequested)
+            Close();
+    }
+
+    private void ScanWorkerCompleted(RunWorkerCompletedEventArgs e)
+    {
+        if (e.Error != null)
+        {
+            ShowWarning(
+                "An unexpected error occurred while scanning: {0}",
+                e.Error.Message);
+        }
+
+        if (lstResults.Items.Count > 0)
+        {
+            foreach (ColumnHeader columnHeader in lstResults.Columns)
+            {
+                columnHeader.AutoResize(
+                    ColumnHeaderAutoResizeStyle.ColumnContent);
+            }
+        }
+
+        // Redraw was suspended in StartAction; restore sorting and resume now.
+        lstResults.ListViewItemSorter = _lvwColumnSorter;
+        lstResults.ItemChecked += OnResultItemChecked;
+        lstResults.Sort();
+        lstResults.EndUpdate();
+
+        string statusMessage = e.Cancelled
+            ? "Cancelled - {0} files processed"
+            : _currentAction == CurrentAction.View
+                ? "{0} files processed"
+                : "{0} files do not have the correct encoding";
+
+        UpdateControlsOnActionDone(
+            string.Format(statusMessage, lstResults.Items.Count));
+    }
+
+    private void ConvertWorkerCompleted(RunWorkerCompletedEventArgs e)
+    {
+        string targetLabel = _convertTargetLabel!;
+        Dictionary<string, ListViewItem> itemsByPath = _convertItemsByPath!;
+
+        _convertItemsByPath = null;
+        _convertTargetLabel = null;
+
+        if (e.Error != null)
+        {
+            ShowWarning(
+                "An unexpected error occurred while converting: {0}",
+                e.Error.Message);
+
+            UpdateControlsOnActionDone("Conversion failed.");
+            return;
+        }
+
+        // ConvertWorkerDoWork always assigns e.Result, even when cancelled.
+        var completed = (ConcurrentBag<ConversionReportEntry>)e.Result!;
+
+        int convertedCount = 0;
+        int unchangedCount = 0;
+        int errorCount = 0;
+
+        // Update the UI only after parallel processing completes.
+        lstResults.BeginUpdate();
+        lstResults.ItemChecked -= OnResultItemChecked;
+
+        foreach (ConversionReportEntry entry in completed)
+        {
+            if (!itemsByPath.TryGetValue(
+                    entry.FilePath,
+                    out ListViewItem? item))
+            {
+                continue;
+            }
+
+            UpdateResultItem(item, entry, targetLabel);
+
+            switch (entry.Result)
+            {
+                case ConversionRowResult.Converted:
+                    convertedCount++;
+                    break;
+                case ConversionRowResult.Error:
+                    errorCount++;
+                    break;
+                default:
+                    unchangedCount++;
+                    break;
+            }
+        }
+
+        // The Charset column changed for converted rows.
+        lstResults.Sort();
+
+        lstResults.ItemChecked += OnResultItemChecked;
+        lstResults.EndUpdate();
+
+        OnResultItemChecked(
+            lstResults,
+            new ItemCheckedEventArgs(lstResults.Items[0]));
+
+        btnExportReport.Visible = lstResults.Items.Count > 0;
+
+        string statusMessage = e.Cancelled
+            ? $"Conversion cancelled: {convertedCount} converted, " +
+              $"{unchangedCount} unchanged, {errorCount} failed"
+            : $"Conversion complete: {convertedCount} converted, " +
+              $"{unchangedCount} unchanged, {errorCount} failed";
+
+        UpdateControlsOnActionDone(statusMessage);
+    }
+
+    // Single place that formats a row from its ConversionReportEntry.
+    private static void UpdateResultItem(
+        ListViewItem item,
+        ConversionReportEntry entry,
+        string targetLabel)
+    {
+        if (entry.Result == ConversionRowResult.Converted)
+        {
+            item.Checked = false;
+            item.ImageIndex = 0;
+            item.SubItems[RESULTS_COLUMN_CHARSET].Text = targetLabel;
+        }
+        else if (entry.Result == ConversionRowResult.Error)
+        {
+            Debug.WriteLine(
+                $"Conversion failed for {entry.FilePath}: {entry.Diagnostic}");
+        }
+        else if (entry.Result == ConversionRowResult.Skipped)
+        {
+            Debug.WriteLine(
+                $"Conversion skipped for {entry.FilePath}: encoding could not be determined.");
+        }
+        // Unchanged: already matched the target; nothing was written, row stays as-is.
+    }
+
+    #endregion
+
+    #region Loading and saving settings
+
+    private void LoadSettings()
+    {
+        string settingsFileName = GetSettingsFileName();
+
+        if (!File.Exists(settingsFileName))
+            return;
+
+        Settings settings;
+
+        try
+        {
+            using (var settingsFile = new FileStream(
+                settingsFileName,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read))
+            {
+                var serializer = new XmlSerializer(typeof(Settings));
+
+                settings =
+                    serializer.Deserialize(settingsFile) as Settings
+                    ?? new Settings();
+            }
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+            UnauthorizedAccessException or
+            InvalidOperationException)
+        {
+            // Corrupt or unreadable settings shouldn't prevent startup.
+            settings = new Settings();
+        }
+
+        _settings = settings;
+
+        if (settings.RecentDirectories.Count > 0)
+        {
+            foreach (string recentDirectory in
+                     settings.RecentDirectories)
+            {
+                lstBaseDirectory.Items.Add(recentDirectory);
+            }
+
+            lstBaseDirectory.SelectedIndex = 0;
+        }
+        else
+        {
+            lstBaseDirectory.Text =
+                Environment.CurrentDirectory;
+        }
+
+        chkIncludeSubdirectories.Checked =
+            settings.IncludeSubdirectories;
+
+        // Restore CRLF for the multiline textbox; XmlSerializer writes LF.
+        txtFileMasks.Text = settings.FileMasks
+            .Replace("\r\n", "\n")
+            .Replace("\n", "\r\n");
+
+        if (settings.ValidCharsets.Length > 0)
+        {
             for (int i = 0;
-                 i < lstValidCharsets.CheckedItems.Count;
+                 i < lstValidCharsets.Items.Count;
                  i++)
             {
-                _settings.ValidCharsets[i] =
-                    (string)lstValidCharsets.CheckedItems[i]!;
-            }
-
-            _settings.WindowPosition =
-                new WindowPosition
+                if (Array.Exists(
+                    settings.ValidCharsets,
+                    charset => charset.Equals(
+                        (string)lstValidCharsets.Items[i],
+                        StringComparison.OrdinalIgnoreCase)))
                 {
-                    Left = Left,
-                    Top = Top,
-                    Width = Width,
-                    Height = Height
-                };
-
-            string settingsFileName =
-                GetSettingsFileName();
-
-            try
-            {
-                using var settingsFile = new FileStream(
-                    settingsFileName,
-                    FileMode.Create,
-                    FileAccess.Write,
-                    FileShare.None);
-
-                var serializer =
-                    new XmlSerializer(typeof(Settings));
-
-                serializer.Serialize(
-                    settingsFile,
-                    _settings);
-
-                settingsFile.Flush();
-            }
-            catch (Exception ex) when (
-                ex is IOException or
-                UnauthorizedAccessException or
-                InvalidOperationException)
-            {
-                // Settings are non-critical; don't block closing the app over this.
+                    lstValidCharsets.SetItemChecked(i, true);
+                }
             }
         }
 
-        private static string GetSettingsFileName()
+        settings.WindowPosition.ApplyTo(this);
+    }
+
+    private void SaveSettings()
+    {
+        _settings.IncludeSubdirectories =
+            chkIncludeSubdirectories.Checked;
+
+        _settings.FileMasks =
+            txtFileMasks.Text;
+
+        _settings.ValidCharsets =
+            new string[lstValidCharsets.CheckedItems.Count];
+
+        for (int i = 0;
+             i < lstValidCharsets.CheckedItems.Count;
+             i++)
         {
-            string dataDirectory =
-                Environment.GetFolderPath(
-                    Environment.SpecialFolder.ApplicationData);
+            _settings.ValidCharsets[i] =
+                (string)lstValidCharsets.CheckedItems[i]!;
+        }
 
-            if (string.IsNullOrEmpty(dataDirectory) ||
-                !Directory.Exists(dataDirectory))
+        _settings.WindowPosition =
+            new WindowPosition
             {
-                dataDirectory = Environment.CurrentDirectory;
-            }
+                Left = Left,
+                Top = Top,
+                Width = Width,
+                Height = Height
+            };
 
-            dataDirectory =
-                Path.Combine(
-                    dataDirectory,
-                    "EncodingChecker");
+        string settingsFileName =
+            GetSettingsFileName();
 
-            if (!Directory.Exists(dataDirectory))
-                Directory.CreateDirectory(dataDirectory);
+        try
+        {
+            using var settingsFile = new FileStream(
+                settingsFileName,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None);
 
-            return Path.Combine(
+            var serializer =
+                new XmlSerializer(typeof(Settings));
+
+            serializer.Serialize(
+                settingsFile,
+                _settings);
+
+            settingsFile.Flush();
+        }
+        catch (Exception ex) when (
+            ex is IOException or
+            UnauthorizedAccessException or
+            InvalidOperationException)
+        {
+            // Settings are non-critical; don't block closing the app over this.
+        }
+    }
+
+    private static string GetSettingsFileName()
+    {
+        string dataDirectory =
+            Environment.GetFolderPath(
+                Environment.SpecialFolder.ApplicationData);
+
+        if (string.IsNullOrEmpty(dataDirectory) ||
+            !Directory.Exists(dataDirectory))
+        {
+            dataDirectory = Environment.CurrentDirectory;
+        }
+
+        dataDirectory =
+            Path.Combine(
                 dataDirectory,
-                "Settings.xml");
-        }
+                "EncodingChecker");
 
-        #endregion
+        if (!Directory.Exists(dataDirectory))
+            Directory.CreateDirectory(dataDirectory);
 
-        private void UpdateControlsOnActionStart()
+        return Path.Combine(
+            dataDirectory,
+            "Settings.xml");
+    }
+
+    #endregion
+
+    private void UpdateControlsOnActionStart()
+    {
+        btnView.Enabled = false;
+        btnValidate.Enabled = false;
+
+        lblConvert.Enabled = false;
+        lstConvert.Enabled = false;
+        btnConvert.Enabled = false;
+        chkSelectDeselectAll.Enabled = false;
+        chkSelectDeselectAll.CheckState =
+            CheckState.Unchecked;
+        btnExportReport.Visible = false;
+
+        btnCancel.Visible = true;
+
+        // Total file count isn't known up front, so show activity, not a percentage.
+        actionProgress.Style =
+            ProgressBarStyle.Marquee;
+
+        actionProgress.Visible = true;
+        actionStatus.Text = string.Empty;
+    }
+
+    private void UpdateControlsOnActionDone(string statusMessage)
+    {
+        btnView.Enabled = true;
+        btnValidate.Enabled = true;
+
+        if (lstResults.Items.Count > 0)
         {
-            btnView.Enabled = false;
-            btnValidate.Enabled = false;
+            lblConvert.Enabled = true;
+            lstConvert.Enabled = true;
+            btnConvert.Enabled = true;
+            chkSelectDeselectAll.Enabled = true;
 
-            lblConvert.Enabled = false;
-            lstConvert.Enabled = false;
-            btnConvert.Enabled = false;
-            chkSelectDeselectAll.Enabled = false;
-            chkSelectDeselectAll.CheckState =
-                CheckState.Unchecked;
-            btnExportReport.Visible = false;
-
-            btnCancel.Visible = true;
-
-            // Total file count isn't known up front, so show activity, not a percentage.
-            actionProgress.Style =
-                ProgressBarStyle.Marquee;
-
-            actionProgress.Visible = true;
-            actionStatus.Text = string.Empty;
-        }
-
-        private void UpdateControlsOnActionDone(string statusMessage)
-        {
-            btnView.Enabled = true;
-            btnValidate.Enabled = true;
-
-            if (lstResults.Items.Count > 0)
+            if (_currentAction == CurrentAction.Validate &&
+                lstValidCharsets.CheckedItems.Count > 0)
             {
-                lblConvert.Enabled = true;
-                lstConvert.Enabled = true;
-                btnConvert.Enabled = true;
-                chkSelectDeselectAll.Enabled = true;
+                string firstValidCharset =
+                    (string)lstValidCharsets.CheckedItems[0]!;
 
-                if (_currentAction == CurrentAction.Validate &&
-                    lstValidCharsets.CheckedItems.Count > 0)
+                for (int i = 0;
+                     i < lstConvert.Items.Count;
+                     i++)
                 {
-                    string firstValidCharset =
-                        (string)lstValidCharsets.CheckedItems[0]!;
+                    string convertCharset =
+                        (string)lstConvert.Items[i]!;
 
-                    for (int i = 0;
-                         i < lstConvert.Items.Count;
-                         i++)
+                    if (firstValidCharset.Equals(
+                        convertCharset,
+                        StringComparison.OrdinalIgnoreCase))
                     {
-                        string convertCharset =
-                            (string)lstConvert.Items[i]!;
-
-                        if (firstValidCharset.Equals(
-                            convertCharset,
-                            StringComparison.OrdinalIgnoreCase))
-                        {
-                            lstConvert.SelectedIndex = i;
-                            break;
-                        }
+                        lstConvert.SelectedIndex = i;
+                        break;
                     }
                 }
             }
-
-            btnCancel.Visible = false;
-
-            actionProgress.Visible = false;
-            actionProgress.Style =
-                ProgressBarStyle.Continuous;
-            actionProgress.Value = 0;
-
-            actionStatus.Text = statusMessage;
         }
 
-        // Matches the encodings reported by UtfUnknown.Core.CodepageName. UTF-7 is
-        // deliberately excluded: .NET disabled it by default for security reasons (see
-        // SYSLIB0001 - UTF-7 content can be crafted to evade validation that assumes a
-        // different encoding), so Encoding.GetEncoding throws NotSupportedException for
-        // it. Omitting it here documents that instead of leaving it implicit.
-        private static readonly string[] SupportedCharsets =
-        [
-            "ascii", "utf-8", "utf-16le", "utf-16be",
-            "utf-32le", "utf-32be",
-            "euc-jp", "euc-kr", "euc-tw",
-            "iso-2022-cn", "iso-2022-kr", "iso-2022-jp",
-            "x-cp50227",
-            "big5", "gb18030", "hz-gb-2312", "shift-jis",
-            "ks_c_5601-1987", "cp949",
-            "ibm852", "ibm855", "ibm866",
-            "iso-8859-1", "iso-8859-2", "iso-8859-3",
-            "iso-8859-4", "iso-8859-5", "iso-8859-6",
-            "iso-8859-7", "iso-8859-8", "iso-8859-9",
-            "iso-8859-10", "iso-8859-11", "iso-8859-13",
-            "iso-8859-15", "iso-8859-16",
-            "windows-1250", "windows-1251", "windows-1252",
-            "windows-1253", "windows-1255", "windows-1256",
-            "windows-1257", "windows-1258",
-            "x-mac-ce", "x-mac-cyrillic",
-            "koi8-r", "tis-620", "viscii",
-            "X-ISO-10646-UCS-4-3412",
-            "X-ISO-10646-UCS-4-2143"
-        ];
+        btnCancel.Visible = false;
 
-        private static string[] GetSupportedCharsets() =>
-            SupportedCharsets;
+        actionProgress.Visible = false;
+        actionProgress.Style =
+            ProgressBarStyle.Continuous;
+        actionProgress.Value = 0;
 
-        private void ShowWarning(
-            string message,
-            params object[] args)
-        {
-            MessageBox.Show(
-                this,
-                string.Format(message, args),
-                @"Warning",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Warning);
-        }
-
+        actionStatus.Text = statusMessage;
     }
+
+    // Matches the encodings reported by UtfUnknown.Core.CodepageName. UTF-7 is
+    // deliberately excluded: .NET disabled it by default for security reasons (see
+    // SYSLIB0001 - UTF-7 content can be crafted to evade validation that assumes a
+    // different encoding), so Encoding.GetEncoding throws NotSupportedException for
+    // it. Omitting it here documents that instead of leaving it implicit.
+    private static readonly string[] SupportedCharsets =
+    [
+        "ascii", "utf-8", "utf-16le", "utf-16be",
+        "utf-32le", "utf-32be",
+        "euc-jp", "euc-kr", "euc-tw",
+        "iso-2022-cn", "iso-2022-kr", "iso-2022-jp",
+        "x-cp50227",
+        "big5", "gb18030", "hz-gb-2312", "shift-jis",
+        "ks_c_5601-1987", "cp949",
+        "ibm852", "ibm855", "ibm866",
+        "iso-8859-1", "iso-8859-2", "iso-8859-3",
+        "iso-8859-4", "iso-8859-5", "iso-8859-6",
+        "iso-8859-7", "iso-8859-8", "iso-8859-9",
+        "iso-8859-10", "iso-8859-11", "iso-8859-13",
+        "iso-8859-15", "iso-8859-16",
+        "windows-1250", "windows-1251", "windows-1252",
+        "windows-1253", "windows-1255", "windows-1256",
+        "windows-1257", "windows-1258",
+        "x-mac-ce", "x-mac-cyrillic",
+        "koi8-r", "tis-620", "viscii",
+        "X-ISO-10646-UCS-4-3412",
+        "X-ISO-10646-UCS-4-2143"
+    ];
+
+    private static string[] GetSupportedCharsets() =>
+        SupportedCharsets;
+
+    private void ShowWarning(
+        string message,
+        params object[] args)
+    {
+        MessageBox.Show(
+            this,
+            string.Format(message, args),
+            @"Warning",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Warning);
+    }
+
 }

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -790,6 +790,11 @@ namespace EncodingChecker
                 Debug.WriteLine(
                     $"Conversion failed for {entry.FilePath}: {entry.Diagnostic}");
             }
+            else if (entry.Result == ConversionRowResult.Skipped)
+            {
+                Debug.WriteLine(
+                    $"Conversion skipped for {entry.FilePath}: encoding could not be determined.");
+            }
             // Unchanged: already matched the target; nothing was written, row stays as-is.
         }
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -258,6 +258,9 @@ namespace EncodingChecker
                 IncludeSubdirectories = true,
                 IncludePatterns = options.Include,
                 ExcludePatterns = options.Exclude,
+                ExcludedFullPath = string.IsNullOrEmpty(options.ReportPath)
+                    ? null
+                    : Path.GetFullPath(options.ReportPath),
                 Action = action,
                 MaxParallelism =
                     options.MaxParallelism ??

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -580,6 +580,14 @@ namespace EncodingChecker
                 return false;
             }
 
+            if (DirectoryTraversal.IsReparsePointDirectory(options.BasePath))
+            {
+                error =
+                    $"'{options.BasePath}' is a symbolic link or other reparse point; " +
+                    "-BasePath must be a real directory.";
+                return false;
+            }
+
             if (options is
                 {
                     DetectOnly: true,

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -293,7 +293,8 @@ namespace EncodingChecker
                 ScanEngine.ScanDirectory(
                     scanOptions,
                     collectedEntries.Add,
-                    cancellation.Token);
+                    cancellation.Token,
+                    onWarning: Console.Error.WriteLine);
             }
             catch (OperationCanceledException)
             {

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -9,652 +9,651 @@ using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+internal static class Program
 {
-    internal static class Program
+    [STAThread]
+    private static int Main(string[] args)
     {
-        [STAThread]
-        private static int Main(string[] args)
+        // Enable legacy code pages used by the detector and converter.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+        if (args.Length > 0)
         {
-            // Enable legacy code pages used by the detector and converter.
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            bool attachedConsole = TryAttachToParentConsole();
 
-            if (args.Length > 0)
-            {
-                bool attachedConsole = TryAttachToParentConsole();
+            // Only an interactive console needs padding: the shell doesn't wait for a
+            // WinExe process, so its prompt is already drawn where we're about to write.
+            bool needsPromptPadding = attachedConsole && !Console.IsOutputRedirected;
 
-                // Only an interactive console needs padding: the shell doesn't wait for a
-                // WinExe process, so its prompt is already drawn where we're about to write.
-                bool needsPromptPadding = attachedConsole && !Console.IsOutputRedirected;
+            if (needsPromptPadding)
+                Console.Out.WriteLine();
 
-                if (needsPromptPadding)
-                    Console.Out.WriteLine();
+            int exitCode = RunConsoleMode(args);
 
-                int exitCode = RunConsoleMode(args);
+            if (needsPromptPadding)
+                Console.Out.WriteLine();
 
-                if (needsPromptPadding)
-                    Console.Out.WriteLine();
+            return exitCode;
+        }
 
-                return exitCode;
-            }
+        Application.ThreadException += OnApplicationThreadException;
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.Run(new MainForm());
+        return 0;
+    }
 
-            Application.ThreadException += OnApplicationThreadException;
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new MainForm());
+    private static void OnApplicationThreadException(object sender, ThreadExceptionEventArgs e)
+    {
+        MessageBox.Show(
+            e.Exception.Message,
+            @"Error",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Error);
+    }
+
+    #region Console attachment
+
+    private const int ATTACH_PARENT_PROCESS = -1;
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AttachConsole(int dwProcessId);
+
+    /// <summary>
+    /// Attaches to the parent console for CLI launches. Required because a WinExe
+    /// does not automatically acquire the newly attached console's standard streams.
+    /// </summary>
+    /// <returns><see langword="true"/> if a parent console was attached.</returns>
+    private static bool TryAttachToParentConsole()
+    {
+        if (!AttachConsole(ATTACH_PARENT_PROCESS))
+            return false;
+
+        var stdout = new StreamWriter(Console.OpenStandardOutput())
+        {
+            AutoFlush = true
+        };
+        Console.SetOut(stdout);
+
+        var stderr = new StreamWriter(Console.OpenStandardError())
+        {
+            AutoFlush = true
+        };
+        Console.SetError(stderr);
+
+        return true;
+    }
+
+    #endregion
+
+    #region Console mode
+
+    // internal (not private) so EncodingChecker.Tests can exercise argument parsing
+    // directly via InternalsVisibleTo, instead of only through process-level RunConsoleMode.
+    internal sealed class CliOptions
+    {
+        internal string? BasePath;
+        internal List<string> Include = [];
+        internal List<string> Exclude = [];
+        internal string? Target;
+        internal string? ValidateCharsets;
+        internal bool DetectOnly;
+        internal string? ReportPath;
+        internal int? MaxParallelism;
+        internal bool FailOnChanges;
+        internal bool WhatIf;
+        internal bool Backup;
+        internal bool Quiet;
+        internal bool Verbose;
+    }
+
+    private const string UsageText = """
+        EncodingChecker v3.0
+
+        Usage:
+
+          EncodingChecker.exe
+              -BasePath <directory>
+              [-Include "<pattern1,pattern2,...>"]
+              [-Exclude "<pattern1,pattern2,...>"]
+                   Wildcard patterns. A pattern with no "/" or "\"
+                   matches just the filename, at any depth. One
+                   containing a separator matches the path relative
+                   to -BasePath instead (e.g. "src/*.cs"); "/" and
+                   "\" behave the same way. Exclusions are applied
+                   after -Include. The following directories are always
+                   skipped: .git, .svn, .hg, .vs, .idea, bin, obj,
+                   node_modules, packages, dist, build, target.
+
+              Conversion:
+              [-Target "<encoding>"]
+                   The name of the encoding to convert files to, e.g.
+                   "utf-8" or "utf-8-bom". Required unless -Validate or
+                   -DetectOnly is given.
+
+              Modes:
+                   Conversion is the default mode.
+              [-Validate "<charset1,charset2,...>"]
+                   Validate without writing anything. Files whose current
+                   encoding isn't in this list are reported as Invalid.
+                   May be combined with -FailOnChanges. Cannot be
+                   combined with -DetectOnly.
+              [-DetectOnly]
+                   Read-only detection mode. Writes File;Encoding;BOM;
+                   Target;BOM;Result CSV rows to stdout (Target/Result
+                   always mirror the source, since nothing changes).
+                   Nothing is modified. -Target, -WhatIf, -Backup,
+                   -FailOnChanges, -Quiet, and -Verbose have no effect.
+                   Cannot be combined with -Validate.
+
+              Report:
+              [-Report <path>]
+                   Write a CSV report in addition to normal console
+                   output. Valid in every mode. Source/Encoding/BOM
+                   describe the original file; Target/BOM/Result
+                   describe the operation performed.
+
+              Performance:
+              [-MaxParallelism <N>]
+                   Maximum number of files processed concurrently.
+                   Default: min(logical processor count, 4).
+
+              Dry run / safety:
+              [-WhatIf]
+                   Convert mode only. Computes what each file's result
+                   would be without writing anything.
+              [-Backup]
+                   Convert mode only (ignored under -WhatIf). Before
+                   overwriting a file, copies the original to
+                   "<file>.bak" (overwriting any previous one).
+
+              Output:
+              [-Quiet]
+                   Suppress per-file CSV rows on stdout; print only a
+                   final summary line. -Report is unaffected.
+              [-Verbose]
+                   Print full error detail for Error rows and a result
+                   breakdown, in addition to the CSV rows.
+
+              CI / Exit Code:
+              [-FailOnChanges]
+                   Exit with a non-zero code when any file requires (or,
+                   under -Validate, fails) conversion. Useful as a CI
+                   gate, optionally with -WhatIf or -Validate.
+
+        Exit codes: 0 = clean; 1 = usage/argument error; 2 = -FailOnChanges
+        triggered; 3 = one or more files failed to process; 4 = cancelled
+        (Ctrl+C).
+
+        Examples:
+
+          EncodingChecker.exe -BasePath C:\Source -Include "*.cs,*.txt" -Target "utf-8"
+
+          EncodingChecker.exe -BasePath . -Include "*.cpp,*.hpp" -Target "utf-8" -WhatIf
+
+          EncodingChecker.exe -BasePath . -Include "*.cs" -Exclude "*.designer.cs,*.g.cs" -Target "utf-8-bom"
+
+          EncodingChecker.exe -BasePath . -Include "*" -DetectOnly -Report report.csv
+
+          EncodingChecker.exe -BasePath . -Include "*" -Validate "utf-8,utf-8-bom" -Report report.csv
+
+          EncodingChecker.exe -BasePath D:\NetworkShare -Include "*.txt" -Target "utf-8" -MaxParallelism 2 -FailOnChanges
+        """;
+
+    private static int RunConsoleMode(string[] args)
+    {
+        if (args.Length == 1 &&
+            args[0] is "/?" or "-?" or "/h" or "-h" or "--help")
+        {
+            Console.Out.WriteLine(UsageText);
             return 0;
         }
 
-        private static void OnApplicationThreadException(object sender, ThreadExceptionEventArgs e)
+        if (!TryParseArguments(args, out CliOptions options, out string? parseError))
         {
-            MessageBox.Show(
-                e.Exception.Message,
-                @"Error",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error);
+            Console.Error.WriteLine(parseError);
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(UsageText);
+            return 1;
         }
 
-        #region Console attachment
-
-        private const int ATTACH_PARENT_PROCESS = -1;
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool AttachConsole(int dwProcessId);
-
-        /// <summary>
-        /// Attaches to the parent console for CLI launches. Required because a WinExe
-        /// does not automatically acquire the newly attached console's standard streams.
-        /// </summary>
-        /// <returns><see langword="true"/> if a parent console was attached.</returns>
-        private static bool TryAttachToParentConsole()
+        if (!TryValidateOptions(options, out string? validationError))
         {
-            if (!AttachConsole(ATTACH_PARENT_PROCESS))
-                return false;
-
-            var stdout = new StreamWriter(Console.OpenStandardOutput())
-            {
-                AutoFlush = true
-            };
-            Console.SetOut(stdout);
-
-            var stderr = new StreamWriter(Console.OpenStandardError())
-            {
-                AutoFlush = true
-            };
-            Console.SetError(stderr);
-
-            return true;
+            Console.Error.WriteLine(validationError);
+            return 1;
         }
 
-        #endregion
+        ScanAction action = options.DetectOnly
+            ? ScanAction.Detect
+            : options.ValidateCharsets != null
+                ? ScanAction.Validate
+                : ScanAction.Convert;
 
-        #region Console mode
-
-        // internal (not private) so EncodingChecker.Tests can exercise argument parsing
-        // directly via InternalsVisibleTo, instead of only through process-level RunConsoleMode.
-        internal sealed class CliOptions
+        List<string>? validCharsets = null;
+        if (action == ScanAction.Validate)
         {
-            internal string? BasePath;
-            internal List<string> Include = [];
-            internal List<string> Exclude = [];
-            internal string? Target;
-            internal string? ValidateCharsets;
-            internal bool DetectOnly;
-            internal string? ReportPath;
-            internal int? MaxParallelism;
-            internal bool FailOnChanges;
-            internal bool WhatIf;
-            internal bool Backup;
-            internal bool Quiet;
-            internal bool Verbose;
+            validCharsets =
+            [
+                .. options.ValidateCharsets!
+                    .Split(
+                        ',',
+                        StringSplitOptions.RemoveEmptyEntries |
+                        StringSplitOptions.TrimEntries)
+            ];
         }
 
-        private const string UsageText = """
-            EncodingChecker v3.0
+        string? targetCharset = null;
+        bool targetWriteBom = false;
 
-            Usage:
-
-              EncodingChecker.exe
-                  -BasePath <directory>
-                  [-Include "<pattern1,pattern2,...>"]
-                  [-Exclude "<pattern1,pattern2,...>"]
-                       Wildcard patterns. A pattern with no "/" or "\"
-                       matches just the filename, at any depth. One
-                       containing a separator matches the path relative
-                       to -BasePath instead (e.g. "src/*.cs"); "/" and
-                       "\" behave the same way. Exclusions are applied
-                       after -Include. The following directories are always
-                       skipped: .git, .svn, .hg, .vs, .idea, bin, obj,
-                       node_modules, packages, dist, build, target.
-
-                  Conversion:
-                  [-Target "<encoding>"]
-                       The name of the encoding to convert files to, e.g.
-                       "utf-8" or "utf-8-bom". Required unless -Validate or
-                       -DetectOnly is given.
-
-                  Modes:
-                       Conversion is the default mode.
-                  [-Validate "<charset1,charset2,...>"]
-                       Validate without writing anything. Files whose current
-                       encoding isn't in this list are reported as Invalid.
-                       May be combined with -FailOnChanges. Cannot be
-                       combined with -DetectOnly.
-                  [-DetectOnly]
-                       Read-only detection mode. Writes File;Encoding;BOM;
-                       Target;BOM;Result CSV rows to stdout (Target/Result
-                       always mirror the source, since nothing changes).
-                       Nothing is modified. -Target, -WhatIf, -Backup,
-                       -FailOnChanges, -Quiet, and -Verbose have no effect.
-                       Cannot be combined with -Validate.
-
-                  Report:
-                  [-Report <path>]
-                       Write a CSV report in addition to normal console
-                       output. Valid in every mode. Source/Encoding/BOM
-                       describe the original file; Target/BOM/Result
-                       describe the operation performed.
-
-                  Performance:
-                  [-MaxParallelism <N>]
-                       Maximum number of files processed concurrently.
-                       Default: min(logical processor count, 4).
-
-                  Dry run / safety:
-                  [-WhatIf]
-                       Convert mode only. Computes what each file's result
-                       would be without writing anything.
-                  [-Backup]
-                       Convert mode only (ignored under -WhatIf). Before
-                       overwriting a file, copies the original to
-                       "<file>.bak" (overwriting any previous one).
-
-                  Output:
-                  [-Quiet]
-                       Suppress per-file CSV rows on stdout; print only a
-                       final summary line. -Report is unaffected.
-                  [-Verbose]
-                       Print full error detail for Error rows and a result
-                       breakdown, in addition to the CSV rows.
-
-                  CI / Exit Code:
-                  [-FailOnChanges]
-                       Exit with a non-zero code when any file requires (or,
-                       under -Validate, fails) conversion. Useful as a CI
-                       gate, optionally with -WhatIf or -Validate.
-
-            Exit codes: 0 = clean; 1 = usage/argument error; 2 = -FailOnChanges
-            triggered; 3 = one or more files failed to process; 4 = cancelled
-            (Ctrl+C).
-
-            Examples:
-
-              EncodingChecker.exe -BasePath C:\Source -Include "*.cs,*.txt" -Target "utf-8"
-
-              EncodingChecker.exe -BasePath . -Include "*.cpp,*.hpp" -Target "utf-8" -WhatIf
-
-              EncodingChecker.exe -BasePath . -Include "*.cs" -Exclude "*.designer.cs,*.g.cs" -Target "utf-8-bom"
-
-              EncodingChecker.exe -BasePath . -Include "*" -DetectOnly -Report report.csv
-
-              EncodingChecker.exe -BasePath . -Include "*" -Validate "utf-8,utf-8-bom" -Report report.csv
-
-              EncodingChecker.exe -BasePath D:\NetworkShare -Include "*.txt" -Target "utf-8" -MaxParallelism 2 -FailOnChanges
-            """;
-
-        private static int RunConsoleMode(string[] args)
+        if (action == ScanAction.Convert)
         {
-            if (args.Length == 1 &&
-                args[0] is "/?" or "-?" or "/h" or "-h" or "--help")
-            {
-                Console.Out.WriteLine(UsageText);
-                return 0;
-            }
+            ScanEngine.ParseCharsetLabel(
+                options.Target!,
+                out targetCharset,
+                out targetWriteBom);
+        }
 
-            if (!TryParseArguments(args, out CliOptions options, out string? parseError))
-            {
-                Console.Error.WriteLine(parseError);
-                Console.Error.WriteLine();
-                Console.Error.WriteLine(UsageText);
-                return 1;
-            }
+        var scanOptions = new ScanDirectoryOptions
+        {
+            BaseDirectory = options.BasePath!,
+            IncludeSubdirectories = true,
+            IncludePatterns = options.Include,
+            ExcludePatterns = options.Exclude,
+            ExcludedFullPath = string.IsNullOrEmpty(options.ReportPath)
+                ? null
+                : Path.GetFullPath(options.ReportPath),
+            Action = action,
+            MaxParallelism =
+                options.MaxParallelism ??
+                ScanEngine.DefaultMaxParallelism,
+            ValidCharsets = validCharsets,
+            TargetCharset = targetCharset,
+            TargetWriteBom = targetWriteBom,
+            WhatIf = options.WhatIf,
+            Backup = options.Backup,
+        };
 
-            if (!TryValidateOptions(options, out string? validationError))
-            {
-                Console.Error.WriteLine(validationError);
-                return 1;
-            }
+        // onEntry fires concurrently, so collect into a ConcurrentBag, then sort by
+        // path once scanning finishes for deterministic downstream output.
+        var collectedEntries = new ConcurrentBag<ConversionReportEntry>();
 
-            ScanAction action = options.DetectOnly
-                ? ScanAction.Detect
-                : options.ValidateCharsets != null
-                    ? ScanAction.Validate
-                    : ScanAction.Convert;
+        using var cancellation = new CancellationTokenSource();
 
-            List<string>? validCharsets = null;
-            if (action == ScanAction.Validate)
-            {
-                validCharsets =
-                [
-                    .. options.ValidateCharsets!
-                        .Split(
-                            ',',
-                            StringSplitOptions.RemoveEmptyEntries |
-                            StringSplitOptions.TrimEntries)
-                ];
-            }
+        ConsoleCancelEventHandler cancelHandler = (_, e) =>
+        {
+            // Let the scan observe cancellation and unwind cleanly instead of the
+            // process being torn down mid-write.
+            e.Cancel = true;
+            cancellation.Cancel();
+        };
 
-            string? targetCharset = null;
-            bool targetWriteBom = false;
+        Console.CancelKeyPress += cancelHandler;
 
-            if (action == ScanAction.Convert)
-            {
-                ScanEngine.ParseCharsetLabel(
-                    options.Target!,
-                    out targetCharset,
-                    out targetWriteBom);
-            }
+        try
+        {
+            ScanEngine.ScanDirectory(
+                scanOptions,
+                collectedEntries.Add,
+                cancellation.Token,
+                onWarning: Console.Error.WriteLine);
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Error.WriteLine("Scan cancelled.");
+            return 4;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine($"Scan failed: {ex.Message}");
+            return 1;
+        }
+        finally
+        {
+            Console.CancelKeyPress -= cancelHandler;
+        }
 
-            var scanOptions = new ScanDirectoryOptions
-            {
-                BaseDirectory = options.BasePath!,
-                IncludeSubdirectories = true,
-                IncludePatterns = options.Include,
-                ExcludePatterns = options.Exclude,
-                ExcludedFullPath = string.IsNullOrEmpty(options.ReportPath)
-                    ? null
-                    : Path.GetFullPath(options.ReportPath),
-                Action = action,
-                MaxParallelism =
-                    options.MaxParallelism ??
-                    ScanEngine.DefaultMaxParallelism,
-                ValidCharsets = validCharsets,
-                TargetCharset = targetCharset,
-                TargetWriteBom = targetWriteBom,
-                WhatIf = options.WhatIf,
-                Backup = options.Backup,
-            };
+        List<ConversionReportEntry> entries =
+        [
+            .. collectedEntries.OrderBy(
+                e => e.FilePath,
+                StringComparer.OrdinalIgnoreCase)
+        ];
 
-            // onEntry fires concurrently, so collect into a ConcurrentBag, then sort by
-            // path once scanning finishes for deterministic downstream output.
-            var collectedEntries = new ConcurrentBag<ConversionReportEntry>();
+        if (options.Quiet)
+        {
+            Console.Out.WriteLine($"{entries.Count} file(s) processed.");
+        }
+        else
+        {
+            ConversionReport.WriteCsv(entries, Console.Out);
+        }
 
-            using var cancellation = new CancellationTokenSource();
+        if (options.Verbose)
+            PrintVerboseSummary(entries);
 
-            ConsoleCancelEventHandler cancelHandler = (_, e) =>
-            {
-                // Let the scan observe cancellation and unwind cleanly instead of the
-                // process being torn down mid-write.
-                e.Cancel = true;
-                cancellation.Cancel();
-            };
-
-            Console.CancelKeyPress += cancelHandler;
-
+        if (!string.IsNullOrEmpty(options.ReportPath))
+        {
             try
             {
-                ScanEngine.ScanDirectory(
-                    scanOptions,
-                    collectedEntries.Add,
-                    cancellation.Token,
-                    onWarning: Console.Error.WriteLine);
-            }
-            catch (OperationCanceledException)
-            {
-                Console.Error.WriteLine("Scan cancelled.");
-                return 4;
+                using var writer = new StreamWriter(options.ReportPath);
+                ConversionReport.WriteCsv(entries, writer);
             }
             catch (Exception ex) when (
                 ex is IOException or UnauthorizedAccessException)
             {
-                Console.Error.WriteLine($"Scan failed: {ex.Message}");
+                Console.Error.WriteLine(
+                    $"Failed to write report file: {ex.Message}");
                 return 1;
             }
-            finally
-            {
-                Console.CancelKeyPress -= cancelHandler;
-            }
-
-            List<ConversionReportEntry> entries =
-            [
-                .. collectedEntries.OrderBy(
-                    e => e.FilePath,
-                    StringComparer.OrdinalIgnoreCase)
-            ];
-
-            if (options.Quiet)
-            {
-                Console.Out.WriteLine($"{entries.Count} file(s) processed.");
-            }
-            else
-            {
-                ConversionReport.WriteCsv(entries, Console.Out);
-            }
-
-            if (options.Verbose)
-                PrintVerboseSummary(entries);
-
-            if (!string.IsNullOrEmpty(options.ReportPath))
-            {
-                try
-                {
-                    using var writer = new StreamWriter(options.ReportPath);
-                    ConversionReport.WriteCsv(entries, writer);
-                }
-                catch (Exception ex) when (
-                    ex is IOException or UnauthorizedAccessException)
-                {
-                    Console.Error.WriteLine(
-                        $"Failed to write report file: {ex.Message}");
-                    return 1;
-                }
-            }
-
-            if (entries.Any(e => e.Result == ConversionRowResult.Error))
-                return 3;
-
-            if (options is { FailOnChanges: true, DetectOnly: false })
-            {
-                bool changesFound = action == ScanAction.Validate
-                    ? entries.Any(e => e.Result == ConversionRowResult.Invalid)
-                    : entries.Any(e => e.Result == ConversionRowResult.Converted);
-
-                if (changesFound)
-                    return 2;
-            }
-
-            return 0;
         }
 
-        private static void PrintVerboseSummary(
-            List<ConversionReportEntry> entries)
+        if (entries.Any(e => e.Result == ConversionRowResult.Error))
+            return 3;
+
+        if (options is { FailOnChanges: true, DetectOnly: false })
         {
-            foreach (ConversionReportEntry entry in entries)
-            {
-                if (entry.Result == ConversionRowResult.Error &&
-                    !string.IsNullOrEmpty(entry.Diagnostic))
-                {
-                    Console.Error.WriteLine(
-                        $"Error: {entry.FilePath}: {entry.Diagnostic}");
-                }
-            }
+            bool changesFound = action == ScanAction.Validate
+                ? entries.Any(e => e.Result == ConversionRowResult.Invalid)
+                : entries.Any(e => e.Result == ConversionRowResult.Converted);
 
-            var byResult =
-                entries
-                    .GroupBy(e => e.Result)
-                    .ToDictionary(g => g.Key, g => g.Count());
-
-            Console.Out.WriteLine();
-            Console.Out.WriteLine(
-                $"Total: {entries.Count}  " +
-                $"Unchanged: {byResult.GetValueOrDefault(ConversionRowResult.Unchanged)}  " +
-                $"Skipped: {byResult.GetValueOrDefault(ConversionRowResult.Skipped)}  " +
-                $"Converted: {byResult.GetValueOrDefault(ConversionRowResult.Converted)}  " +
-                $"Invalid: {byResult.GetValueOrDefault(ConversionRowResult.Invalid)}  " +
-                $"Error: {byResult.GetValueOrDefault(ConversionRowResult.Error)}");
+            if (changesFound)
+                return 2;
         }
 
-        // internal so EncodingChecker.Tests can cover parsing directly (see CliOptions).
-        internal static bool TryParseArguments(
-            string[] args,
-            out CliOptions options,
-            [NotNullWhen(false)] out string? error)
+        return 0;
+    }
+
+    private static void PrintVerboseSummary(
+        List<ConversionReportEntry> entries)
+    {
+        foreach (ConversionReportEntry entry in entries)
         {
-            options = new CliOptions();
-            error = null;
-
-            for (int i = 0; i < args.Length; i++)
+            if (entry.Result == ConversionRowResult.Error &&
+                !string.IsNullOrEmpty(entry.Diagnostic))
             {
-                string flag = args[i].TrimStart('-');
+                Console.Error.WriteLine(
+                    $"Error: {entry.FilePath}: {entry.Diagnostic}");
+            }
+        }
 
-                switch (flag.ToLowerInvariant())
-                {
-                    case "basepath":
-                        if (!TryTakeValue(
-                                args,
-                                ref i,
-                                out options.BasePath))
-                        {
-                            error = "-BasePath requires a value.";
-                            return false;
-                        }
-                        break;
+        var byResult =
+            entries
+                .GroupBy(e => e.Result)
+                .ToDictionary(g => g.Key, g => g.Count());
 
-                    case "include":
-                        if (!TryTakeValue(
-                                args,
-                                ref i,
-                                out string? include))
-                        {
-                            error = "-Include requires a value.";
-                            return false;
-                        }
-                        options.Include = SplitCommaList(include);
-                        break;
+        Console.Out.WriteLine();
+        Console.Out.WriteLine(
+            $"Total: {entries.Count}  " +
+            $"Unchanged: {byResult.GetValueOrDefault(ConversionRowResult.Unchanged)}  " +
+            $"Skipped: {byResult.GetValueOrDefault(ConversionRowResult.Skipped)}  " +
+            $"Converted: {byResult.GetValueOrDefault(ConversionRowResult.Converted)}  " +
+            $"Invalid: {byResult.GetValueOrDefault(ConversionRowResult.Invalid)}  " +
+            $"Error: {byResult.GetValueOrDefault(ConversionRowResult.Error)}");
+    }
 
-                    case "exclude":
-                        if (!TryTakeValue(
-                                args,
-                                ref i,
-                                out string? exclude))
-                        {
-                            error = "-Exclude requires a value.";
-                            return false;
-                        }
-                        options.Exclude = SplitCommaList(exclude);
-                        break;
+    // internal so EncodingChecker.Tests can cover parsing directly (see CliOptions).
+    internal static bool TryParseArguments(
+        string[] args,
+        out CliOptions options,
+        [NotNullWhen(false)] out string? error)
+    {
+        options = new CliOptions();
+        error = null;
 
-                    case "target":
-                        if (!TryTakeValue(
-                                args,
-                                ref i,
-                                out options.Target))
-                        {
-                            error = "-Target requires a value.";
-                            return false;
-                        }
-                        break;
+        for (int i = 0; i < args.Length; i++)
+        {
+            string flag = args[i].TrimStart('-');
 
-                    case "validate":
-                        if (!TryTakeValue(
-                                args,
-                                ref i,
-                                out options.ValidateCharsets))
-                        {
-                            error = "-Validate requires a value.";
-                            return false;
-                        }
-                        break;
-
-                    case "detectonly":
-                        options.DetectOnly = true;
-                        break;
-
-                    case "report":
-                        if (!TryTakeValue(
-                                args,
-                                ref i,
-                                out options.ReportPath))
-                        {
-                            error = "-Report requires a value.";
-                            return false;
-                        }
-                        break;
-
-                    case "maxparallelism":
-                        if (!TryTakeValue(
-                                args,
-                                ref i,
-                                out string? maxParallelismText) ||
-                            !int.TryParse(
-                                maxParallelismText,
-                                out int maxParallelism) ||
-                            maxParallelism <= 0)
-                        {
-                            error =
-                                "-MaxParallelism requires a positive integer.";
-                            return false;
-                        }
-
-                        options.MaxParallelism = maxParallelism;
-                        break;
-
-                    case "failonchanges":
-                        options.FailOnChanges = true;
-                        break;
-
-                    case "whatif":
-                        options.WhatIf = true;
-                        break;
-
-                    case "backup":
-                        options.Backup = true;
-                        break;
-
-                    case "quiet":
-                        options.Quiet = true;
-                        break;
-
-                    case "verbose":
-                        options.Verbose = true;
-                        break;
-
-                    default:
-                        error = $"Unrecognized argument: {args[i]}";
+            switch (flag.ToLowerInvariant())
+            {
+                case "basepath":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out options.BasePath))
+                    {
+                        error = "-BasePath requires a value.";
                         return false;
-                }
-            }
+                    }
+                    break;
 
-            return true;
+                case "include":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out string? include))
+                    {
+                        error = "-Include requires a value.";
+                        return false;
+                    }
+                    options.Include = SplitCommaList(include);
+                    break;
+
+                case "exclude":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out string? exclude))
+                    {
+                        error = "-Exclude requires a value.";
+                        return false;
+                    }
+                    options.Exclude = SplitCommaList(exclude);
+                    break;
+
+                case "target":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out options.Target))
+                    {
+                        error = "-Target requires a value.";
+                        return false;
+                    }
+                    break;
+
+                case "validate":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out options.ValidateCharsets))
+                    {
+                        error = "-Validate requires a value.";
+                        return false;
+                    }
+                    break;
+
+                case "detectonly":
+                    options.DetectOnly = true;
+                    break;
+
+                case "report":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out options.ReportPath))
+                    {
+                        error = "-Report requires a value.";
+                        return false;
+                    }
+                    break;
+
+                case "maxparallelism":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out string? maxParallelismText) ||
+                        !int.TryParse(
+                            maxParallelismText,
+                            out int maxParallelism) ||
+                        maxParallelism <= 0)
+                    {
+                        error =
+                            "-MaxParallelism requires a positive integer.";
+                        return false;
+                    }
+
+                    options.MaxParallelism = maxParallelism;
+                    break;
+
+                case "failonchanges":
+                    options.FailOnChanges = true;
+                    break;
+
+                case "whatif":
+                    options.WhatIf = true;
+                    break;
+
+                case "backup":
+                    options.Backup = true;
+                    break;
+
+                case "quiet":
+                    options.Quiet = true;
+                    break;
+
+                case "verbose":
+                    options.Verbose = true;
+                    break;
+
+                default:
+                    error = $"Unrecognized argument: {args[i]}";
+                    return false;
+            }
         }
 
-        // Lets TryTakeValue detect "-BasePath -Include" as a missing value, not a path.
-        private static readonly HashSet<string> KnownFlagNames =
-            new(StringComparer.OrdinalIgnoreCase)
+        return true;
+    }
+
+    // Lets TryTakeValue detect "-BasePath -Include" as a missing value, not a path.
+    private static readonly HashSet<string> KnownFlagNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "basepath", "include", "exclude", "target", "validate",
+            "detectonly", "report", "maxparallelism", "failonchanges",
+            "whatif", "backup", "quiet", "verbose",
+        };
+
+    // internal so EncodingChecker.Tests can cover parsing directly (see CliOptions).
+    internal static bool TryTakeValue(
+        string[] args,
+        ref int i,
+        [NotNullWhen(true)] out string? value)
+    {
+        if (i + 1 >= args.Length)
+        {
+            value = null;
+            return false;
+        }
+
+        string candidate = args[i + 1];
+
+        if (candidate.StartsWith('-') &&
+            KnownFlagNames.Contains(candidate.TrimStart('-')))
+        {
+            value = null;
+            return false;
+        }
+
+        value = args[++i];
+        return true;
+    }
+
+    private static List<string> SplitCommaList(string value) =>
+    [
+        .. value.Split(
+            ',',
+            StringSplitOptions.RemoveEmptyEntries |
+            StringSplitOptions.TrimEntries)
+    ];
+
+    // internal so EncodingChecker.Tests can cover validation directly (see CliOptions).
+    internal static bool TryValidateOptions(
+        CliOptions options,
+        [NotNullWhen(false)] out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(options.BasePath))
+        {
+            error = "-BasePath is required.";
+            return false;
+        }
+
+        if (!Directory.Exists(options.BasePath))
+        {
+            error =
+                $"The directory '{options.BasePath}' does not exist.";
+            return false;
+        }
+
+        if (DirectoryTraversal.IsReparsePointDirectory(options.BasePath))
+        {
+            error =
+                $"'{options.BasePath}' is a symbolic link or other reparse point; " +
+                "-BasePath must be a real directory.";
+            return false;
+        }
+
+        if (options is
             {
-                "basepath", "include", "exclude", "target", "validate",
-                "detectonly", "report", "maxparallelism", "failonchanges",
-                "whatif", "backup", "quiet", "verbose",
+                DetectOnly: true,
+                ValidateCharsets: not null
+            })
+        {
+            error =
+                "-DetectOnly cannot be combined with -Validate.";
+            return false;
+        }
+
+        if (options.ValidateCharsets is not null &&
+            SplitCommaList(options.ValidateCharsets).Count == 0)
+        {
+            error = "-Validate requires at least one charset.";
+            return false;
+        }
+
+        bool isConvertMode =
+            options is
+            {
+                DetectOnly: false,
+                ValidateCharsets: null
             };
 
-        // internal so EncodingChecker.Tests can cover parsing directly (see CliOptions).
-        internal static bool TryTakeValue(
-            string[] args,
-            ref int i,
-            [NotNullWhen(true)] out string? value)
+        if (isConvertMode &&
+            string.IsNullOrWhiteSpace(options.Target))
         {
-            if (i + 1 >= args.Length)
-            {
-                value = null;
-                return false;
-            }
-
-            string candidate = args[i + 1];
-
-            if (candidate.StartsWith('-') &&
-                KnownFlagNames.Contains(candidate.TrimStart('-')))
-            {
-                value = null;
-                return false;
-            }
-
-            value = args[++i];
-            return true;
+            error =
+                "-Target is required (Convert is the default mode; " +
+                "use -Validate or -DetectOnly for read-only modes).";
+            return false;
         }
 
-        private static List<string> SplitCommaList(string value) =>
-        [
-            .. value.Split(
-                ',',
-                StringSplitOptions.RemoveEmptyEntries |
-                StringSplitOptions.TrimEntries)
-        ];
-
-        // internal so EncodingChecker.Tests can cover validation directly (see CliOptions).
-        internal static bool TryValidateOptions(
-            CliOptions options,
-            [NotNullWhen(false)] out string? error)
+        if (isConvertMode &&
+            !string.IsNullOrWhiteSpace(options.Target))
         {
-            if (string.IsNullOrWhiteSpace(options.BasePath))
-            {
-                error = "-BasePath is required.";
-                return false;
-            }
+            ScanEngine.ParseCharsetLabel(
+                options.Target!,
+                out string baseCharset,
+                out _);
 
-            if (!Directory.Exists(options.BasePath))
+            try
             {
-                error =
-                    $"The directory '{options.BasePath}' does not exist.";
-                return false;
+                Encoding.GetEncoding(baseCharset);
             }
-
-            if (DirectoryTraversal.IsReparsePointDirectory(options.BasePath))
+            catch (ArgumentException)
             {
                 error =
-                    $"'{options.BasePath}' is a symbolic link or other reparse point; " +
-                    "-BasePath must be a real directory.";
+                    $"'{options.Target}' is not a recognized encoding.";
                 return false;
             }
-
-            if (options is
-                {
-                    DetectOnly: true,
-                    ValidateCharsets: not null
-                })
-            {
-                error =
-                    "-DetectOnly cannot be combined with -Validate.";
-                return false;
-            }
-
-            if (options.ValidateCharsets is not null &&
-                SplitCommaList(options.ValidateCharsets).Count == 0)
-            {
-                error = "-Validate requires at least one charset.";
-                return false;
-            }
-
-            bool isConvertMode =
-                options is
-                {
-                    DetectOnly: false,
-                    ValidateCharsets: null
-                };
-
-            if (isConvertMode &&
-                string.IsNullOrWhiteSpace(options.Target))
-            {
-                error =
-                    "-Target is required (Convert is the default mode; " +
-                    "use -Validate or -DetectOnly for read-only modes).";
-                return false;
-            }
-
-            if (isConvertMode &&
-                !string.IsNullOrWhiteSpace(options.Target))
-            {
-                ScanEngine.ParseCharsetLabel(
-                    options.Target!,
-                    out string baseCharset,
-                    out _);
-
-                try
-                {
-                    Encoding.GetEncoding(baseCharset);
-                }
-                catch (ArgumentException)
-                {
-                    error =
-                        $"'{options.Target}' is not a recognized encoding.";
-                    return false;
-                }
-            }
-
-            error = null;
-            return true;
         }
 
-        #endregion
+        error = null;
+        return true;
     }
+
+    #endregion
 }

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -119,7 +119,11 @@ namespace EncodingChecker
                   -BasePath <directory>
                   [-Include "<pattern1,pattern2,...>"]
                   [-Exclude "<pattern1,pattern2,...>"]
-                       Wildcard file-name patterns. Exclusions are applied
+                       Wildcard patterns. A pattern with no "/" or "\"
+                       matches just the filename, at any depth. One
+                       containing a separator matches the path relative
+                       to -BasePath instead (e.g. "src/*.cs"); "/" and
+                       "\" behave the same way. Exclusions are applied
                        after -Include. The following directories are always
                        skipped: .git, .svn, .hg, .vs, .idea, bin, obj,
                        node_modules, packages, dist, build, target.

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -385,6 +385,7 @@ namespace EncodingChecker
             Console.Out.WriteLine(
                 $"Total: {entries.Count}  " +
                 $"Unchanged: {byResult.GetValueOrDefault(ConversionRowResult.Unchanged)}  " +
+                $"Skipped: {byResult.GetValueOrDefault(ConversionRowResult.Skipped)}  " +
                 $"Converted: {byResult.GetValueOrDefault(ConversionRowResult.Converted)}  " +
                 $"Invalid: {byResult.GetValueOrDefault(ConversionRowResult.Invalid)}  " +
                 $"Error: {byResult.GetValueOrDefault(ConversionRowResult.Error)}");

--- a/sources/EncodingChecker/Properties/PublishProfiles/SelfContainedRelease.pubxml
+++ b/sources/EncodingChecker/Properties/PublishProfiles/SelfContainedRelease.pubxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net10.0-windows\publish\win-x64-selfcontained\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+</Project>

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -46,9 +46,8 @@ internal sealed class ScanDirectoryOptions
     internal IReadOnlyList<string>? ExcludePatterns { get; init; }
 
     /// <summary>
-    /// Full path of a file to exclude regardless of patterns, e.g. an in-progress
-    /// -Report output that would otherwise get rescanned as ordinary input on a
-    /// later run with a broad -Include.
+    /// Full path of a file to exclude regardless of pattern matches - e.g. an
+    /// in-progress -Report output, so it isn't rescanned as input on a later run.
     /// </summary>
     internal string? ExcludedFullPath { get; init; }
 
@@ -413,9 +412,8 @@ internal static class ScanEngine
     }
 
     /// <summary>
-    /// Writes "<paramref name="path"/>.bak" via a temp-file-then-atomic-replace
-    /// sequence, so a crash mid-write can't leave a truncated/corrupt backup - the
-    /// same crash-safety as the main conversion write, instead of a plain File.Copy.
+    /// Writes "<paramref name="path"/>.bak" via temp-file-then-atomic-replace, so a
+    /// crash mid-write can't leave a truncated backup (unlike a plain File.Copy).
     /// </summary>
     private static void CreateBackup(string path)
     {

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -72,41 +72,6 @@ namespace EncodingChecker
         internal static readonly int DefaultMaxParallelism =
             Math.Min(Environment.ProcessorCount, 4);
 
-        // Never descend into these directories.
-        private static readonly HashSet<string> ExcludedDirectoryNames =
-            new(StringComparer.OrdinalIgnoreCase)
-            {
-                ".git",
-                ".svn",
-                ".hg",
-                ".vs",
-                ".idea",
-                "bin",
-                "obj",
-                "node_modules",
-                "packages",
-                "dist",
-                "build",
-                "target"
-            };
-
-        private static readonly EnumerationOptions DirectoryWalkOptions = new()
-        {
-            // Do not traverse symlinks or junctions.
-            AttributesToSkip = FileAttributes.ReparsePoint,
-        };
-
-        /// <summary>
-        /// Always excluded, regardless of -Include/-Exclude: the tool's own backup and
-        /// temporary-file artifacts. Without this, a broad include pattern (e.g. "*")
-        /// combined with -Backup re-scans previous runs' ".bak" files as ordinary input,
-        /// which cascades (.bak, .bak.bak, ...) and can race against another file's
-        /// concurrent backup write to the same path.
-        /// </summary>
-        private static bool IsAlwaysExcludedFile(string fileName) =>
-            fileName.EndsWith(".bak", StringComparison.OrdinalIgnoreCase) ||
-            fileName.EndsWith("." + EncodingConverter.TEMP_FILE_SUFFIX, StringComparison.OrdinalIgnoreCase);
-
         #region Public API
 
         /// <summary>
@@ -131,12 +96,12 @@ namespace EncodingChecker
             Encoding? targetEncoding = ValidateOptions(options);
 
             List<Regex> includePatterns =
-                CompilePatterns(options.IncludePatterns, defaultToMatchAll: true);
+                DirectoryTraversal.CompilePatterns(options.IncludePatterns, defaultToMatchAll: true);
 
             List<Regex> excludePatterns =
-                CompilePatterns(options.ExcludePatterns, defaultToMatchAll: false);
+                DirectoryTraversal.CompilePatterns(options.ExcludePatterns, defaultToMatchAll: false);
 
-            IEnumerable<string> files = EnumerateFiles(
+            IEnumerable<string> files = DirectoryTraversal.EnumerateFiles(
                 options.BaseDirectory,
                 options.IncludeSubdirectories,
                 includePatterns,
@@ -420,139 +385,6 @@ namespace EncodingChecker
             if (!result.Success)
                 entry.Diagnostic =
                     $"{result.ErrorCode}: {result.ErrorMessage}";
-        }
-
-        #endregion
-
-
-        #region Directory Walking
-
-        /// <summary>
-        /// Enumerates matching files while skipping excluded directories and reparse points.
-        /// Inaccessible directories are skipped.
-        /// </summary>
-        private static IEnumerable<string> EnumerateFiles(
-            string baseDirectory,
-            bool includeSubdirectories,
-            List<Regex> includePatterns,
-            List<Regex> excludePatterns)
-        {
-            var pending = new Stack<string>();
-            pending.Push(baseDirectory);
-
-            while (pending.Count > 0)
-            {
-                string dir = pending.Pop();
-
-                List<string> files;
-
-                try
-                {
-                    // Force enumeration here so access errors stay inside the try block.
-                    files =
-                    [
-                        .. Directory.EnumerateFiles(
-                            dir,
-                            "*",
-                            DirectoryWalkOptions)
-                    ];
-                }
-                catch (Exception ex) when (
-                    ex is IOException or UnauthorizedAccessException)
-                {
-                    continue;
-                }
-
-                foreach (string file in files)
-                {
-                    string fileName = Path.GetFileName(file);
-
-                    if (IsAlwaysExcludedFile(fileName))
-                        continue;
-
-                    if (MatchesAny(fileName, includePatterns) &&
-                        !MatchesAny(fileName, excludePatterns))
-                    {
-                        yield return file;
-                    }
-                }
-
-                if (!includeSubdirectories)
-                    continue;
-
-                List<string> subdirectories;
-
-                try
-                {
-                    subdirectories =
-                    [
-                        .. Directory.EnumerateDirectories(
-                            dir,
-                            "*",
-                            DirectoryWalkOptions)
-                    ];
-                }
-                catch (Exception ex) when (
-                    ex is IOException or UnauthorizedAccessException)
-                {
-                    continue;
-                }
-
-                foreach (string subdirectory in subdirectories)
-                {
-                    if (!ExcludedDirectoryNames.Contains(
-                        Path.GetFileName(subdirectory)))
-                    {
-                        pending.Push(subdirectory);
-                    }
-                }
-            }
-        }
-
-        private static bool MatchesAny(
-            string fileName,
-            List<Regex> patterns)
-        {
-            foreach (Regex pattern in patterns)
-            {
-                if (pattern.IsMatch(fileName))
-                    return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Converts wildcard masks to case-insensitive regexes.
-        /// </summary>
-        private static List<Regex> CompilePatterns(
-            IReadOnlyList<string>? patterns,
-            bool defaultToMatchAll)
-        {
-            var effectivePatterns = (patterns ?? [])
-                .Select(p => p.Trim())
-                .Where(p => p.Length > 0)
-                .ToList();
-
-            if (effectivePatterns.Count == 0)
-            {
-                if (!defaultToMatchAll)
-                    return [];
-
-                effectivePatterns.Add("*");
-            }
-
-            return
-            [
-                .. effectivePatterns.Select(mask =>
-                    new Regex(
-                        "^" +
-                        Regex.Escape(mask)
-                            .Replace(@"\*", ".*")
-                            .Replace(@"\?", ".") +
-                        "$",
-                        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
-            ];
         }
 
         #endregion

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -131,6 +131,14 @@ namespace EncodingChecker
                     nameof(options));
             }
 
+            if (DirectoryTraversal.IsReparsePointDirectory(options.BaseDirectory))
+            {
+                throw new ArgumentException(
+                    $"Base directory '{options.BaseDirectory}' is a symbolic link or " +
+                    "other reparse point.",
+                    nameof(options));
+            }
+
             if (options.MaxParallelism < 1)
             {
                 throw new ArgumentOutOfRangeException(

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -366,10 +366,7 @@ namespace EncodingChecker
             {
                 try
                 {
-                    File.Copy(
-                        path,
-                        path + ".bak",
-                        overwrite: true);
+                    CreateBackup(path);
                 }
                 catch (Exception ex) when (
                     ex is IOException or UnauthorizedAccessException)
@@ -401,6 +398,63 @@ namespace EncodingChecker
             if (!result.Success)
                 entry.Diagnostic =
                     $"{result.ErrorCode}: {result.ErrorMessage}";
+        }
+
+        /// <summary>
+        /// Writes "<paramref name="path"/>.bak" via a temp-file-then-atomic-replace
+        /// sequence, so a crash mid-write can't leave a truncated/corrupt backup - the
+        /// same crash-safety as the main conversion write, instead of a plain File.Copy.
+        /// </summary>
+        private static void CreateBackup(string path)
+        {
+            string? directory = Path.GetDirectoryName(path);
+
+            if (string.IsNullOrEmpty(directory))
+            {
+                throw new IOException(
+                    $"Could not determine a directory for path '{path}'.");
+            }
+
+            string tempPath = Path.Combine(
+                directory,
+                $"{Path.GetFileName(path)}.{Guid.NewGuid():N}.bak.tmp");
+
+            try
+            {
+                using (FileStream source = new(
+                           path,
+                           FileMode.Open,
+                           FileAccess.Read,
+                           FileShare.Read,
+                           EncodingConverter.DEFAULT_BUFFER_SIZE,
+                           FileOptions.SequentialScan))
+                using (FileStream destination = new(
+                           tempPath,
+                           FileMode.CreateNew,
+                           FileAccess.Write,
+                           FileShare.None,
+                           EncodingConverter.DEFAULT_BUFFER_SIZE,
+                           FileOptions.SequentialScan))
+                {
+                    source.CopyTo(destination, EncodingConverter.DEFAULT_BUFFER_SIZE);
+                    destination.Flush(flushToDisk: true);
+                }
+
+                EncodingConverter.AtomicReplaceForBackup(tempPath, path + ".bak");
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(tempPath))
+                        File.Delete(tempPath);
+                }
+                catch (Exception ex) when (
+                    ex is IOException or UnauthorizedAccessException)
+                {
+                    // Cleanup failure does not affect the backup result.
+                }
+            }
         }
 
         #endregion

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -7,526 +7,525 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+/// <summary>
+/// Action performed for each scanned file.
+/// </summary>
+internal enum ScanAction
 {
     /// <summary>
-    /// Action performed for each scanned file.
+    /// Detect and report only.
     /// </summary>
-    internal enum ScanAction
+    Detect,
+
+    /// <summary>
+    /// Detect and validate against <see cref="ScanDirectoryOptions.ValidCharsets"/>.
+    /// </summary>
+    Validate,
+
+    /// <summary>
+    /// Detect and convert when required.
+    /// </summary>
+    Convert,
+}
+
+/// <summary>
+/// Options for <see cref="ScanEngine.ScanDirectory"/>.
+/// </summary>
+internal sealed class ScanDirectoryOptions
+{
+    internal required string BaseDirectory { get; init; }
+
+    internal bool IncludeSubdirectories { get; init; } = true;
+
+    /// <summary>Include masks; empty means "*".</summary>
+    internal IReadOnlyList<string>? IncludePatterns { get; init; }
+
+    /// <summary>Exclude masks applied after include masks.</summary>
+    internal IReadOnlyList<string>? ExcludePatterns { get; init; }
+
+    /// <summary>
+    /// Full path of a file to exclude regardless of patterns, e.g. an in-progress
+    /// -Report output that would otherwise get rescanned as ordinary input on a
+    /// later run with a broad -Include.
+    /// </summary>
+    internal string? ExcludedFullPath { get; init; }
+
+    internal ScanAction Action { get; init; }
+
+    /// <summary>Accepted charset labels for validation.</summary>
+    internal IReadOnlyCollection<string>? ValidCharsets { get; init; }
+
+    /// <summary>Target charset for conversion, without "-bom".</summary>
+    internal string? TargetCharset { get; init; }
+
+    internal bool TargetWriteBom { get; init; }
+
+    /// <summary>Simulate conversion without writing.</summary>
+    internal bool WhatIf { get; init; }
+
+    /// <summary>Back up the original file before conversion.</summary>
+    internal bool Backup { get; init; }
+
+    internal int MaxParallelism { get; init; } = ScanEngine.DefaultMaxParallelism;
+}
+
+/// <summary>
+/// Shared file-scanning and conversion pipeline for the GUI and CLI.
+/// </summary>
+internal static class ScanEngine
+{
+    internal static readonly int DefaultMaxParallelism =
+        Math.Min(Environment.ProcessorCount, 4);
+
+    #region Public API
+
+    /// <summary>
+    /// Scans the base directory and processes matching files with bounded parallelism.
+    /// Skips excluded directories, reparse points, the tool's own backup/temp files,
+    /// and likely binary files.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="onEntry"/> is invoked concurrently from worker threads; callers
+    /// must marshal to the UI thread themselves rather than touch UI controls directly.
+    /// </remarks>
+    internal static void ScanDirectory(
+        ScanDirectoryOptions options,
+        Action<ConversionReportEntry> onEntry,
+        CancellationToken cancellationToken,
+        Action<string>? onWarning = null)
     {
-        /// <summary>
-        /// Detect and report only.
-        /// </summary>
-        Detect,
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(onEntry);
 
-        /// <summary>
-        /// Detect and validate against <see cref="ScanDirectoryOptions.ValidCharsets"/>.
-        /// </summary>
-        Validate,
+        // Resolved once and reused per file; also makes an invalid target fail the
+        // whole scan immediately, including under -WhatIf.
+        Encoding? targetEncoding = ValidateOptions(options);
 
-        /// <summary>
-        /// Detect and convert when required.
-        /// </summary>
-        Convert,
+        List<Regex> includePatterns =
+            DirectoryTraversal.CompilePatterns(options.IncludePatterns, defaultToMatchAll: true);
+
+        List<Regex> excludePatterns =
+            DirectoryTraversal.CompilePatterns(options.ExcludePatterns, defaultToMatchAll: false);
+
+        IEnumerable<string> files = DirectoryTraversal.EnumerateFiles(
+            options.BaseDirectory,
+            options.IncludeSubdirectories,
+            includePatterns,
+            excludePatterns,
+            options.ExcludedFullPath,
+            onWarning);
+
+        RunParallel(
+            files,
+            options.MaxParallelism,
+            getPath: path => path,
+            processItem: path => ProcessFileForScan(path, options, targetEncoding),
+            onEntry: onEntry,
+            cancellationToken);
     }
 
     /// <summary>
-    /// Options for <see cref="ScanEngine.ScanDirectory"/>.
+    /// Validates options up front, independent of caller-side validation. Returns the
+    /// resolved target <see cref="Encoding"/> for <see cref="ScanAction.Convert"/>, or
+    /// <see langword="null"/> otherwise.
     /// </summary>
-    internal sealed class ScanDirectoryOptions
+    private static Encoding? ValidateOptions(ScanDirectoryOptions options)
     {
-        internal required string BaseDirectory { get; init; }
-
-        internal bool IncludeSubdirectories { get; init; } = true;
-
-        /// <summary>Include masks; empty means "*".</summary>
-        internal IReadOnlyList<string>? IncludePatterns { get; init; }
-
-        /// <summary>Exclude masks applied after include masks.</summary>
-        internal IReadOnlyList<string>? ExcludePatterns { get; init; }
-
-        /// <summary>
-        /// Full path of a file to exclude regardless of patterns, e.g. an in-progress
-        /// -Report output that would otherwise get rescanned as ordinary input on a
-        /// later run with a broad -Include.
-        /// </summary>
-        internal string? ExcludedFullPath { get; init; }
-
-        internal ScanAction Action { get; init; }
-
-        /// <summary>Accepted charset labels for validation.</summary>
-        internal IReadOnlyCollection<string>? ValidCharsets { get; init; }
-
-        /// <summary>Target charset for conversion, without "-bom".</summary>
-        internal string? TargetCharset { get; init; }
-
-        internal bool TargetWriteBom { get; init; }
-
-        /// <summary>Simulate conversion without writing.</summary>
-        internal bool WhatIf { get; init; }
-
-        /// <summary>Back up the original file before conversion.</summary>
-        internal bool Backup { get; init; }
-
-        internal int MaxParallelism { get; init; } = ScanEngine.DefaultMaxParallelism;
-    }
-
-    /// <summary>
-    /// Shared file-scanning and conversion pipeline for the GUI and CLI.
-    /// </summary>
-    internal static class ScanEngine
-    {
-        internal static readonly int DefaultMaxParallelism =
-            Math.Min(Environment.ProcessorCount, 4);
-
-        #region Public API
-
-        /// <summary>
-        /// Scans the base directory and processes matching files with bounded parallelism.
-        /// Skips excluded directories, reparse points, the tool's own backup/temp files,
-        /// and likely binary files.
-        /// </summary>
-        /// <remarks>
-        /// <paramref name="onEntry"/> is invoked concurrently from worker threads; callers
-        /// must marshal to the UI thread themselves rather than touch UI controls directly.
-        /// </remarks>
-        internal static void ScanDirectory(
-            ScanDirectoryOptions options,
-            Action<ConversionReportEntry> onEntry,
-            CancellationToken cancellationToken,
-            Action<string>? onWarning = null)
+        if (string.IsNullOrWhiteSpace(options.BaseDirectory) ||
+            !Directory.Exists(options.BaseDirectory))
         {
-            ArgumentNullException.ThrowIfNull(options);
-            ArgumentNullException.ThrowIfNull(onEntry);
+            throw new ArgumentException(
+                $"Base directory '{options.BaseDirectory}' does not exist.",
+                nameof(options));
+        }
 
-            // Resolved once and reused per file; also makes an invalid target fail the
-            // whole scan immediately, including under -WhatIf.
-            Encoding? targetEncoding = ValidateOptions(options);
+        if (DirectoryTraversal.IsReparsePointDirectory(options.BaseDirectory))
+        {
+            throw new ArgumentException(
+                $"Base directory '{options.BaseDirectory}' is a symbolic link or " +
+                "other reparse point.",
+                nameof(options));
+        }
 
-            List<Regex> includePatterns =
-                DirectoryTraversal.CompilePatterns(options.IncludePatterns, defaultToMatchAll: true);
-
-            List<Regex> excludePatterns =
-                DirectoryTraversal.CompilePatterns(options.ExcludePatterns, defaultToMatchAll: false);
-
-            IEnumerable<string> files = DirectoryTraversal.EnumerateFiles(
-                options.BaseDirectory,
-                options.IncludeSubdirectories,
-                includePatterns,
-                excludePatterns,
-                options.ExcludedFullPath,
-                onWarning);
-
-            RunParallel(
-                files,
+        if (options.MaxParallelism < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
                 options.MaxParallelism,
-                getPath: path => path,
-                processItem: path => ProcessFileForScan(path, options, targetEncoding),
-                onEntry: onEntry,
-                cancellationToken);
+                "MaxParallelism must be at least 1.");
         }
 
-        /// <summary>
-        /// Validates options up front, independent of caller-side validation. Returns the
-        /// resolved target <see cref="Encoding"/> for <see cref="ScanAction.Convert"/>, or
-        /// <see langword="null"/> otherwise.
-        /// </summary>
-        private static Encoding? ValidateOptions(ScanDirectoryOptions options)
+        switch (options.Action)
         {
-            if (string.IsNullOrWhiteSpace(options.BaseDirectory) ||
-                !Directory.Exists(options.BaseDirectory))
-            {
-                throw new ArgumentException(
-                    $"Base directory '{options.BaseDirectory}' does not exist.",
-                    nameof(options));
-            }
-
-            if (DirectoryTraversal.IsReparsePointDirectory(options.BaseDirectory))
-            {
-                throw new ArgumentException(
-                    $"Base directory '{options.BaseDirectory}' is a symbolic link or " +
-                    "other reparse point.",
-                    nameof(options));
-            }
-
-            if (options.MaxParallelism < 1)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(options),
-                    options.MaxParallelism,
-                    "MaxParallelism must be at least 1.");
-            }
-
-            switch (options.Action)
-            {
-                case ScanAction.Convert:
-                    if (string.IsNullOrWhiteSpace(options.TargetCharset))
-                    {
-                        throw new ArgumentException(
-                            "TargetCharset is required for Convert.",
-                            nameof(options));
-                    }
-
-                    return Encoding.GetEncoding(options.TargetCharset);
-
-                case ScanAction.Validate:
-                    if (options.ValidCharsets is null ||
-                        options.ValidCharsets.Count == 0)
-                    {
-                        throw new ArgumentException(
-                            "ValidCharsets is required for Validate.",
-                            nameof(options));
-                    }
-
-                    break;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Converts previously detected entries with bounded parallelism.
-        /// </summary>
-        /// <remarks>Same concurrent-<paramref name="onEntry"/> contract as <see cref="ScanDirectory"/>.</remarks>
-        internal static void ConvertFiles(
-            IEnumerable<ConversionReportEntry> entries,
-            string targetCharset,
-            bool targetWriteBom,
-            int maxParallelism,
-            Action<ConversionReportEntry> onEntry,
-            CancellationToken cancellationToken)
-        {
-            ArgumentNullException.ThrowIfNull(entries);
-            ArgumentNullException.ThrowIfNull(onEntry);
-
-            // Resolved once instead of per file, matching ScanDirectory.
-            Encoding targetEncoding = Encoding.GetEncoding(targetCharset);
-
-            RunParallel(
-                entries,
-                maxParallelism,
-                getPath: entry => entry.FilePath,
-                processItem: entry =>
+            case ScanAction.Convert:
+                if (string.IsNullOrWhiteSpace(options.TargetCharset))
                 {
-                    if (entry.SourceEncoding == "(Unknown)")
-                    {
-                        entry.Result = ConversionRowResult.Skipped;
-                        return entry;
-                    }
+                    throw new ArgumentException(
+                        "TargetCharset is required for Convert.",
+                        nameof(options));
+                }
 
-                    Encoding sourceEncoding;
+                return Encoding.GetEncoding(options.TargetCharset);
 
-                    try
-                    {
-                        sourceEncoding = Encoding.GetEncoding(entry.SourceEncoding);
-                    }
-                    catch (ArgumentException)
-                    {
-                        entry.Result = ConversionRowResult.Error;
-                        return entry;
-                    }
+            case ScanAction.Validate:
+                if (options.ValidCharsets is null ||
+                    options.ValidCharsets.Count == 0)
+                {
+                    throw new ArgumentException(
+                        "ValidCharsets is required for Validate.",
+                        nameof(options));
+                }
 
-                    ApplyConversion(
-                        entry,
-                        entry.FilePath,
-                        sourceEncoding,
-                        targetCharset,
-                        targetEncoding,
-                        targetWriteBom,
-                        whatIf: false,
-                        backup: false);
+                break;
+        }
 
+        return null;
+    }
+
+    /// <summary>
+    /// Converts previously detected entries with bounded parallelism.
+    /// </summary>
+    /// <remarks>Same concurrent-<paramref name="onEntry"/> contract as <see cref="ScanDirectory"/>.</remarks>
+    internal static void ConvertFiles(
+        IEnumerable<ConversionReportEntry> entries,
+        string targetCharset,
+        bool targetWriteBom,
+        int maxParallelism,
+        Action<ConversionReportEntry> onEntry,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(onEntry);
+
+        // Resolved once instead of per file, matching ScanDirectory.
+        Encoding targetEncoding = Encoding.GetEncoding(targetCharset);
+
+        RunParallel(
+            entries,
+            maxParallelism,
+            getPath: entry => entry.FilePath,
+            processItem: entry =>
+            {
+                if (entry.SourceEncoding == "(Unknown)")
+                {
+                    entry.Result = ConversionRowResult.Skipped;
                     return entry;
-                },
-                onEntry: onEntry,
-                cancellationToken: cancellationToken);
-        }
+                }
 
-        /// <summary>
-        /// Splits a charset label into its base name and BOM flag.
-        /// </summary>
-        internal static void ParseCharsetLabel(
-            string label,
-            out string baseCharset,
-            out bool hasBom)
-        {
-            hasBom = label.EndsWith("-bom", StringComparison.OrdinalIgnoreCase);
-            baseCharset = hasBom ? label[..^4] : label;
-        }
+                Encoding sourceEncoding;
 
-        internal static string FormatCharsetLabel(
-            string baseCharset,
-            bool hasBom) =>
-            hasBom ? baseCharset + "-bom" : baseCharset;
-
-        #endregion
-
-
-        #region Per-File Processing
-
-        private static ConversionReportEntry? ProcessFileForScan(
-            string path,
-            ScanDirectoryOptions options,
-            Encoding? targetEncoding)
-        {
-            Encoding? detected = TextEncoding.DetectFromFile(path);
-
-            bool hasBom =
-                detected != null &&
-                detected.GetPreamble().Length > 0;
-
-            string sourceCharset =
-                detected?.WebName ?? "(Unknown)";
-
-            var entry = new ConversionReportEntry
-            {
-                FilePath = path,
-                SourceEncoding = sourceCharset,
-                SourceHasBom = hasBom,
-                TargetEncoding = sourceCharset,
-                TargetHasBom = hasBom,
-                Result = ConversionRowResult.Unchanged,
-            };
-
-            switch (options.Action)
-            {
-                case ScanAction.Detect:
-                    if (sourceCharset == "(Unknown)")
-                        entry.Result = ConversionRowResult.Skipped;
-
-                    break;
-
-                case ScanAction.Validate:
-                    string label =
-                        FormatCharsetLabel(sourceCharset, hasBom);
-
-                    bool isValid =
-                        sourceCharset != "(Unknown)" &&
-                        options.ValidCharsets is not null &&
-                        options.ValidCharsets.Contains(
-                            label,
-                            StringComparer.OrdinalIgnoreCase);
-
-                    entry.Result =
-                        isValid
-                            ? ConversionRowResult.Unchanged
-                            : ConversionRowResult.Invalid;
-
-                    break;
-
-                case ScanAction.Convert:
-                    if (detected != null)
-                    {
-                        // Guaranteed present for Convert by ValidateOptions.
-                        ApplyConversion(
-                            entry,
-                            path,
-                            detected,
-                            options.TargetCharset!,
-                            targetEncoding!,
-                            options.TargetWriteBom,
-                            options.WhatIf,
-                            options.Backup);
-                    }
-                    else
-                    {
-                        entry.Result = ConversionRowResult.Skipped;
-                    }
-
-                    break;
-            }
-
-            return entry;
-        }
-
-        /// <summary>
-        /// Converts when the source does not already match the target.
-        /// </summary>
-        private static void ApplyConversion(
-            ConversionReportEntry entry,
-            string path,
-            Encoding sourceEncoding,
-            string targetCharset,
-            Encoding targetEncoding,
-            bool targetWriteBom,
-            bool whatIf,
-            bool backup)
-        {
-            entry.TargetEncoding = targetCharset;
-            entry.TargetHasBom = targetWriteBom;
-
-            bool alreadyMatches =
-                string.Equals(
-                    entry.SourceEncoding,
-                    targetCharset,
-                    StringComparison.OrdinalIgnoreCase) &&
-                entry.SourceHasBom == targetWriteBom;
-
-            if (alreadyMatches)
-            {
-                entry.Result = ConversionRowResult.Unchanged;
-                return;
-            }
-
-            if (whatIf)
-            {
-                entry.Result = ConversionRowResult.Converted; // "would be converted"
-                return;
-            }
-
-            if (backup)
-            {
                 try
                 {
-                    CreateBackup(path);
+                    sourceEncoding = Encoding.GetEncoding(entry.SourceEncoding);
                 }
-                catch (Exception ex) when (
-                    ex is IOException or UnauthorizedAccessException)
+                catch (ArgumentException)
                 {
                     entry.Result = ConversionRowResult.Error;
-                    entry.Diagnostic = $"Backup failed: {ex.Message}";
-                    return;
+                    return entry;
                 }
-            }
 
-            var conversionOptions = new ConversionOptions
-            {
-                WriteBom = targetWriteBom,
-            };
-
-            ConversionResult result =
-                EncodingConverter.Convert(
-                    path,
-                    path,
+                ApplyConversion(
+                    entry,
+                    entry.FilePath,
                     sourceEncoding,
+                    targetCharset,
                     targetEncoding,
-                    conversionOptions);
+                    targetWriteBom,
+                    whatIf: false,
+                    backup: false);
 
-            entry.Result =
-                result.Success
-                    ? ConversionRowResult.Converted
-                    : ConversionRowResult.Error;
+                return entry;
+            },
+            onEntry: onEntry,
+            cancellationToken: cancellationToken);
+    }
 
-            if (!result.Success)
-                entry.Diagnostic =
-                    $"{result.ErrorCode}: {result.ErrorMessage}";
+    /// <summary>
+    /// Splits a charset label into its base name and BOM flag.
+    /// </summary>
+    internal static void ParseCharsetLabel(
+        string label,
+        out string baseCharset,
+        out bool hasBom)
+    {
+        hasBom = label.EndsWith("-bom", StringComparison.OrdinalIgnoreCase);
+        baseCharset = hasBom ? label[..^4] : label;
+    }
+
+    internal static string FormatCharsetLabel(
+        string baseCharset,
+        bool hasBom) =>
+        hasBom ? baseCharset + "-bom" : baseCharset;
+
+    #endregion
+
+
+    #region Per-File Processing
+
+    private static ConversionReportEntry? ProcessFileForScan(
+        string path,
+        ScanDirectoryOptions options,
+        Encoding? targetEncoding)
+    {
+        Encoding? detected = TextEncoding.DetectFromFile(path);
+
+        bool hasBom =
+            detected != null &&
+            detected.GetPreamble().Length > 0;
+
+        string sourceCharset =
+            detected?.WebName ?? "(Unknown)";
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = sourceCharset,
+            SourceHasBom = hasBom,
+            TargetEncoding = sourceCharset,
+            TargetHasBom = hasBom,
+            Result = ConversionRowResult.Unchanged,
+        };
+
+        switch (options.Action)
+        {
+            case ScanAction.Detect:
+                if (sourceCharset == "(Unknown)")
+                    entry.Result = ConversionRowResult.Skipped;
+
+                break;
+
+            case ScanAction.Validate:
+                string label =
+                    FormatCharsetLabel(sourceCharset, hasBom);
+
+                bool isValid =
+                    sourceCharset != "(Unknown)" &&
+                    options.ValidCharsets is not null &&
+                    options.ValidCharsets.Contains(
+                        label,
+                        StringComparer.OrdinalIgnoreCase);
+
+                entry.Result =
+                    isValid
+                        ? ConversionRowResult.Unchanged
+                        : ConversionRowResult.Invalid;
+
+                break;
+
+            case ScanAction.Convert:
+                if (detected != null)
+                {
+                    // Guaranteed present for Convert by ValidateOptions.
+                    ApplyConversion(
+                        entry,
+                        path,
+                        detected,
+                        options.TargetCharset!,
+                        targetEncoding!,
+                        options.TargetWriteBom,
+                        options.WhatIf,
+                        options.Backup);
+                }
+                else
+                {
+                    entry.Result = ConversionRowResult.Skipped;
+                }
+
+                break;
         }
 
-        /// <summary>
-        /// Writes "<paramref name="path"/>.bak" via a temp-file-then-atomic-replace
-        /// sequence, so a crash mid-write can't leave a truncated/corrupt backup - the
-        /// same crash-safety as the main conversion write, instead of a plain File.Copy.
-        /// </summary>
-        private static void CreateBackup(string path)
+        return entry;
+    }
+
+    /// <summary>
+    /// Converts when the source does not already match the target.
+    /// </summary>
+    private static void ApplyConversion(
+        ConversionReportEntry entry,
+        string path,
+        Encoding sourceEncoding,
+        string targetCharset,
+        Encoding targetEncoding,
+        bool targetWriteBom,
+        bool whatIf,
+        bool backup)
+    {
+        entry.TargetEncoding = targetCharset;
+        entry.TargetHasBom = targetWriteBom;
+
+        bool alreadyMatches =
+            string.Equals(
+                entry.SourceEncoding,
+                targetCharset,
+                StringComparison.OrdinalIgnoreCase) &&
+            entry.SourceHasBom == targetWriteBom;
+
+        if (alreadyMatches)
         {
-            string? directory = Path.GetDirectoryName(path);
+            entry.Result = ConversionRowResult.Unchanged;
+            return;
+        }
 
-            if (string.IsNullOrEmpty(directory))
-            {
-                throw new IOException(
-                    $"Could not determine a directory for path '{path}'.");
-            }
+        if (whatIf)
+        {
+            entry.Result = ConversionRowResult.Converted; // "would be converted"
+            return;
+        }
 
-            string tempPath = Path.Combine(
-                directory,
-                $"{Path.GetFileName(path)}.{Guid.NewGuid():N}.bak.tmp");
-
+        if (backup)
+        {
             try
             {
-                using (FileStream source = new(
-                           path,
-                           FileMode.Open,
-                           FileAccess.Read,
-                           FileShare.Read,
-                           EncodingConverter.DEFAULT_BUFFER_SIZE,
-                           FileOptions.SequentialScan))
-                using (FileStream destination = new(
-                           tempPath,
-                           FileMode.CreateNew,
-                           FileAccess.Write,
-                           FileShare.None,
-                           EncodingConverter.DEFAULT_BUFFER_SIZE,
-                           FileOptions.SequentialScan))
-                {
-                    source.CopyTo(destination, EncodingConverter.DEFAULT_BUFFER_SIZE);
-                    destination.Flush(flushToDisk: true);
-                }
-
-                EncodingConverter.AtomicReplaceForBackup(tempPath, path + ".bak");
+                CreateBackup(path);
             }
-            finally
+            catch (Exception ex) when (
+                ex is IOException or UnauthorizedAccessException)
             {
+                entry.Result = ConversionRowResult.Error;
+                entry.Diagnostic = $"Backup failed: {ex.Message}";
+                return;
+            }
+        }
+
+        var conversionOptions = new ConversionOptions
+        {
+            WriteBom = targetWriteBom,
+        };
+
+        ConversionResult result =
+            EncodingConverter.Convert(
+                path,
+                path,
+                sourceEncoding,
+                targetEncoding,
+                conversionOptions);
+
+        entry.Result =
+            result.Success
+                ? ConversionRowResult.Converted
+                : ConversionRowResult.Error;
+
+        if (!result.Success)
+            entry.Diagnostic =
+                $"{result.ErrorCode}: {result.ErrorMessage}";
+    }
+
+    /// <summary>
+    /// Writes "<paramref name="path"/>.bak" via a temp-file-then-atomic-replace
+    /// sequence, so a crash mid-write can't leave a truncated/corrupt backup - the
+    /// same crash-safety as the main conversion write, instead of a plain File.Copy.
+    /// </summary>
+    private static void CreateBackup(string path)
+    {
+        string? directory = Path.GetDirectoryName(path);
+
+        if (string.IsNullOrEmpty(directory))
+        {
+            throw new IOException(
+                $"Could not determine a directory for path '{path}'.");
+        }
+
+        string tempPath = Path.Combine(
+            directory,
+            $"{Path.GetFileName(path)}.{Guid.NewGuid():N}.bak.tmp");
+
+        try
+        {
+            using (FileStream source = new(
+                       path,
+                       FileMode.Open,
+                       FileAccess.Read,
+                       FileShare.Read,
+                       EncodingConverter.DEFAULT_BUFFER_SIZE,
+                       FileOptions.SequentialScan))
+            using (FileStream destination = new(
+                       tempPath,
+                       FileMode.CreateNew,
+                       FileAccess.Write,
+                       FileShare.None,
+                       EncodingConverter.DEFAULT_BUFFER_SIZE,
+                       FileOptions.SequentialScan))
+            {
+                source.CopyTo(destination, EncodingConverter.DEFAULT_BUFFER_SIZE);
+                destination.Flush(flushToDisk: true);
+            }
+
+            EncodingConverter.AtomicReplaceForBackup(tempPath, path + ".bak");
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+            catch (Exception ex) when (
+                ex is IOException or UnauthorizedAccessException)
+            {
+                // Cleanup failure does not affect the backup result.
+            }
+        }
+    }
+
+    #endregion
+
+
+    #region Bounded Parallel Execution
+
+    /// <summary>
+    /// Processes items with bounded parallelism and isolates per-file errors.
+    /// Cancellation propagates normally.
+    /// </summary>
+    private static void RunParallel<T>(
+        IEnumerable<T> items,
+        int maxParallelism,
+        Func<T, string> getPath,
+        Func<T, ConversionReportEntry?> processItem,
+        Action<ConversionReportEntry> onEntry,
+        CancellationToken cancellationToken)
+    {
+        var parallelOptions = new ParallelOptions
+        {
+            MaxDegreeOfParallelism =
+                Math.Max(1, maxParallelism),
+
+            CancellationToken =
+                cancellationToken,
+        };
+
+        Parallel.ForEach(
+            items,
+            parallelOptions,
+            item =>
+            {
+                ConversionReportEntry? entry;
+
                 try
                 {
-                    if (File.Exists(tempPath))
-                        File.Delete(tempPath);
+                    entry = processItem(item);
                 }
                 catch (Exception ex) when (
-                    ex is IOException or UnauthorizedAccessException)
+                    ex is IOException or
+                    UnauthorizedAccessException or
+                    ArgumentException or
+                    NotSupportedException)
                 {
-                    // Cleanup failure does not affect the backup result.
+                    entry = new ConversionReportEntry
+                    {
+                        FilePath = getPath(item),
+                        SourceEncoding = "(Error)",
+                        TargetEncoding = "(Error)",
+                        Result = ConversionRowResult.Error,
+                        Diagnostic = ex.Message,
+                    };
                 }
-            }
-        }
 
-        #endregion
-
-
-        #region Bounded Parallel Execution
-
-        /// <summary>
-        /// Processes items with bounded parallelism and isolates per-file errors.
-        /// Cancellation propagates normally.
-        /// </summary>
-        private static void RunParallel<T>(
-            IEnumerable<T> items,
-            int maxParallelism,
-            Func<T, string> getPath,
-            Func<T, ConversionReportEntry?> processItem,
-            Action<ConversionReportEntry> onEntry,
-            CancellationToken cancellationToken)
-        {
-            var parallelOptions = new ParallelOptions
-            {
-                MaxDegreeOfParallelism =
-                    Math.Max(1, maxParallelism),
-
-                CancellationToken =
-                    cancellationToken,
-            };
-
-            Parallel.ForEach(
-                items,
-                parallelOptions,
-                item =>
-                {
-                    ConversionReportEntry? entry;
-
-                    try
-                    {
-                        entry = processItem(item);
-                    }
-                    catch (Exception ex) when (
-                        ex is IOException or
-                        UnauthorizedAccessException or
-                        ArgumentException or
-                        NotSupportedException)
-                    {
-                        entry = new ConversionReportEntry
-                        {
-                            FilePath = getPath(item),
-                            SourceEncoding = "(Error)",
-                            TargetEncoding = "(Error)",
-                            Result = ConversionRowResult.Error,
-                            Diagnostic = ex.Message,
-                        };
-                    }
-
-                    if (entry is not null)
-                        onEntry(entry);
-                });
-        }
-
-        #endregion
+                if (entry is not null)
+                    onEntry(entry);
+            });
     }
+
+    #endregion
 }

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -209,7 +209,10 @@ namespace EncodingChecker
                 processItem: entry =>
                 {
                     if (entry.SourceEncoding == "(Unknown)")
+                    {
+                        entry.Result = ConversionRowResult.Skipped;
                         return entry;
+                    }
 
                     Encoding sourceEncoding;
 
@@ -288,6 +291,9 @@ namespace EncodingChecker
             switch (options.Action)
             {
                 case ScanAction.Detect:
+                    if (sourceCharset == "(Unknown)")
+                        entry.Result = ConversionRowResult.Skipped;
+
                     break;
 
                 case ScanAction.Validate:
@@ -321,6 +327,10 @@ namespace EncodingChecker
                             options.TargetWriteBom,
                             options.WhatIf,
                             options.Backup);
+                    }
+                    else
+                    {
+                        entry.Result = ConversionRowResult.Skipped;
                     }
 
                     break;

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -93,7 +93,8 @@ namespace EncodingChecker
         internal static void ScanDirectory(
             ScanDirectoryOptions options,
             Action<ConversionReportEntry> onEntry,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            Action<string>? onWarning = null)
         {
             ArgumentNullException.ThrowIfNull(options);
             ArgumentNullException.ThrowIfNull(onEntry);
@@ -113,7 +114,8 @@ namespace EncodingChecker
                 options.IncludeSubdirectories,
                 includePatterns,
                 excludePatterns,
-                options.ExcludedFullPath);
+                options.ExcludedFullPath,
+                onWarning);
 
             RunParallel(
                 files,

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -45,6 +45,13 @@ namespace EncodingChecker
         /// <summary>Exclude masks applied after include masks.</summary>
         internal IReadOnlyList<string>? ExcludePatterns { get; init; }
 
+        /// <summary>
+        /// Full path of a file to exclude regardless of patterns, e.g. an in-progress
+        /// -Report output that would otherwise get rescanned as ordinary input on a
+        /// later run with a broad -Include.
+        /// </summary>
+        internal string? ExcludedFullPath { get; init; }
+
         internal ScanAction Action { get; init; }
 
         /// <summary>Accepted charset labels for validation.</summary>
@@ -105,7 +112,8 @@ namespace EncodingChecker
                 options.BaseDirectory,
                 options.IncludeSubdirectories,
                 includePatterns,
-                excludePatterns);
+                excludePatterns,
+                options.ExcludedFullPath);
 
             RunParallel(
                 files,

--- a/sources/EncodingChecker/Settings.cs
+++ b/sources/EncodingChecker/Settings.cs
@@ -2,48 +2,47 @@
 using System.Collections.Generic;
 using System.Windows.Forms;
 
-namespace EncodingChecker
+namespace EncodingChecker;
+
+public sealed class Settings
 {
-    public sealed class Settings
+    public WindowPosition WindowPosition = new();
+
+    public List<string> RecentDirectories = [];
+    public bool IncludeSubdirectories = true;
+
+    public string FileMasks = string.Empty;
+    public string[] ValidCharsets = [];
+
+    /// <summary>
+    /// Adds a directory to the front of the most-recently-used list, removing any existing
+    /// occurrence and trimming the list to the 10 most recent entries.
+    /// </summary>
+    public void AddRecentDirectory(string directory)
     {
-        public WindowPosition WindowPosition = new();
-
-        public List<string> RecentDirectories = [];
-        public bool IncludeSubdirectories = true;
-
-        public string FileMasks = string.Empty;
-        public string[] ValidCharsets = [];
-
-        /// <summary>
-        /// Adds a directory to the front of the most-recently-used list, removing any existing
-        /// occurrence and trimming the list to the 10 most recent entries.
-        /// </summary>
-        public void AddRecentDirectory(string directory)
+        for (int i = RecentDirectories.Count - 1; i >= 0; i--)
         {
-            for (int i = RecentDirectories.Count - 1; i >= 0; i--)
-            {
-                if (RecentDirectories[i].Equals(directory, StringComparison.OrdinalIgnoreCase))
-                    RecentDirectories.RemoveAt(i);
-            }
-
-            RecentDirectories.Insert(0, directory);
-
-            if (RecentDirectories.Count > 10)
-                RecentDirectories.RemoveRange(10, RecentDirectories.Count - 10);
+            if (RecentDirectories[i].Equals(directory, StringComparison.OrdinalIgnoreCase))
+                RecentDirectories.RemoveAt(i);
         }
+
+        RecentDirectories.Insert(0, directory);
+
+        if (RecentDirectories.Count > 10)
+            RecentDirectories.RemoveRange(10, RecentDirectories.Count - 10);
     }
+}
 
-    public sealed class WindowPosition
+public sealed class WindowPosition
+{
+    public int Left = -1;
+    public int Top = -1;
+    public int Width = -1;
+    public int Height = -1;
+
+    public void ApplyTo(Form form)
     {
-        public int Left = -1;
-        public int Top = -1;
-        public int Width = -1;
-        public int Height = -1;
-
-        public void ApplyTo(Form form)
-        {
-            if (Left >= 0 && Top >= 0 && Width > 0 && Height > 0)
-                form.SetBounds(Left, Top, Width, Height);
-        }
+        if (Left >= 0 && Top >= 0 && Width > 0 && Height > 0)
+            form.SetBounds(Left, Top, Width, Height);
     }
 }


### PR DESCRIPTION
## Summary

Hardens EncodingChecker's directory traversal, backup safety, and CLI robustness, porting proven patterns from the sibling LineEndingNormalizer project (and vice versa where LEN was behind), then closes out lower-priority cleanup and packaging work.

**Traversal & safety (P0)**
- Extract `DirectoryTraversal.cs` as a shared, dedicated traversal/pattern-matching module.
- Reject a reparse-point (symlink/junction) `-BasePath` up front instead of silently scanning through it.
- Exclude the `-Report` output path from being rescanned as ordinary input on a later run, even with a broad `-Include "*"`.
- Make backup (`.bak`) writes atomic/crash-safe via temp-file-then-replace, matching the main conversion write.
- Re-check reparse-point status immediately before replacing the destination (defense-in-depth, not a full TOCTOU guarantee).
- Warn (instead of silently skipping) when a directory can't be listed, and report a distinct `Skipped` result for files whose encoding can't be detected.
- Wire Ctrl+C cancellation through the CLI entry point and the scan/convert pipeline.

**CLI robustness (P1)**
- Detect a value-taking flag (e.g. `-BasePath`) being handed another known flag as its value, instead of silently consuming it.
- Support `-?`, `-h`, `/?`, `/h`, `--help` as a sole argument.
- Path-aware `-Include`/`-Exclude` patterns: a bare pattern (`*.cs`) still matches at any depth; a pattern containing a separator (`src/*.cs`) matches relative to `-BasePath` instead.
- Centralize `Encoding.RegisterProvider` registration in test setup via a module initializer.
- Add `ListViewColumnSorter` unit tests documenting existing sort behavior.

**Cleanup & packaging (P2)**
- Convert the remaining block-scoped namespaces to file-scoped.
- Compile the include/exclude pattern regexes (`RegexOptions.Compiled`).
- Add a self-contained release build alongside the existing framework-dependent one, and an optional code-signing step in the release workflow (no-op unless signing secrets are configured).

**Bug fixes found along the way**
- `ListViewColumnSorter.CompareRemainingColumns` redundantly re-compared the already-tied sort column ordinally instead of skipping it, so a case-only difference in the sort column decided the order instead of falling through to the next column.
- `EnumerationOptions.IgnoreInaccessible` defaults to `true`, so the new directory-listing warning silently never fired for the most common real case (an ACL-denied subdirectory) - found via manual verification against a real `icacls`-denied directory, fixed, and covered by a regression test that fails without the fix.

## Test plan

- `dotnet build EncodingChecker.sln` - 0 warnings, 0 errors.
- `dotnet test EncodingChecker.sln` - 147/147 passing.
- Manual verification with the built CLI: reparse-point root rejection (real junction), report self-exclusion across repeated runs, backup safety under repeated `-Include "*" -Backup` (no cascading, no stray temp files), missing-value CLI parsing, all 5 help-flag spellings, skipped-encoding handling (bytes unchanged, exit 0), path-aware include/exclude patterns, and the ACL-denied-directory warning.
- Both publish profiles (framework-dependent and self-contained) verified locally: single-file output, no PDB, distinct output directories.
