### PR TITLE
Fix stale conversion results in CSV export

### DIFF
--- a/sources/EncodingChecker.Tests/ResultEntryReconciliationTests.cs
+++ b/sources/EncodingChecker.Tests/ResultEntryReconciliationTests.cs
@@ -1,0 +1,243 @@
+using System.Text;
+using System.Windows.Forms;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// One file, one row, one authoritative ConversionReportEntry.
+///
+/// A row's entry lives in ListViewItem.Tag and is what OnExportReport writes to CSV,
+/// while the GUI's per-row presentation is driven by whatever entry came back from
+/// processing. Those are normally the same instance, because processing mutates the
+/// entry in place - but ScanEngine.RunParallel substitutes a fresh error entry when a
+/// file throws, and a substitute that never reached Tag would leave the exported CSV
+/// reporting a stale pre-error result for a row the GUI showed as failed.
+/// </summary>
+public sealed class ResultEntryReconciliationTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_reconcile_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static ListViewItem Row(ConversionReportEntry entry) =>
+        new([
+            ScanEngine.FormatCharsetLabel(entry.SourceEncoding, entry.SourceHasBom),
+            Path.GetFileName(entry.FilePath),
+            Path.GetExtension(entry.FilePath),
+            Path.GetDirectoryName(entry.FilePath) ?? string.Empty,
+        ])
+        {
+            Tag = entry,
+        };
+
+    private static ConversionReportEntry ScannedEntry(string path) => new()
+    {
+        FilePath = path,
+        SourceEncoding = "windows-1252",
+        SourceHasBom = false,
+        TargetEncoding = "windows-1252",
+        TargetHasBom = false,
+        Result = ConversionRowResult.Unchanged,
+    };
+
+    private static string[] CsvValuesFor(ListViewItem item)
+    {
+        var entry = (ConversionReportEntry)item.Tag!;
+        string csv = ConversionReport.ToCsvString([entry]);
+
+        return csv
+            .Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries)[1]
+            .Split(',');
+    }
+
+    [Fact]
+    public void SubstituteErrorEntry_ReachesTheRow_SoCsvExportReportsTheError()
+    {
+        // The bug: RunParallel builds a *different* entry object for a file that threw,
+        // the row kept the original, and the CSV therefore said "Unchanged" for a file
+        // the GUI had just marked failed.
+        ConversionReportEntry scanned = ScannedEntry(Path.Combine(_root, "boom.txt"));
+        ListViewItem item = Row(scanned);
+        item.Checked = true;
+
+        var substitute = new ConversionReportEntry
+        {
+            FilePath = scanned.FilePath,
+            SourceEncoding = "(Error)",
+            TargetEncoding = "(Error)",
+            Result = ConversionRowResult.Error,
+            Diagnostic = "Access to the path is denied.",
+        };
+
+        MainForm.UpdateResultItem(item, substitute, targetLabel: "utf-8", wasPreview: false);
+
+        // The row now owns the outcome that was actually reported...
+        var authoritative = (ConversionReportEntry)item.Tag!;
+        Assert.Same(substitute, authoritative);
+        Assert.Equal(ConversionRowResult.Error, authoritative.Result);
+        Assert.Equal("Access to the path is denied.", authoritative.Diagnostic);
+
+        // ...and the export agrees with it, instead of reporting the stale scan result.
+        string[] values = CsvValuesFor(item);
+        Assert.Equal("Error", values[5]);
+        Assert.NotEqual("Unchanged", values[5]);
+
+        // Presentation is unchanged by this fix: an error row keeps its charset and
+        // stays checked so it can be retried.
+        Assert.True(item.Checked);
+    }
+
+    [Fact]
+    public void NonErrorRowsProcessedAlongsideAnError_ExportTheirOwnResults()
+    {
+        ConversionReportEntry okScan = ScannedEntry(Path.Combine(_root, "ok.txt"));
+        ConversionReportEntry failScan = ScannedEntry(Path.Combine(_root, "fail.txt"));
+
+        ListViewItem okItem = Row(okScan);
+        ListViewItem failItem = Row(failScan);
+
+        // The successful file's entry is mutated in place, as processing normally does.
+        okScan.Result = ConversionRowResult.Converted;
+        okScan.TargetEncoding = "utf-8";
+        okScan.TargetHasBom = true;
+
+        var substitute = new ConversionReportEntry
+        {
+            FilePath = failScan.FilePath,
+            SourceEncoding = "(Error)",
+            TargetEncoding = "(Error)",
+            Result = ConversionRowResult.Error,
+            Diagnostic = "The process cannot access the file.",
+        };
+
+        MainForm.UpdateResultItem(okItem, okScan, "utf-8-bom", wasPreview: false);
+        MainForm.UpdateResultItem(failItem, substitute, "utf-8-bom", wasPreview: false);
+
+        Assert.Equal("Converted", CsvValuesFor(okItem)[5]);
+        Assert.Equal("Error", CsvValuesFor(failItem)[5]);
+    }
+
+    [Theory]
+    [InlineData("Unchanged")]
+    [InlineData("Skipped")]
+    [InlineData("Converted")]
+    public void InPlaceMutatedEntries_StillExportTheirFinalResult(string resultName)
+    {
+        // ConversionRowResult is internal, so a public [Theory] method can't take it as
+        // a parameter (CS0051); round-trip through its name instead, as
+        // ConversionReportCsvTests already does.
+        var result = Enum.Parse<ConversionRowResult>(resultName);
+
+        // The ordinary path: the same instance is scanned, processed and exported.
+        ConversionReportEntry entry = ScannedEntry(Path.Combine(_root, "f.txt"));
+        ListViewItem item = Row(entry);
+
+        entry.Result = result;
+
+        MainForm.UpdateResultItem(item, entry, "utf-8", wasPreview: false);
+
+        Assert.Same(entry, item.Tag);
+        Assert.Equal(resultName, CsvValuesFor(item)[5]);
+    }
+
+    [Fact]
+    public void PreviewResult_DoesNotLeaveTheRowExportingAStaleEntry()
+    {
+        ConversionReportEntry entry = ScannedEntry(Path.Combine(_root, "preview.txt"));
+        ListViewItem item = Row(entry);
+        item.Checked = true;
+
+        entry.Result = ConversionRowResult.Converted; // "would convert"
+
+        MainForm.UpdateResultItem(item, entry, "utf-8", wasPreview: true);
+
+        Assert.Same(entry, item.Tag);
+        Assert.True(item.Checked);
+    }
+
+    [Fact]
+    public void CsvExportedFromTheRow_KeepsTheSixColumnSchemaAndEscaping()
+    {
+        // Guards the export path this fix touches: schema and quoting are unaffected.
+        var entry = new ConversionReportEntry
+        {
+            FilePath = Path.Combine(_root, "has, comma.txt"),
+            SourceEncoding = "windows-1252",
+            SourceHasBom = false,
+            TargetEncoding = "utf-8",
+            TargetHasBom = true,
+            Result = ConversionRowResult.Error,
+            Diagnostic = "should never appear in the CSV",
+        };
+
+        ListViewItem item = Row(entry);
+        MainForm.UpdateResultItem(item, entry, "utf-8-bom", wasPreview: false);
+
+        string csv = ConversionReport.ToCsvString([(ConversionReportEntry)item.Tag!]);
+        string[] lines = csv.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal("File,Encoding,BOM,Target,TargetBOM,Result", lines[0]);
+        Assert.StartsWith("\"" + entry.FilePath + "\",", lines[1]);
+        Assert.EndsWith(",Error", lines[1]);
+        Assert.DoesNotContain("should never appear", csv);
+    }
+
+    [Fact]
+    public void ConvertFiles_EmitsTheSameEntryInstanceItWasGiven_ForSuccessAndFailure()
+    {
+        // The engine half of the invariant: a caller that holds an entry (as the GUI
+        // does, in ListViewItem.Tag) sees its own object updated, rather than an
+        // outcome recorded on some other instance it never learns about.
+        string converts = Path.Combine(_root, "converts.txt");
+        File.WriteAllText(converts, "hello", new UTF8Encoding(false));
+
+        string fails = Path.Combine(_root, "missing.txt"); // never created
+
+        ConversionReportEntry convertsEntry = new()
+        {
+            FilePath = converts,
+            SourceEncoding = "utf-8",
+            SourceHasBom = false,
+            TargetEncoding = "utf-8",
+        };
+
+        ConversionReportEntry failsEntry = new()
+        {
+            FilePath = fails,
+            SourceEncoding = "utf-8",
+            SourceHasBom = false,
+            TargetEncoding = "utf-8",
+        };
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [convertsEntry, failsEntry],
+            "utf-16",
+            targetWriteBom: true,
+            maxParallelism: 1,
+            whatIf: false,
+            backup: false,
+            completed.Add,
+            CancellationToken.None);
+
+        Assert.Equal(2, completed.Count);
+        Assert.Same(convertsEntry, completed.Single(e => e.FilePath == converts));
+        Assert.Same(failsEntry, completed.Single(e => e.FilePath == fails));
+
+        Assert.Equal(ConversionRowResult.Converted, convertsEntry.Result);
+        Assert.Equal(ConversionRowResult.Error, failsEntry.Result);
+        Assert.NotNull(failsEntry.Diagnostic);
+    }
+}

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -806,14 +806,21 @@ public partial class MainForm : Form
         UpdateControlsOnActionDone(statusMessage);
     }
 
-    // Formats one result row. Kept internal so preview/convert presentation
-    // behavior can be tested without creating a real form.
+    // Reconciles one result row with the outcome of processing it. Kept internal so
+    // preview/convert presentation behavior can be tested without creating a real form.
     internal static void UpdateResultItem(
         ListViewItem item,
         ConversionReportEntry entry,
         string targetLabel,
         bool wasPreview)
     {
+        // The row's own entry is what OnExportReport writes to CSV, so it has to be the
+        // entry that produced this presentation. Processing normally mutates the entry
+        // in place, but ScanEngine.RunParallel substitutes a fresh error entry if a file
+        // throws, and that substitute would otherwise never reach the row - leaving the
+        // CSV reporting a stale pre-error result while the row displayed the failure.
+        item.Tag = entry;
+
         if (entry.Result == ConversionRowResult.Converted)
         {
             // Under preview nothing was written, so the row must keep describing the


### PR DESCRIPTION
## Root cause

A row's `ConversionReportEntry` lives in `ListViewItem.Tag` and is what `OnExportReport` writes to CSV. The GUI's per-row presentation, though, is driven by whatever entry came back from processing. Those are normally the *same object*, because processing mutates the entry in place.

`ScanEngine.RunParallel` is the exception: when a file throws it builds a **fresh substitute entry** carrying the error.

```
ListViewItem.Tag  ->  original entry        (exported to CSV)
RunParallel       ->  substitute entry      (drives the GUI)
```

In the Convert path the row already exists and is matched by `FilePath`, so the substitute reached `UpdateResultItem` and the display, but never reached `Tag`. Exporting that row reported the stale pre-error result while the GUI showed the failure.

The scan paths (View/Validate/Detect) were never affected - there the row is *created from* the entry in `ActionWorkerProgressChanged`, so `Tag` is already whichever entry arrived, substitute or not. The CLI was never affected either; it reports from the emitted entries directly.

## Fix

One line in `MainForm.UpdateResultItem`, the single place a row is reconciled with a processing outcome:

```csharp
item.Tag = entry;
```

Chosen over editing `ConvertWorkerCompleted` (same one line, but not reachable from a form-less test) and over reshaping `RunParallel` (which is generic over `string` and `ConversionReportEntry`, so it cannot always mutate a caller's object - the scan path has none). No new abstractions, no result-architecture changes.

## Honest scope note

**This is a latent bug, not an observed one.** I probed for a reachable trigger and could not find one:

```
missing file         : sameInstance=True  result=Error  diag=SourceOpenError: Could not find file ...
directory as file    : sameInstance=True  result=Error  diag=SourceOpenError: Access to the path ... is denied.
directory as file+bk : sameInstance=True  result=Error  diag=Backup failed: Access to the path ... is denied.
bak path is a dir    : sameInstance=True  result=Error  diag=Backup failed: Cannot create a file when that file already exists.
normal (control)     : sameInstance=True  result=Converted
```

Every error reachable today is caught and recorded on the real entry, because `EncodingConverter.Convert` has a top-level `catch (Exception)` and `ApplyConversion` catches backup failures. The substitute path therefore does not currently fire from `ConvertFiles`. The fix and its tests pin the invariant so that remains true if those handlers are ever narrowed or `RunParallel`'s catch list widened.

## Tests

New `ResultEntryReconciliationTests` (8 cases), deterministic and form-less - no GUI automation:

- `SubstituteErrorEntry_ReachesTheRow_SoCsvExportReportsTheError` - the reported bug: a substitute error entry is presented, and the CSV exported from `Tag` must say `Error`, not the stale `Unchanged`.
- `NonErrorRowsProcessedAlongsideAnError_ExportTheirOwnResults` - mixed batch.
- `InPlaceMutatedEntries_StillExportTheirFinalResult` - Unchanged/Skipped/Converted.
- `PreviewResult_DoesNotLeaveTheRowExportingAStaleEntry`.
- `CsvExportedFromTheRow_KeepsTheSixColumnSchemaAndEscaping` - schema, quoting, and `Diagnostic` still excluded.
- `ConvertFiles_EmitsTheSameEntryInstanceItWasGiven_ForSuccessAndFailure` - the engine half of the invariant.

The first two were confirmed to **fail without the fix** by temporarily removing the assignment, then pass once restored.

## Verification

- `dotnet build -c Release`: 0 warnings, 0 errors.
- Full suite run twice: **198 passed, 0 failed** both times (190 existing unchanged, +8 new).
- CSV schema unchanged: `File,Encoding,BOM,Target,TargetBOM,Result`.

Note: the task text referred to the "BOM2 six-column schema". That column was renamed to `TargetBOM` in v3.3.1; I preserved the schema as it currently stands rather than reverting it.

Generated with [Claude Code](https://claude.com/claude-code)
