### PR TITLE
Fix GUI cancellation crash, wire cancellation into the converter, and split exit code 1

### DIFF
--- a/sources/EncodingChecker.Tests/CancellationTests.cs
+++ b/sources/EncodingChecker.Tests/CancellationTests.cs
@@ -1,0 +1,161 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Cancellation must unwind cleanly at every stage: nothing half-written, no temp files
+/// left behind, and no file modified. Genuine OS-level Ctrl+C delivery can't be unit
+/// tested, so these drive the same CancellationToken the CLI and GUI hand in.
+/// </summary>
+public sealed class CancellationTests : IDisposable
+{
+    private readonly string _root;
+
+    public CancellationTests()
+    {
+        _root = Directory.CreateTempSubdirectory("ec_cancel_").FullName;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static string[] TempArtifacts(string root) =>
+        Directory.GetFiles(root, $"*.{EncodingConverter.TEMP_FILE_SUFFIX}");
+
+    [Fact]
+    public void Convert_PreCancelledToken_ReportsCancelled_WithoutTouchingTheFile()
+    {
+        // StreamConvert checks the token at the top of its read loop, so a pre-cancelled
+        // token is observed deterministically before any byte is converted.
+        string path = Path.Combine(_root, "convert-me.txt");
+        File.WriteAllText(path, TestContent.Multilingual, new UTF8Encoding(false));
+        byte[] originalBytes = File.ReadAllBytes(path);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        ConversionResult result = EncodingConverter.Convert(
+            path,
+            path,
+            Encoding.UTF8,
+            new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            new ConversionOptions { WriteBom = true },
+            progress: null,
+            cts.Token);
+
+        Assert.False(result.Success);
+        Assert.Equal(ConversionErrorCode.Cancelled, result.ErrorCode);
+        Assert.False(result.ReplacementCommitted);
+
+        // The original must be byte-identical and no temp file may survive.
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+        Assert.Empty(TempArtifacts(_root));
+    }
+
+    [Fact]
+    public void ScanDirectory_PreCancelledToken_ThrowsAndConvertsNothing()
+    {
+        string path = Path.Combine(_root, "convert-me.txt");
+        File.WriteAllText(path, TestContent.Multilingual, new UTF8Encoding(false));
+        byte[] originalBytes = File.ReadAllBytes(path);
+
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Convert,
+            TargetCharset = "utf-16",
+            TargetWriteBom = true,
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(() =>
+            ScanEngine.ScanDirectory(options, _ => { }, cts.Token));
+
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+        Assert.Empty(TempArtifacts(_root));
+    }
+
+    [Fact]
+    public void ScanDirectory_CancelledFromCallback_StopsAndLeavesRemainingFilesUntouched()
+    {
+        // MaxParallelism 1 makes this deterministic: the first delivered entry cancels
+        // the run, so at least one of the remaining files must never be converted.
+        var originals = new Dictionary<string, byte[]>();
+
+        for (int i = 0; i < 12; i++)
+        {
+            string path = Path.Combine(_root, $"file{i:D2}.txt");
+            File.WriteAllText(path, TestContent.Multilingual, new UTF8Encoding(false));
+            originals[path] = File.ReadAllBytes(path);
+        }
+
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Convert,
+            TargetCharset = "utf-16",
+            TargetWriteBom = true,
+            MaxParallelism = 1,
+        };
+
+        using var cts = new CancellationTokenSource();
+
+        Assert.ThrowsAny<OperationCanceledException>(() =>
+            ScanEngine.ScanDirectory(options, _ => cts.Cancel(), cts.Token));
+
+        int untouched = originals.Count(
+            pair => File.ReadAllBytes(pair.Key).AsSpan().SequenceEqual(pair.Value));
+
+        // The run stopped early rather than converting everything anyway.
+        Assert.True(
+            untouched > 0,
+            "Cancellation did not stop the scan; every file was still converted.");
+
+        // A cancelled run must never leave conversion temp files behind.
+        Assert.Empty(TempArtifacts(_root));
+    }
+
+    [Fact]
+    public void ConvertFiles_PreCancelledToken_ThrowsAndConvertsNothing()
+    {
+        string path = Path.Combine(_root, "convert-me.txt");
+        File.WriteAllText(path, TestContent.Multilingual, new UTF8Encoding(false));
+        byte[] originalBytes = File.ReadAllBytes(path);
+
+        var entries = new List<ConversionReportEntry>
+        {
+            new()
+            {
+                FilePath = path,
+                SourceEncoding = "utf-8",
+                TargetEncoding = "utf-8",
+            },
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAny<OperationCanceledException>(() =>
+            ScanEngine.ConvertFiles(
+                entries,
+                "utf-16",
+                targetWriteBom: true,
+                ScanEngine.DefaultMaxParallelism,
+                onEntry: _ => { },
+                cts.Token));
+
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+        Assert.Empty(TempArtifacts(_root));
+    }
+}

--- a/sources/EncodingChecker.Tests/GuiWorkerCancellationTests.cs
+++ b/sources/EncodingChecker.Tests/GuiWorkerCancellationTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Pins the BackgroundWorker contract MainForm's convert path depends on.
+/// MainForm.ConvertWorkerDoWork sets e.Cancel when the conversion is cancelled, and
+/// MainForm.ConvertWorkerCompleted still has to apply whatever was converted before the
+/// cancellation. These tests exist because RunWorkerCompletedEventArgs.Result cannot be
+/// used to carry those partial results.
+/// </summary>
+public sealed class GuiWorkerCancellationTests
+{
+    private static void RunWorker(
+        Action<DoWorkEventArgs> doWork,
+        Action<RunWorkerCompletedEventArgs> completed)
+    {
+        using var worker = new BackgroundWorker { WorkerSupportsCancellation = true };
+        using var finished = new ManualResetEventSlim(false);
+
+        worker.DoWork += (_, e) => doWork(e);
+
+        worker.RunWorkerCompleted += (_, e) =>
+        {
+            try
+            {
+                completed(e);
+            }
+            finally
+            {
+                finished.Set();
+            }
+        };
+
+        worker.RunWorkerAsync();
+
+        Assert.True(finished.Wait(TimeSpan.FromSeconds(10)), "The worker did not complete in time.");
+    }
+
+    [Fact]
+    public void ResultProperty_WhenCancelled_Throws_WhichIsWhyPartialResultsAreNotCarriedThere()
+    {
+        // Documents the exact framework behavior behind the bug this class guards:
+        // assigning e.Result in DoWork is not enough, because the getter refuses to
+        // hand it back once the operation is marked cancelled.
+        Exception? observed = null;
+
+        RunWorker(
+            doWork: e =>
+            {
+                e.Cancel = true;
+                e.Result = new ConcurrentBag<ConversionReportEntry>();
+            },
+            completed: e =>
+            {
+                Assert.True(e.Cancelled);
+                Assert.Null(e.Error);
+
+                observed = Record.Exception(() => _ = e.Result);
+            });
+
+        Assert.IsType<InvalidOperationException>(observed);
+    }
+
+    [Fact]
+    public void CancelledConversion_PartialResultsSurviveViaSharedBag_AndCompletionDoesNotThrow()
+    {
+        // Mirrors MainForm's shape: the bag is created by the UI thread before the worker
+        // starts, filled by the worker, and read back after completion regardless of
+        // whether the run was cancelled.
+        var completedEntries = new ConcurrentBag<ConversionReportEntry>();
+
+        var converted = new ConversionReportEntry
+        {
+            FilePath = @"C:\somewhere\already-done.txt",
+            SourceEncoding = "us-ascii",
+            TargetEncoding = "utf-8",
+            Result = ConversionRowResult.Converted,
+        };
+
+        int appliedCount = -1;
+        bool wasCancelled = false;
+
+        RunWorker(
+            doWork: e =>
+            {
+                // One file finished before the user hit Cancel.
+                completedEntries.Add(converted);
+                e.Cancel = true;
+            },
+            completed: e =>
+            {
+                wasCancelled = e.Cancelled;
+
+                // Must not touch e.Result here; reading the shared bag is safe.
+                appliedCount = completedEntries.Count;
+            });
+
+        Assert.True(wasCancelled);
+        Assert.Equal(1, appliedCount);
+        Assert.Equal(ConversionRowResult.Converted, Assert.Single(completedEntries).Result);
+    }
+
+    [Fact]
+    public void ErrorProperty_IsReadableWhenCancelled_SoTheScanPathIsUnaffected()
+    {
+        // MainForm.ScanWorkerCompleted reads only e.Error/e.Cancelled, neither of which
+        // raises - confirming the cancellation defect was specific to the convert path.
+        RunWorker(
+            doWork: e => e.Cancel = true,
+            completed: e =>
+            {
+                Assert.True(e.Cancelled);
+                Assert.Null(e.Error);
+            });
+    }
+}

--- a/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
+++ b/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace EncodingChecker.Tests;
 
 /// <summary>
@@ -45,7 +47,9 @@ public sealed class PathAwarePatternTests : IDisposable
             Action = ScanAction.Detect,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        // The tree has several matching files, so onEntry genuinely fires from multiple
+        // worker threads; List<T>.Add would race here.
+        var entries = new ConcurrentBag<ConversionReportEntry>();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         return

--- a/sources/EncodingChecker.Tests/ReportSelfExclusionTests.cs
+++ b/sources/EncodingChecker.Tests/ReportSelfExclusionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text;
 
 namespace EncodingChecker.Tests;
@@ -118,7 +119,8 @@ public sealed class ReportSelfExclusionTests : IDisposable
             Action = ScanAction.Detect,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        // Two matching files, so onEntry can fire concurrently; List<T>.Add would race.
+        var entries = new ConcurrentBag<ConversionReportEntry>();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         Assert.Equal(2, entries.Count);

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -30,6 +30,7 @@ public partial class MainForm : Form
         internal required List<ConversionReportEntry> Entries;
         internal required string TargetBaseCharset;
         internal required bool TargetWriteBom;
+        internal required ConcurrentBag<ConversionReportEntry> Completed;
         internal CancellationToken CancellationToken;
     }
 
@@ -51,6 +52,12 @@ public partial class MainForm : Form
     // Set by OnConvert, read back by ConvertWorkerCompleted; never touched by the worker thread.
     private Dictionary<string, ListViewItem>? _convertItemsByPath;
     private string? _convertTargetLabel;
+
+    // Filled by the worker thread, read by ConvertWorkerCompleted once it finishes.
+    // RunWorkerCompletedEventArgs.Result cannot carry this: its getter throws
+    // InvalidOperationException whenever the operation was cancelled, which is exactly
+    // when the partial results still need to be applied to the list.
+    private ConcurrentBag<ConversionReportEntry>? _convertResults;
 
     private const int RESULTS_COLUMN_CHARSET = 0;
     private const int RESULTS_COLUMN_FILE_NAME = 1;
@@ -495,8 +502,11 @@ public partial class MainForm : Form
             entries.Add(entry);
         }
 
+        var completed = new ConcurrentBag<ConversionReportEntry>();
+
         _convertItemsByPath = itemsByPath;
         _convertTargetLabel = targetLabel;
+        _convertResults = completed;
         _currentAction = CurrentAction.Convert;
 
         UpdateControlsOnActionStart();
@@ -509,6 +519,7 @@ public partial class MainForm : Form
             Entries = entries,
             TargetBaseCharset = targetBaseCharset,
             TargetWriteBom = writeBom,
+            Completed = completed,
             CancellationToken = _actionCancellation.Token,
         };
 
@@ -580,13 +591,13 @@ public partial class MainForm : Form
         }
     }
 
-    // No per-file progress to report; results are applied in one batch in ConvertWorkerCompleted.
+    // No per-file progress to report; results are applied in one batch in
+    // ConvertWorkerCompleted. Results accumulate into args.Completed (the caller's
+    // _convertResults) rather than e.Result, which is unreadable once e.Cancel is set.
     private static void ConvertWorkerDoWork(
         ConvertWorkerArgs args,
         DoWorkEventArgs e)
     {
-        var completed = new ConcurrentBag<ConversionReportEntry>();
-
         try
         {
             ScanEngine.ConvertFiles(
@@ -594,15 +605,13 @@ public partial class MainForm : Form
                 args.TargetBaseCharset,
                 args.TargetWriteBom,
                 ScanEngine.DefaultMaxParallelism,
-                onEntry: completed.Add,
+                onEntry: args.Completed.Add,
                 args.CancellationToken);
         }
         catch (OperationCanceledException)
         {
             e.Cancel = true;
         }
-
-        e.Result = completed;
     }
 
     // GUI masks are newline-separated; ScanEngine receives split patterns.
@@ -702,9 +711,11 @@ public partial class MainForm : Form
     {
         string targetLabel = _convertTargetLabel!;
         Dictionary<string, ListViewItem> itemsByPath = _convertItemsByPath!;
+        ConcurrentBag<ConversionReportEntry> completed = _convertResults ?? [];
 
         _convertItemsByPath = null;
         _convertTargetLabel = null;
+        _convertResults = null;
 
         if (e.Error != null)
         {
@@ -715,9 +726,6 @@ public partial class MainForm : Form
             UpdateControlsOnActionDone("Conversion failed.");
             return;
         }
-
-        // ConvertWorkerDoWork always assigns e.Result, even when cancelled.
-        var completed = (ConcurrentBag<ConversionReportEntry>)e.Result!;
 
         int convertedCount = 0;
         int unchangedCount = 0;

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -184,9 +184,10 @@ internal static class Program
                    under -Validate, fails) conversion. Useful as a CI
                    gate, optionally with -WhatIf or -Validate.
 
-        Exit codes: 0 = clean; 1 = usage/argument error; 2 = -FailOnChanges
-        triggered; 3 = one or more files failed to process; 4 = cancelled
-        (Ctrl+C).
+        Exit codes: 0 = clean; 1 = usage/argument error (nothing was scanned);
+        2 = -FailOnChanges triggered; 3 = the run did not complete cleanly -
+        one or more files failed to process, the scan itself failed, or the
+        -Report file could not be written; 4 = cancelled (Ctrl+C).
 
         Examples:
 
@@ -308,8 +309,10 @@ internal static class Program
         catch (Exception ex) when (
             ex is IOException or UnauthorizedAccessException)
         {
+            // Exit 3, not 1: the arguments were valid and the run started; this is a
+            // processing failure, and a CI gate must be able to tell them apart.
             Console.Error.WriteLine($"Scan failed: {ex.Message}");
-            return 1;
+            return 3;
         }
         finally
         {
@@ -345,9 +348,11 @@ internal static class Program
             catch (Exception ex) when (
                 ex is IOException or UnauthorizedAccessException)
             {
+                // Exit 3, not 1: in Convert mode the files have already been rewritten
+                // by this point, so reporting a usage error here would be misleading.
                 Console.Error.WriteLine(
                     $"Failed to write report file: {ex.Message}");
-                return 1;
+                return 3;
             }
         }
 

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -120,7 +120,8 @@ internal static class ScanEngine
             files,
             options.MaxParallelism,
             getPath: path => path,
-            processItem: path => ProcessFileForScan(path, options, targetEncoding),
+            processItem: path =>
+                ProcessFileForScan(path, options, targetEncoding, cancellationToken),
             onEntry: onEntry,
             cancellationToken);
     }
@@ -233,7 +234,8 @@ internal static class ScanEngine
                     targetEncoding,
                     targetWriteBom,
                     whatIf: false,
-                    backup: false);
+                    backup: false,
+                    cancellationToken);
 
                 return entry;
             },
@@ -266,7 +268,8 @@ internal static class ScanEngine
     private static ConversionReportEntry? ProcessFileForScan(
         string path,
         ScanDirectoryOptions options,
-        Encoding? targetEncoding)
+        Encoding? targetEncoding,
+        CancellationToken cancellationToken)
     {
         Encoding? detected = TextEncoding.DetectFromFile(path);
 
@@ -325,7 +328,8 @@ internal static class ScanEngine
                         targetEncoding!,
                         options.TargetWriteBom,
                         options.WhatIf,
-                        options.Backup);
+                        options.Backup,
+                        cancellationToken);
                 }
                 else
                 {
@@ -349,7 +353,8 @@ internal static class ScanEngine
         Encoding targetEncoding,
         bool targetWriteBom,
         bool whatIf,
-        bool backup)
+        bool backup,
+        CancellationToken cancellationToken)
     {
         entry.TargetEncoding = targetCharset;
         entry.TargetHasBom = targetWriteBom;
@@ -393,13 +398,25 @@ internal static class ScanEngine
             WriteBom = targetWriteBom,
         };
 
+        // Without the token, Parallel.ForEach could only observe cancellation between
+        // files, so a large in-flight conversion had to finish first. Convert's own
+        // checkpoints make cancelling mid-file safe: nothing is installed until the
+        // temp file is written, verified, and atomically replaced.
         ConversionResult result =
             EncodingConverter.Convert(
                 path,
                 path,
                 sourceEncoding,
                 targetEncoding,
-                conversionOptions);
+                conversionOptions,
+                progress: null,
+                cancellationToken);
+
+        // Convert reports cancellation as a result code rather than an exception.
+        // Rethrow it so a user-initiated cancel unwinds the scan like every other
+        // cancellation instead of being recorded as a per-file conversion failure.
+        if (result.ErrorCode == ConversionErrorCode.Cancelled)
+            throw new OperationCanceledException(cancellationToken);
 
         entry.Result =
             result.Success


### PR DESCRIPTION
## Summary

Four fixes found by an independent review of the current repository. Each is
its own commit. Two are user-facing defects; two are hygiene fixes with real
value.

### P0 — GUI conversion cancellation threw and left the UI unusable (`00c7e4b`)

`ConvertWorkerDoWork` set **both** `e.Cancel = true` and `e.Result`, and
`ConvertWorkerCompleted` read `e.Result` unconditionally. `RunWorkerCompleted-
EventArgs.Result` raises `InvalidOperationException` whenever `Cancelled` is
true, *regardless of whether a result was assigned* — verified empirically.

Cancelling a conversion therefore threw out of the completion handler: the
error surfaced via `Application.ThreadException`, and because everything after
that line was skipped, `UpdateControlsOnActionDone` never ran — View/Validate/
Convert stayed disabled and the progress marquee spun forever, with no in-app
recovery. A pending form close (cancel triggered by closing the window) was
also silently dropped.

Partial results now accumulate into a `ConcurrentBag` created before the worker
starts and read back through a field, so they survive cancellation. The comment
claiming assigning `e.Result` was sufficient described the opposite of the
framework's behavior and is removed.

### P0 — the cancellation token never reached `EncodingConverter.Convert` (`a39a9b1`)

`ApplyConversion` neither accepted nor forwarded a `CancellationToken`, and it
is the only production caller of `Convert`, so the token was always `default`.
That made all of the following unreachable outside tests: `Convert`'s three
cancellation checkpoints, `StreamConvert`'s and `ComputeContentDigest`'s
per-buffer checks, and `ConversionErrorCode.Cancelled`. `Parallel.ForEach` could
only observe cancellation *between* files, so cancelling during a large file
waited for that file to finish.

The token now flows `ScanDirectory`/`ConvertFiles` → `ProcessFileForScan` →
`ApplyConversion` → `Convert`. Since `Convert` reports cancellation as a result
code rather than an exception, `ApplyConversion` rethrows it as
`OperationCanceledException` so a cancel unwinds the scan like every other
cancellation instead of being recorded as a per-file conversion failure.

### P1 — exit code `1` conflated three different outcomes (`47a5dd6`)

`1` is documented as "usage/argument error", but was also returned when the scan
failed with an I/O error and when the `-Report` file could not be written. The
second case is the misleading one: in Convert mode the files have **already been
rewritten** by then, so a CI gate saw "bad arguments" for a run that did its work
and only failed to write the report. Both now return `3`; `1` is once again
reserved for arguments rejected before anything was scanned. Help text updated.

### P1 — concurrent `List<T>.Add` races in tests (`f5c1356`)

`ScanEngine` documents that `onEntry` fires concurrently, and several tests
already use `ConcurrentBag` for that reason. Two tests that scan multiple files
still passed `List<T>.Add`. Test-only fix, scoped to the two sites that
genuinely scan more than one file — the remaining `List<T>` call sites all
assert `Assert.Single`, so no concurrency is possible and they are left alone.

## Test plan

- [x] `dotnet build EncodingChecker.sln` — 0 warnings, 0 errors after each commit
- [x] `dotnet test EncodingChecker.sln` — **157 → 164**, 0 failures, identical
      across two consecutive runs
- [x] CLI verification: convert + `-Backup` over `-Include "*"` at
      `-MaxParallelism 4`, repeated (no chaining, no leftover temp files); and
      all four exit codes distinguished (clean 0, usage 1, report failure 3,
      `-FailOnChanges` 2)

New coverage — the suite previously had **zero** cancellation tests and **zero**
GUI/`BackgroundWorker` tests:

- `CancellationTests` (4) — pre-cancelled tokens through `Convert`,
  `ScanDirectory` and `ConvertFiles`, plus a cancel-from-callback run; all
  assert no file is modified and no temp file survives.
- `GuiWorkerCancellationTests` (3) — pins the `BackgroundWorker` contract,
  including a test that documents `e.Result` throwing when cancelled so the bug
  cannot be reintroduced by "simplifying" it back.

## Reviewer notes

**The P0-2 tests do not strictly prove forwarding.** A pre-cancelled token makes
`Parallel.ForEach` short-circuit before invoking the body, so none of the new
tests would have *failed* against the old code. They lock in the cancellation
contract (previously untested) and would catch a regression in `Convert`'s own
handling. Proving mid-file interruption deterministically would need production
instrumentation or a timing-dependent test; the forwarding itself is visible in
the diff and was exercised via the CLI.

**Deliberately not changed.** The review also examined four issues recently fixed
in the sibling LineEndingNormalizer project. Three were already fixed here (PR
#22). The fourth — cleanup masking the primary exception on ReadOnly files — is
**architecturally impossible** in EncodingChecker, because `Convert` returns a
structured result that is fully built before the cleanup `finally` runs, and
`TryDeleteTempFile` already clears ReadOnly and swallows its own failures. No
change was made there. Likewise, EncodingChecker correctly does **not** need
LEN's `IsSafeLegacyEncoding` allowlist: it has no raw-byte path, converting
everything through strict decode/encode with SHA-256 content verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
