### PR TITLE
Pin the CLI exit-code contract with tests

### DIFF
--- a/sources/EncodingChecker.Tests/ExitCodeContractTests.cs
+++ b/sources/EncodingChecker.Tests/ExitCodeContractTests.cs
@@ -1,0 +1,185 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// EncodingChecker's exit codes are a published CLI contract - documented in the
+/// README and printed by -? - and codes 0-4 are deliberately shared with
+/// LineEndingNormalizer so a script driving both tools can use one mapping.
+///
+/// These pin the numbers themselves rather than just "non-zero". Renumbering them
+/// would silently change the meaning of results already relied on by CI gates
+/// (exit 2 = -FailOnChanges is the most likely to be scripted), so it must never
+/// happen without an explicit, deliberate change here.
+///
+/// RunConsoleMode writes to Console.Out/Error, which is process-global, so these
+/// redirect around each call.
+/// </summary>
+public sealed class ExitCodeContractTests : IDisposable
+{
+    private const int ExpectedClean = 0;
+    private const int ExpectedUsageError = 1;
+    private const int ExpectedChangesNeeded = 2;
+    private const int ExpectedProcessingErrors = 3;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_exitcodes_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    private string WriteAscii(string name, string content)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllText(path, content, Encoding.ASCII);
+
+        return path;
+    }
+
+    [Fact]
+    public void Help_ExitsZero()
+    {
+        Assert.Equal(ExpectedClean, Run("-?"));
+    }
+
+    [Fact]
+    public void CleanDetectOnlyRun_ExitsZero()
+    {
+        WriteAscii("a.txt", "hello");
+
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", _root, "-Include", "*.txt", "-DetectOnly"));
+    }
+
+    [Fact]
+    public void UnknownArgument_ExitsOne()
+    {
+        Assert.Equal(ExpectedUsageError, Run("-BasePath", _root, "-NoSuchSwitch"));
+    }
+
+    [Fact]
+    public void MissingBasePath_ExitsOne()
+    {
+        Assert.Equal(ExpectedUsageError, Run("-Include", "*.txt", "-DetectOnly"));
+    }
+
+    [Fact]
+    public void NonexistentBasePath_ExitsOne()
+    {
+        // EncodingChecker folds "directory not found" into the usage-error code.
+        // LineEndingNormalizer reports this as 5 instead - a refinement of the same
+        // case, deliberately at a number EncodingChecker never returns.
+        Assert.Equal(
+            ExpectedUsageError,
+            Run("-BasePath", Path.Combine(_root, "nope"), "-Include", "*", "-DetectOnly"));
+    }
+
+    [Fact]
+    public void ConvertModeWithoutTarget_ExitsOne()
+    {
+        Assert.Equal(ExpectedUsageError, Run("-BasePath", _root, "-Include", "*.txt"));
+    }
+
+    [Fact]
+    public void FailOnChanges_WithFilesNeedingConversion_ExitsTwo()
+    {
+        // The CI-gate code, and the one most likely to be scripted: it must stay 2,
+        // matching LineEndingNormalizer's -FailOnChanges.
+        WriteAscii("a.txt", "hello");
+
+        Assert.Equal(
+            ExpectedChangesNeeded,
+            Run(
+                "-BasePath", _root,
+                "-Include", "*.txt",
+                "-Target", "utf-8-bom",
+                "-WhatIf",
+                "-FailOnChanges"));
+    }
+
+    [Fact]
+    public void FailOnChanges_WithNothingToConvert_ExitsZero()
+    {
+        string path = Path.Combine(_root, "already.txt");
+        File.WriteAllText(path, "hello", new UTF8Encoding(true));
+
+        Assert.Equal(
+            ExpectedClean,
+            Run(
+                "-BasePath", _root,
+                "-Include", "already.txt",
+                "-Target", "utf-8-bom",
+                "-FailOnChanges"));
+    }
+
+    [Fact]
+    public void UnwritableReportPath_ExitsThree()
+    {
+        // A report that cannot be written is a processing failure, not a usage error:
+        // in Convert mode the files have already been rewritten by this point.
+        WriteAscii("a.txt", "hello");
+
+        string reportPath = Path.Combine(_root, "report.csv");
+        Directory.CreateDirectory(reportPath);
+
+        Assert.Equal(
+            ExpectedProcessingErrors,
+            Run(
+                "-BasePath", _root,
+                "-Include", "*.txt",
+                "-DetectOnly",
+                "-Report", reportPath));
+    }
+
+    [Fact]
+    public void PerFileConversionFailure_ExitsThree()
+    {
+        // Cyrillic cannot be represented in windows-1252, so the file fails to convert.
+        string path = Path.Combine(_root, "cyrillic.txt");
+        File.WriteAllText(path, "Привет", new UTF8Encoding(false));
+
+        Assert.Equal(
+            ExpectedProcessingErrors,
+            Run(
+                "-BasePath", _root,
+                "-Include", "cyrillic.txt",
+                "-Target", "windows-1252"));
+    }
+
+    [Fact]
+    public void ProcessingFailure_IsNotReportedAsAUsageError()
+    {
+        // These must stay distinct: a CI gate has to tell "you invoked me wrong" from
+        // "the run started and some files failed".
+        Assert.NotEqual(ExpectedUsageError, ExpectedProcessingErrors);
+    }
+}

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -206,7 +206,9 @@ internal static class Program
           EncodingChecker.exe -BasePath D:\NetworkShare -Include "*.txt" -Target "utf-8" -MaxParallelism 2 -FailOnChanges
         """;
 
-    private static int RunConsoleMode(string[] args)
+    // Internal so ExitCodeContractTests can pin the exit codes, which are a published
+    // CLI contract shared with LineEndingNormalizer.
+    internal static int RunConsoleMode(string[] args)
     {
         if (args.Length == 1 &&
             args[0] is "/?" or "-?" or "/h" or "-h" or "--help")


### PR DESCRIPTION
## Why

EncodingChecker's exit codes are documented in the README and printed by `-?`, but **nothing tested them**. A renumbering would have gone unnoticed until it broke someone's CI gate.

They are now also shared with LineEndingNormalizer, whose codes `0`-`4` were aligned to these in amrali-eg/LineEndingNormalizer#1, which makes silent drift more costly still.

## What changed

No behaviour change. New `ExitCodeContractTests` pins each code:

| Code | Meaning | Covered by |
|---|---|---|
| 0 | clean run, and `-?` | `Help_ExitsZero`, `CleanDetectOnlyRun_ExitsZero`, `FailOnChanges_WithNothingToConvert_ExitsZero` |
| 1 | usage/argument error | unknown switch, missing `-BasePath`, nonexistent `-BasePath`, Convert without `-Target` |
| 2 | `-FailOnChanges` triggered | `FailOnChanges_WithFilesNeedingConversion_ExitsTwo` |
| 3 | processing errors | unwritable `-Report` path, and a real per-file conversion failure (Cyrillic to windows-1252) |

`RunConsoleMode` is widened from `private` to `internal` so the tests can call it directly rather than launching the built executable and coupling tests to publish output. `InternalsVisibleTo("EncodingChecker.Tests")` was already in place.

The test asserting `1` for a nonexistent `-BasePath` documents the deliberate asymmetry with LEN, which reports `5` for that case - a refinement at a number EncodingChecker never returns, not a conflict.

## Verification

- Full suite run twice: **209 passed, 0 failed** (198 existing unchanged, +11 new).
- Cross-checked the real executables against LEN side by side: help `0`/`0`, clean run `0`/`0`, unknown switch `1`/`1`, `-FailOnChanges` `2`/`2`.

Generated with [Claude Code](https://claude.com/claude-code)
