### PR TITLE
Fix audit-verified bugs, harden CLI input, and expand encoding coverage

### DIFF
--- a/sources/EncodingChecker.Tests/BackupExceptionPreservationTests.cs
+++ b/sources/EncodingChecker.Tests/BackupExceptionPreservationTests.cs
@@ -1,0 +1,128 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// AtomicReplaceForBackup clears the destination's ReadOnly attribute so the replacement
+/// can proceed, then puts it back. Restoring from a plain finally meant a failing
+/// SetAttributes could throw over an in-flight replacement failure, so the caller was
+/// told about an attribute problem instead of why the backup actually failed.
+///
+/// SCOPE: these pin the observable contract - the replacement failure is what surfaces,
+/// the rollback still happens, and the success path is unchanged. They do NOT exercise
+/// the masking branch itself, which needs the replacement AND the rollback to fail
+/// together. That combination is not reachable from the filesystem: SetAttributes
+/// succeeds on a locked file and silently ignores unsettable attributes, and any ACL
+/// that would deny the rollback also denies the initial clear, which happens earlier and
+/// outside the try. Forcing it would need an injection seam in production code, so the
+/// branch is covered by inspection against AtomicReplace's equivalent handling instead.
+/// </summary>
+public sealed class BackupExceptionPreservationTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_backup_exc_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            // ReadOnly fixtures would otherwise block the recursive delete.
+            foreach (string file in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+                File.SetAttributes(file, FileAttributes.Normal);
+
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string WriteFile(string name, string content, bool readOnly = false)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllText(path, content, new UTF8Encoding(false));
+
+        if (readOnly)
+            File.SetAttributes(path, FileAttributes.ReadOnly);
+
+        return path;
+    }
+
+    [Fact]
+    public void ReplacementFailure_IsReportedInsteadOfAnAttributeError()
+    {
+        // A missing temp file makes the replacement fail deterministically while the
+        // destination stays present and restorable - the exact shape where a finally
+        // could previously substitute its own exception.
+        string missingTemp = Path.Combine(_root, "does-not-exist.tmp");
+        string destination = WriteFile("target.bak", "original", readOnly: true);
+
+        var ex = Assert.ThrowsAny<IOException>(
+            () => EncodingConverter.AtomicReplaceForBackup(missingTemp, destination));
+
+        // The reported failure must describe the replacement, not the attribute rollback.
+        Assert.DoesNotContain(
+            "ReadOnly attribute could also not be restored",
+            ex.Message,
+            StringComparison.Ordinal);
+
+        Assert.DoesNotContain(
+            "could not be restored",
+            ex.Message,
+            StringComparison.Ordinal);
+
+        // And the rollback still happened: the destination keeps its ReadOnly state.
+        Assert.True(File.GetAttributes(destination).HasFlag(FileAttributes.ReadOnly));
+        Assert.Equal("original", File.ReadAllText(destination));
+    }
+
+    [Fact]
+    public void ReplacementFailure_PreservesTheOriginalExceptionType()
+    {
+        string missingTemp = Path.Combine(_root, "absent.tmp");
+        string destination = WriteFile("target2.bak", "original", readOnly: true);
+
+        var ex = Assert.ThrowsAny<IOException>(
+            () => EncodingConverter.AtomicReplaceForBackup(missingTemp, destination));
+
+        // Rethrown unchanged when the rollback succeeds - not wrapped, not replaced.
+        Assert.IsType<FileNotFoundException>(ex);
+    }
+
+    [Fact]
+    public void SuccessfulReplacement_InstallsTheTempAndRestoresReadOnly()
+    {
+        string temp = WriteFile("incoming.tmp", "new backup content");
+        string destination = WriteFile("target3.bak", "stale backup", readOnly: true);
+
+        EncodingConverter.AtomicReplaceForBackup(temp, destination);
+
+        Assert.Equal("new backup content", File.ReadAllText(destination));
+        Assert.True(File.GetAttributes(destination).HasFlag(FileAttributes.ReadOnly));
+        Assert.False(File.Exists(temp));
+    }
+
+    [Fact]
+    public void SuccessfulReplacement_OverANonReadOnlyDestination_LeavesItWritable()
+    {
+        string temp = WriteFile("incoming2.tmp", "fresh");
+        string destination = WriteFile("target4.bak", "stale");
+
+        EncodingConverter.AtomicReplaceForBackup(temp, destination);
+
+        Assert.Equal("fresh", File.ReadAllText(destination));
+        Assert.False(File.GetAttributes(destination).HasFlag(FileAttributes.ReadOnly));
+    }
+
+    [Fact]
+    public void NewBackup_WithNoExistingDestination_Succeeds()
+    {
+        string temp = WriteFile("incoming3.tmp", "first backup");
+        string destination = Path.Combine(_root, "brand-new.bak");
+
+        EncodingConverter.AtomicReplaceForBackup(temp, destination);
+
+        Assert.Equal("first backup", File.ReadAllText(destination));
+    }
+}

--- a/sources/EncodingChecker.Tests/CliInputPreservationTests.cs
+++ b/sources/EncodingChecker.Tests/CliInputPreservationTests.cs
@@ -1,0 +1,123 @@
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Two places where the CLI used to discard what the caller typed without saying so:
+/// -Validate silently won over -Target, and a repeated -Include silently dropped every
+/// pattern but the last. Both are the same failure mode - the run proceeds, the user is
+/// told nothing, and the result does not reflect the command they wrote.
+/// </summary>
+public sealed class CliInputPreservationTests
+{
+    private static Program.CliOptions Parse(params string[] args)
+    {
+        Assert.True(
+            Program.TryParseArguments(args, out Program.CliOptions options, out string? parseError),
+            parseError);
+
+        return options;
+    }
+
+    // ---------- -Validate + -Target ----------
+
+    [Fact]
+    public void ValidateCombinedWithTarget_IsRejected()
+    {
+        Program.CliOptions options = Parse(
+            "-BasePath", ".", "-Validate", "utf-8", "-Target", "utf-16");
+
+        Assert.False(Program.TryValidateOptions(options, out string? error));
+        Assert.NotNull(error);
+        Assert.Contains("-Validate", error, StringComparison.Ordinal);
+        Assert.Contains("-Target", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateWithoutTarget_StillValidates()
+    {
+        Program.CliOptions options = Parse("-BasePath", ".", "-Validate", "utf-8,utf-8-bom");
+
+        Assert.True(Program.TryValidateOptions(options, out string? error), error);
+    }
+
+    [Fact]
+    public void TargetWithoutValidate_StillValidates()
+    {
+        Program.CliOptions options = Parse("-BasePath", ".", "-Target", "utf-8");
+
+        Assert.True(Program.TryValidateOptions(options, out string? error), error);
+    }
+
+    [Fact]
+    public void DetectOnlyCombinedWithValidate_IsStillRejected()
+    {
+        // The pre-existing incompatibility this one was modelled on.
+        Program.CliOptions options = Parse(
+            "-BasePath", ".", "-DetectOnly", "-Validate", "utf-8");
+
+        Assert.False(Program.TryValidateOptions(options, out string? error));
+        Assert.NotNull(error);
+    }
+
+    // ---------- repeated -Include / -Exclude ----------
+
+    [Fact]
+    public void RepeatedInclude_KeepsEveryPattern()
+    {
+        Program.CliOptions options = Parse(
+            "-BasePath", ".", "-Include", "*.cs", "-Include", "*.txt", "-DetectOnly");
+
+        Assert.Equal(["*.cs", "*.txt"], options.Include);
+    }
+
+    [Fact]
+    public void RepeatedExclude_KeepsEveryPattern()
+    {
+        Program.CliOptions options = Parse(
+            "-BasePath", ".", "-Exclude", "*.g.cs", "-Exclude", "*.designer.cs", "-DetectOnly");
+
+        Assert.Equal(["*.g.cs", "*.designer.cs"], options.Exclude);
+    }
+
+    [Fact]
+    public void CommaSeparatedPatterns_BehaveExactlyAsBefore()
+    {
+        Program.CliOptions options = Parse(
+            "-BasePath", ".", "-Include", "*.cs,*.txt,*.md", "-DetectOnly");
+
+        Assert.Equal(["*.cs", "*.txt", "*.md"], options.Include);
+    }
+
+    [Fact]
+    public void SinglePattern_IsUnchanged()
+    {
+        Program.CliOptions options = Parse("-BasePath", ".", "-Include", "*.cs", "-DetectOnly");
+
+        Assert.Equal(["*.cs"], options.Include);
+    }
+
+    [Fact]
+    public void RepeatedAndCommaSeparatedTogether_ProduceTheCombinedSet()
+    {
+        Program.CliOptions options = Parse(
+            "-BasePath", ".",
+            "-Include", "*.cs,*.vb",
+            "-Include", "*.txt",
+            "-Exclude", "*.g.cs",
+            "-Exclude", "bin/*,obj/*",
+            "-DetectOnly");
+
+        Assert.Equal(["*.cs", "*.vb", "*.txt"], options.Include);
+        Assert.Equal(["*.g.cs", "bin/*", "obj/*"], options.Exclude);
+    }
+
+    [Fact]
+    public void NoIncludeGiven_LeavesTheListEmpty()
+    {
+        // An empty list means "match everything" downstream; accumulation must not
+        // invent a pattern where none was supplied.
+        Program.CliOptions options = Parse("-BasePath", ".", "-DetectOnly");
+
+        Assert.Empty(options.Include);
+        Assert.Empty(options.Exclude);
+    }
+}

--- a/sources/EncodingChecker.Tests/MultibyteRoundTripTests.cs
+++ b/sources/EncodingChecker.Tests/MultibyteRoundTripTests.cs
@@ -1,0 +1,214 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// EncodingConversionMatrixTests covers the Unicode families exhaustively but contains no
+/// legacy multibyte cases, even though Shift-JIS, GB18030, Big5, EUC-JP and EUC-KR are all
+/// in the supported set. These are the structural cases for those families: unlike
+/// single-byte code pages, a multibyte decoder can desynchronise mid-character, so a
+/// byte-exact round trip is the property worth pinning.
+///
+/// Deliberately not a full matrix expansion - one representative structural case per
+/// family, using real script content rather than ASCII.
+/// </summary>
+public sealed class MultibyteRoundTripTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_multibyte_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    public static IEnumerable<object[]> MultibyteCases()
+    {
+        // (charset, representative text in that script)
+        yield return ["shift_jis", "こんにちは世界。日本語のテキストです。\r\n二行目。\r\n"];
+        yield return ["euc-jp", "こんにちは世界。日本語のテキストです。\r\n二行目。\r\n"];
+        yield return ["gb18030", "你好世界。这是一段简体中文文本。\r\n第二行。\r\n"];
+        yield return ["big5", "你好世界。這是一段繁體中文文字。\r\n第二行。\r\n"];
+        yield return ["euc-kr", "안녕하세요 세계. 한국어 텍스트입니다.\r\n두 번째 줄.\r\n"];
+    }
+
+    private static ConversionReportEntry Entry(string path, string sourceCharset) => new()
+    {
+        FilePath = path,
+        SourceEncoding = sourceCharset,
+        SourceHasBom = false,
+        TargetEncoding = sourceCharset,
+        TargetHasBom = false,
+    };
+
+    private static ConversionReportEntry Convert(
+        ConversionReportEntry entry,
+        string targetCharset,
+        bool targetWriteBom)
+    {
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [entry],
+            targetCharset,
+            targetWriteBom,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false,
+            backup: false,
+            completed.Add,
+            CancellationToken.None);
+
+        return Assert.Single(completed);
+    }
+
+    [Theory]
+    [MemberData(nameof(MultibyteCases))]
+    public void TheSampleIsActuallyRepresentableInItsEncoding(string charset, string text)
+    {
+        // Guards the fixtures themselves: a sample the encoder cannot represent would
+        // make every other case in this file fail for the wrong reason.
+        Encoding encoding = Encoding.GetEncoding(charset);
+        byte[] bytes = encoding.GetBytes(text);
+
+        Assert.Equal(text, encoding.GetString(bytes));
+        Assert.True(bytes.Length > text.Length, "Expected multibyte expansion.");
+        Assert.Empty(encoding.GetPreamble());
+    }
+
+    [Theory]
+    [MemberData(nameof(MultibyteCases))]
+    public void LegacyToUtf8Bom_PreservesContentExactly(string charset, string text)
+    {
+        Encoding encoding = Encoding.GetEncoding(charset);
+
+        string path = Path.Combine(_root, $"{charset}_to_utf8.txt");
+        File.WriteAllBytes(path, encoding.GetBytes(text));
+
+        ConversionReportEntry result = Convert(Entry(path, charset), "utf-8", targetWriteBom: true);
+
+        Assert.Equal(ConversionRowResult.Converted, result.Result);
+
+        byte[] converted = File.ReadAllBytes(path);
+        Assert.Equal([0xEF, 0xBB, 0xBF], converted[..3]);
+        Assert.Equal(text, new UTF8Encoding(true).GetString(converted[3..]));
+    }
+
+    [Theory]
+    [MemberData(nameof(MultibyteCases))]
+    public void LegacyToUtf8AndBack_IsByteIdenticalToTheOriginal(string charset, string text)
+    {
+        // The property that matters for a multibyte codec: a full round trip must not
+        // desynchronise or substitute a single byte.
+        Encoding encoding = Encoding.GetEncoding(charset);
+
+        string path = Path.Combine(_root, $"{charset}_roundtrip.txt");
+        byte[] originalBytes = encoding.GetBytes(text);
+        File.WriteAllBytes(path, originalBytes);
+
+        ConversionReportEntry entry = Entry(path, charset);
+
+        Assert.Equal(ConversionRowResult.Converted, Convert(entry, "utf-8", false).Result);
+        Assert.Equal(text, new UTF8Encoding(false).GetString(File.ReadAllBytes(path)));
+
+        Assert.Equal(ConversionRowResult.Converted, Convert(entry, charset, false).Result);
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+    }
+
+    [Theory]
+    [MemberData(nameof(MultibyteCases))]
+    public void ConvertingToTheEncodingItAlreadyHas_ReportsUnchanged(string charset, string text)
+    {
+        Encoding encoding = Encoding.GetEncoding(charset);
+
+        string path = Path.Combine(_root, $"{charset}_idempotent.txt");
+        byte[] originalBytes = encoding.GetBytes(text);
+        File.WriteAllBytes(path, originalBytes);
+
+        ConversionReportEntry entry = Entry(path, charset);
+
+        Assert.Equal(ConversionRowResult.Unchanged, Convert(entry, charset, false).Result);
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+
+        // And a repeat run stays a no-op rather than rewriting the file.
+        Assert.Equal(ConversionRowResult.Unchanged, Convert(entry, charset, false).Result);
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+    }
+
+    [Theory]
+    [MemberData(nameof(MultibyteCases))]
+    public void RequestingABomForAnEncodingWithoutOne_IsRejectedBeforeAnyWrite(
+        string charset,
+        string text)
+    {
+        Encoding encoding = Encoding.GetEncoding(charset);
+
+        string path = Path.Combine(_root, $"{charset}_bom.txt");
+        File.WriteAllText(path, text, new UTF8Encoding(false));
+        byte[] originalBytes = File.ReadAllBytes(path);
+
+        ConversionResult result = EncodingConverter.Convert(
+            path, path,
+            new UTF8Encoding(false),
+            encoding,
+            new ConversionOptions { WriteBom = true },
+            progress: null,
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(ConversionErrorCode.BomMismatch, result.ErrorCode);
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+    }
+
+    // GB18030 is deliberately absent: unlike the others it maps the whole Unicode range,
+    // so an emoji is representable and conversion correctly succeeds. See
+    // Gb18030_CoversTheFullUnicodeRange below.
+    public static IEnumerable<object[]> UnicodeIncompleteCases() =>
+        MultibyteCases().Where(c => (string)c[0] != "gb18030");
+
+    [Theory]
+    [MemberData(nameof(UnicodeIncompleteCases))]
+    public void UnrepresentableContent_IsRejectedRatherThanSubstituted(
+        string charset,
+        string text)
+    {
+        _ = text;
+
+        // These code pages cannot represent an astral-plane emoji. The encoder must fail
+        // rather than silently writing '?' - the substitution the hash check exists to catch.
+        string path = Path.Combine(_root, $"{charset}_unmappable.txt");
+        File.WriteAllText(path, "before 🌍 after", new UTF8Encoding(false));
+        byte[] originalBytes = File.ReadAllBytes(path);
+
+        ConversionReportEntry result = Convert(
+            Entry(path, "utf-8"), charset, targetWriteBom: false);
+
+        Assert.Equal(ConversionRowResult.Error, result.Result);
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void Gb18030_CoversTheFullUnicodeRange()
+    {
+        // GB18030 is the one legacy code page here that is Unicode-complete, so content
+        // the others reject converts cleanly and round-trips exactly.
+        const string text = "汉字 with emoji 🌍 and 𠜎 supplementary\r\n";
+
+        string path = Path.Combine(_root, "gb18030_full_unicode.txt");
+        File.WriteAllText(path, text, new UTF8Encoding(false));
+
+        ConversionReportEntry entry = Entry(path, "utf-8");
+
+        Assert.Equal(ConversionRowResult.Converted, Convert(entry, "gb18030", false).Result);
+        Assert.Equal(text, Encoding.GetEncoding("gb18030").GetString(File.ReadAllBytes(path)));
+
+        Assert.Equal(ConversionRowResult.Converted, Convert(entry, "utf-8", false).Result);
+        Assert.Equal(text, new UTF8Encoding(false).GetString(File.ReadAllBytes(path)));
+    }
+}

--- a/sources/EncodingChecker.Tests/ReadOnlyPreservationMatrixTests.cs
+++ b/sources/EncodingChecker.Tests/ReadOnlyPreservationMatrixTests.cs
@@ -1,0 +1,187 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// The destination's ReadOnly attribute is cleared so replacement can proceed and must be
+/// put back afterwards. Restoration used to be guarded by !sameFile, which is only safe
+/// while the temp file arrives already carrying the original attributes - something
+/// PreserveAttributes = false skips, silently dropping ReadOnly.
+///
+/// Targets EncodingConverter directly: the product always leaves PreserveAttributes at
+/// its default, so the defect is reachable only through the library API.
+/// </summary>
+public sealed class ReadOnlyPreservationMatrixTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_readonly_matrix_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            foreach (string file in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+                File.SetAttributes(file, FileAttributes.Normal);
+
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string WriteFile(string name, string content, bool readOnly)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllText(path, content, new UTF8Encoding(false));
+
+        if (readOnly)
+            File.SetAttributes(path, FileAttributes.ReadOnly);
+
+        return path;
+    }
+
+    private static ConversionResult Convert(
+        string sourcePath,
+        string destinationPath,
+        bool preserveAttributes) =>
+        EncodingConverter.Convert(
+            sourcePath,
+            destinationPath,
+            new UTF8Encoding(false),
+            new UnicodeEncoding(false, false),
+            new ConversionOptions
+            {
+                WriteBom = false,
+                PreserveAttributes = preserveAttributes,
+            },
+            progress: null,
+            CancellationToken.None);
+
+    // ---- same-file replacement ----
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SameFile_ReadOnly_StaysReadOnly_RegardlessOfPreserveAttributes(
+        bool preserveAttributes)
+    {
+        // The regression: with preserveAttributes false the temp carries no ReadOnly and
+        // the !sameFile guard skipped restoration, so the bit vanished.
+        string path = WriteFile(
+            $"same_ro_{preserveAttributes}.txt", "café content", readOnly: true);
+
+        ConversionResult result = Convert(path, path, preserveAttributes);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.True(
+            File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly),
+            "ReadOnly must survive a same-file conversion.");
+
+        Assert.Equal(
+            "café content",
+            new UnicodeEncoding(false, false).GetString(File.ReadAllBytes(path)));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SameFile_NotReadOnly_StaysWritable(bool preserveAttributes)
+    {
+        string path = WriteFile(
+            $"same_rw_{preserveAttributes}.txt", "plain content", readOnly: false);
+
+        ConversionResult result = Convert(path, path, preserveAttributes);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.False(File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly));
+    }
+
+    // ---- different destination ----
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DifferentDestination_ReadOnlyDestination_StaysReadOnly(
+        bool preserveAttributes)
+    {
+        string source = WriteFile(
+            $"src_{preserveAttributes}.txt", "source content", readOnly: false);
+
+        string destination = WriteFile(
+            $"dst_ro_{preserveAttributes}.txt", "old destination", readOnly: true);
+
+        ConversionResult result = Convert(source, destination, preserveAttributes);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.True(File.GetAttributes(destination).HasFlag(FileAttributes.ReadOnly));
+
+        Assert.Equal(
+            "source content",
+            new UnicodeEncoding(false, false).GetString(File.ReadAllBytes(destination)));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DifferentDestination_WritableDestination_StaysWritable(
+        bool preserveAttributes)
+    {
+        string source = WriteFile(
+            $"src2_{preserveAttributes}.txt", "source content", readOnly: false);
+
+        string destination = WriteFile(
+            $"dst_rw_{preserveAttributes}.txt", "old destination", readOnly: false);
+
+        ConversionResult result = Convert(source, destination, preserveAttributes);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.False(File.GetAttributes(destination).HasFlag(FileAttributes.ReadOnly));
+    }
+
+    // ---- failure path ----
+
+    [Fact]
+    public void FailedConversion_LeavesTheReadOnlyDestinationUntouched()
+    {
+        // Cyrillic cannot be represented in windows-1252, so verification rejects the
+        // write and nothing is installed.
+        string path = Path.Combine(_root, "unmappable.txt");
+        File.WriteAllText(path, "Привет", new UTF8Encoding(false));
+        byte[] originalBytes = File.ReadAllBytes(path);
+        File.SetAttributes(path, FileAttributes.ReadOnly);
+
+        ConversionResult result = EncodingConverter.Convert(
+            path, path,
+            new UTF8Encoding(false),
+            Encoding.GetEncoding("windows-1252"),
+            new ConversionOptions { WriteBom = false },
+            progress: null,
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.True(
+            File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly),
+            "A failed conversion must not strip ReadOnly from the original.");
+
+        Assert.Equal(originalBytes, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void SameFile_PreserveAttributesFalse_DoesNotResurrectUnrelatedAttributes()
+    {
+        // Restoration puts back exactly the destination's captured attribute set; a file
+        // that was never Hidden must not become Hidden.
+        string path = WriteFile("same_plain.txt", "content here", readOnly: true);
+
+        ConversionResult result = Convert(path, path, preserveAttributes: false);
+
+        Assert.True(result.Success, result.ErrorMessage);
+
+        FileAttributes attributes = File.GetAttributes(path);
+        Assert.True(attributes.HasFlag(FileAttributes.ReadOnly));
+        Assert.False(attributes.HasFlag(FileAttributes.Hidden));
+        Assert.False(attributes.HasFlag(FileAttributes.System));
+    }
+}

--- a/sources/EncodingChecker.Tests/Utf32PrefilterTests.cs
+++ b/sources/EncodingChecker.Tests/Utf32PrefilterTests.cs
@@ -1,0 +1,149 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// CheckUtf32's structural prefilter runs before CheckUtf16, so BOM-less UTF-16 reaches it
+/// first. Testing only the most significant byte left an ASCII-range UTF-16 buffer looking
+/// like a live UTF-32 candidate for its whole length, paying a full strict UTF-32 decode
+/// before IsValidText rejected it. Bounding the next byte by 0x10 - the ceiling implied by
+/// U+10FFFF - rejects it on the first code unit instead.
+///
+/// This is a prefilter optimisation, not a correctness fix: invalid UTF-32 was already
+/// rejected downstream, and still is. Surrogates in particular are unaffected by the added
+/// test and continue to rely on IsValidText.
+/// </summary>
+public sealed class Utf32PrefilterTests
+{
+    private static byte[] Encode(bool bigEndian, string text) =>
+        new UTF32Encoding(bigEndian, byteOrderMark: false).GetBytes(text);
+
+    private static byte[] RawLittleEndian(params uint[] scalars)
+    {
+        var bytes = new byte[scalars.Length * 4];
+
+        for (int i = 0; i < scalars.Length; i++)
+            BitConverter.GetBytes(scalars[i]).CopyTo(bytes, i * 4);
+
+        return bytes;
+    }
+
+    private static string Repeat(string s, int times) =>
+        string.Concat(Enumerable.Repeat(s, times));
+
+    // ---- valid UTF-32 must still be detected ----
+
+    [Theory]
+    [InlineData(false, "utf-32")]
+    [InlineData(true, "utf-32BE")]
+    public void AsciiText_IsStillDetected(bool bigEndian, string expected)
+    {
+        byte[] bytes = Encode(bigEndian, Repeat("Hello, World! ", 8));
+
+        Assert.Equal(expected, TextEncoding.DetectFromBuffer(bytes)?.WebName);
+    }
+
+    [Theory]
+    [InlineData(false, "utf-32")]
+    [InlineData(true, "utf-32BE")]
+    public void CjkText_IsStillDetected(bool bigEndian, string expected)
+    {
+        byte[] bytes = Encode(bigEndian, Repeat("東京都渋谷区 ", 8));
+
+        Assert.Equal(expected, TextEncoding.DetectFromBuffer(bytes)?.WebName);
+    }
+
+    [Theory]
+    [InlineData(false, "utf-32")]
+    [InlineData(true, "utf-32BE")]
+    public void SupplementaryPlaneText_IsStillDetected(bool bigEndian, string expected)
+    {
+        // Emoji sit above U+FFFF, so the byte the new test inspects is non-zero here -
+        // the case most at risk of being rejected by an over-eager bound.
+        byte[] bytes = Encode(bigEndian, Repeat("🌍🎉𠜎 ", 8));
+
+        Assert.Equal(expected, TextEncoding.DetectFromBuffer(bytes)?.WebName);
+    }
+
+    [Fact]
+    public void TheExactUpperBoundScalar_IsStillAccepted()
+    {
+        // U+10FFFF puts 0x10 in the tested byte: the boundary the comparison must not
+        // exclude. Padded with ASCII so LooksLikeText sees ordinary text either side.
+        uint[] scalars =
+        [
+            .. Enumerable.Repeat((uint)'a', 20),
+            0x10FFFF,
+            .. Enumerable.Repeat((uint)'b', 20),
+        ];
+
+        Assert.Equal("utf-32", TextEncoding.DetectFromBuffer(RawLittleEndian(scalars))?.WebName);
+    }
+
+    [Fact]
+    public void OneAboveTheUpperBound_IsRejected()
+    {
+        uint[] scalars =
+        [
+            .. Enumerable.Repeat((uint)'a', 20),
+            0x110000,
+            .. Enumerable.Repeat((uint)'b', 20),
+        ];
+
+        Assert.NotEqual("utf-32", TextEncoding.DetectFromBuffer(RawLittleEndian(scalars))?.WebName);
+    }
+
+    // ---- UTF-16 must not be mistaken for a UTF-32 candidate ----
+
+    [Theory]
+    [InlineData(false, "utf-16")]
+    [InlineData(true, "utf-16BE")]
+    public void Utf16Text_IsDetectedAsUtf16NotUtf32(bool bigEndian, string expected)
+    {
+        // The motivating case: ASCII-range UTF-16 has a zero in every other byte, which
+        // the most-significant-byte test alone could not rule out.
+        byte[] bytes = new UnicodeEncoding(bigEndian, byteOrderMark: false)
+            .GetBytes(Repeat("Hello, World! ", 40));
+
+        Assert.Equal(expected, TextEncoding.DetectFromBuffer(bytes)?.WebName);
+    }
+
+    // ---- invalid scalars stay rejected by the authoritative stage ----
+
+    [Theory]
+    [InlineData(0xD800u)]
+    [InlineData(0xDFFFu)]
+    public void SurrogateScalars_AreStillRejected(uint surrogate)
+    {
+        // Not rejected by the prefilter - the tested byte is zero for these - so this
+        // pins that IsValidText still catches them.
+        uint[] scalars =
+        [
+            .. Enumerable.Repeat((uint)'a', 20),
+            surrogate,
+            .. Enumerable.Repeat((uint)'b', 20),
+        ];
+
+        Assert.NotEqual("utf-32", TextEncoding.DetectFromBuffer(RawLittleEndian(scalars))?.WebName);
+    }
+
+    [Fact]
+    public void AllSurrogates_AreRejected()
+    {
+        byte[] bytes = RawLittleEndian([.. Enumerable.Repeat(0xD800u, 40)]);
+
+        Assert.Null(TextEncoding.DetectFromBuffer(bytes));
+    }
+
+    [Fact]
+    public void BomPrefixedUtf32_IsUnaffectedByThePrefilter()
+    {
+        // BOM detection happens before the structural scan and must keep winning.
+        byte[] bytes = new UTF32Encoding(bigEndian: false, byteOrderMark: true)
+            .GetPreamble()
+            .Concat(Encode(false, Repeat("Hello ", 8)))
+            .ToArray();
+
+        Assert.Equal("utf-32", TextEncoding.DetectFromBuffer(bytes)?.WebName);
+    }
+}

--- a/sources/EncodingChecker/EncodingConverter.cs
+++ b/sources/EncodingChecker/EncodingConverter.cs
@@ -1211,14 +1211,27 @@ internal static class EncodingConverter
 
             replacementCommitted = true;
 
-            // For a different destination, restore its original ReadOnly state.
-            if (!sameFile && clearedAttributes is not null)
+            // Restore the destination's original ReadOnly state when the installed file
+            // does not already carry it.
+            //
+            // For a different destination it never does, so this always applies, as
+            // before. For a same-file replacement the temp normally arrives holding the
+            // original attributes - but only because they were applied to it before
+            // installation, which PreserveAttributes = false skips. Keying off the
+            // installed file's actual state rather than sameFile alone stops ReadOnly
+            // being dropped silently in that combination.
+            if (clearedAttributes is not null)
             {
                 try
                 {
-                    File.SetAttributes(
-                        destinationPath,
-                        clearedAttributes.Value);
+                    if (!sameFile ||
+                        !File.GetAttributes(destinationPath)
+                            .HasFlag(FileAttributes.ReadOnly))
+                    {
+                        File.SetAttributes(
+                            destinationPath,
+                            clearedAttributes.Value);
+                    }
                 }
                 catch (Exception ex) when (
                     ex is IOException or UnauthorizedAccessException
@@ -1305,10 +1318,61 @@ internal static class EncodingConverter
         {
             ReplaceOrMove(tempPath, destinationPath, destinationExists);
         }
-        finally
+        catch (Exception replaceEx) when (
+            replaceEx is IOException or UnauthorizedAccessException
+                or ArgumentException or NotSupportedException)
         {
-            if (clearedAttributes is not null && File.Exists(destinationPath))
+            // The replacement failure is the real error. Restoring ReadOnly from a plain
+            // finally would let a failing SetAttributes throw over it, reporting an
+            // attribute problem instead of why the backup actually failed - so the
+            // rollback is attempted here and only ever added as context, matching
+            // AtomicReplace's handling of the same situation.
+            string? rollbackError = TryRestoreReadOnly(destinationPath, clearedAttributes);
+
+            if (rollbackError is null)
+                throw;
+
+            throw new IOException(
+                $"{replaceEx.Message} The original ReadOnly attribute could also not " +
+                $"be restored: {rollbackError}",
+                replaceEx);
+        }
+
+        // Replacement succeeded; a restoration failure here is itself the primary error.
+        string? restoreError = TryRestoreReadOnly(destinationPath, clearedAttributes);
+
+        if (restoreError is not null)
+        {
+            throw new IOException(
+                $"The backup was written, but the original ReadOnly attribute could " +
+                $"not be restored: {restoreError}");
+        }
+    }
+
+
+    /// <summary>
+    /// Restores previously cleared attributes, returning the failure message instead of
+    /// throwing so a caller can decide whether it outranks an error already in flight.
+    /// </summary>
+    private static string? TryRestoreReadOnly(
+        string destinationPath,
+        FileAttributes? clearedAttributes)
+    {
+        if (clearedAttributes is null)
+            return null;
+
+        try
+        {
+            if (File.Exists(destinationPath))
                 File.SetAttributes(destinationPath, clearedAttributes.Value);
+
+            return null;
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException
+                or ArgumentException or NotSupportedException)
+        {
+            return ex.Message;
         }
     }
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -117,8 +117,8 @@ internal static class Program
 
           EncodingChecker.exe
               -BasePath <directory>
-              [-Include "<pattern1,pattern2,...>"]
-              [-Exclude "<pattern1,pattern2,...>"]
+              [-Include "<pattern1,pattern2,...>"]   # repeatable; patterns accumulate
+              [-Exclude "<pattern1,pattern2,...>"]   # repeatable; patterns accumulate
                    Wildcard patterns. A pattern with no "/" or "\"
                    matches just the filename, at any depth. One
                    containing a separator matches the path relative
@@ -140,7 +140,7 @@ internal static class Program
                    Validate without writing anything. Files whose current
                    encoding isn't in this list are reported as Invalid.
                    May be combined with -FailOnChanges. Cannot be
-                   combined with -DetectOnly.
+                   combined with -DetectOnly or -Target.
               [-DetectOnly]
                    Read-only detection mode. Writes
                    File,Encoding,BOM,Target,TargetBOM,Result CSV rows to
@@ -439,7 +439,9 @@ internal static class Program
                         error = "-Include requires a value.";
                         return false;
                     }
-                    options.Include = SplitCommaList(include);
+                    // Accumulate: repeating the option used to discard the earlier
+                    // patterns silently, so only the last one took effect.
+                    options.Include.AddRange(SplitCommaList(include));
                     break;
 
                 case "exclude":
@@ -451,7 +453,9 @@ internal static class Program
                         error = "-Exclude requires a value.";
                         return false;
                     }
-                    options.Exclude = SplitCommaList(exclude);
+                    // Accumulates for the same reason as -Include, keeping the two
+                    // options consistent with each other.
+                    options.Exclude.AddRange(SplitCommaList(exclude));
                     break;
 
                 case "target":
@@ -614,6 +618,20 @@ internal static class Program
         {
             error =
                 "-DetectOnly cannot be combined with -Validate.";
+            return false;
+        }
+
+        // Validate and Convert are separate modes. Accepting both silently ran Validate
+        // and ignored -Target, so a caller expecting files to be converted was told
+        // nothing while nothing was converted.
+        if (options is
+            {
+                ValidateCharsets: not null,
+                Target: not null
+            })
+        {
+            error =
+                "-Validate cannot be combined with -Target.";
             return false;
         }
 

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -85,8 +85,9 @@ internal static class ScanEngine
 
     /// <summary>
     /// Scans the base directory and processes matching files with bounded parallelism.
-    /// Skips excluded directories, reparse points, the tool's own backup/temp files,
-    /// and likely binary files.
+    /// Traversal skips excluded directories, reparse points, and the tool's own
+    /// backup/temp files. Likely binary files are not filtered here: they are rejected
+    /// later, during encoding detection, and reported as Skipped.
     /// </summary>
     /// <remarks>
     /// <paramref name="onEntry"/> is invoked concurrently from worker threads; callers

--- a/sources/EncodingChecker/UnicodeDetector.cs
+++ b/sources/EncodingChecker/UnicodeDetector.cs
@@ -241,16 +241,32 @@ internal static class UnicodeDetector
         bool leCandidate = true;
 
         //
-        // For valid Unicode scalar values (U+0000..U+10FFFF), the most
-        // significant UTF-32 byte is always zero.
+        // For valid Unicode scalar values (U+0000..U+10FFFF), the most significant
+        // UTF-32 byte is always zero and the next one never exceeds 0x10.
+        //
+        // Testing both bounds matters because CheckUtf32 runs before CheckUtf16: in
+        // ASCII-range UTF-16 every other byte is zero, so the most-significant-byte test
+        // alone leaves a candidate alive for the whole buffer and pays a full strict
+        // UTF-32 decode before IsValidText rejects it. The second byte fails on the first
+        // code unit instead.
+        //
+        // This bounds the scalar range only. Surrogates (U+D800..U+DFFF) have a zero in
+        // this position and still reach IsValidText, which remains the authoritative
+        // validation stage.
         //
         for (int i = 0; i < buffer.Length; i += 4)
         {
-            if (beCandidate && buffer[i] != 0)
+            if (beCandidate &&
+                (buffer[i] != 0 || buffer[i + 1] > 0x10))
+            {
                 beCandidate = false;
+            }
 
-            if (leCandidate && buffer[i + 3] != 0)
+            if (leCandidate &&
+                (buffer[i + 3] != 0 || buffer[i + 2] > 0x10))
+            {
                 leCandidate = false;
+            }
 
             // Early rejection if neither byte order is plausible.
             if (!beCandidate && !leCandidate)


### PR DESCRIPTION
Implements the verified items from the audit verification queue. Four commits, one per group.

Deliberately excludes the Private Use Area false negative (#5), which is being handled separately.

## 1. Backup exception masking (confirmed bug)

`AtomicReplaceForBackup` restored the destination's ReadOnly attribute from a bare `finally`. If the replacement threw and `SetAttributes` then threw too, the second exception replaced the first, so the caller was told about an attribute problem instead of why the backup actually failed. The rollback now runs in a `catch` and is only ever added as context, matching how `AtomicReplace` already handles the same situation one method away.

**Honest scope note:** the five new tests pin the observable contract but do **not** exercise the masking branch itself. That needs the replacement *and* the rollback to fail together, which the filesystem will not produce: `SetAttributes` succeeds on a locked file, silently ignores unsettable attributes, and any ACL denying the rollback also denies the initial clear, which happens earlier and outside the `try`. Both were tested and ruled out. Forcing it needs an injection seam in production code, which this plan excludes, so the branch is covered by inspection against its sibling. The test file's summary records this so a future reader is not misled.

## 2. ReadOnly + PreserveAttributes=false (confirmed latent bug)

Restoration was guarded by `!sameFile`, which is only safe while attributes are applied to the temp before installation — a step `PreserveAttributes = false` skips, so a same-file replacement dropped ReadOnly silently. Restoration now keys off whether the installed file actually carries the attribute.

Latent: `ScanEngine` builds the only `ConversionOptions` in the product and leaves the default, so neither CLI nor GUI could reach it. **Two of the new matrix cases fail against the previous guard.**

## 3. CLI silent-input issues (confirmed risks)

- `-Validate` with `-Target` ran Validate and silently ignored `-Target`. Now rejected during validation, matching `-DetectOnly` + `-Validate`. The README already called the modes mutually exclusive; the code now enforces it.
- Repeated `-Include` overwrote the previous value. Both `-Include` and `-Exclude` now accumulate. Comma form unchanged; an unsupplied option still leaves an empty list.

**Four of the ten new tests fail against the previous behaviour.** Usage text updated for both.

## 4. Multibyte round-trip coverage (test gap)

`EncodingConversionMatrixTests` is entirely Unicode — it had **zero** legacy multibyte cases despite all five being in the supported set. One representative structural case per family (Shift-JIS, GB18030, Big5, EUC-JP, EUC-KR) with real script content: legacy→utf-8 with BOM, a byte-identical round trip, idempotence, BOM rejection where there is no preamble, and a fixture guard that each sample is genuinely representable in its own encoding.

Turned up something worth recording: **GB18030 is Unicode-complete**, so an emoji converts cleanly there while the other four correctly reject it. It gets its own test rather than being quietly excluded.

## 5. UTF-32 prefilter (measured optimisation)

`CheckUtf32` runs before `CheckUtf16`, and ASCII-range UTF-16 has a zero in every other byte, so it stayed a live UTF-32 candidate for the whole buffer and paid a full strict decode before rejection. Bounding the next byte by `0x10` rejects it on the first code unit.

```
64 KiB UTF-16LE, prefilter scan   16,384 code units -> 1
full detection, 2000 iterations   182 ms -> 146 ms
valid UTF-32 path                 +7 ms / 2000 iterations (~3% of the decode that dominates it)
```

Not a correctness fix — invalid UTF-32 was already rejected downstream and still is. **Surrogates have a zero in the tested byte and are unaffected**, so they continue to rely on `IsValidText`; the tests pin that explicitly so the change is not mistaken for closing that gap.

## 6. Documentation correction

`ScanEngine.ScanDirectory`'s summary claimed traversal skips "likely binary files". There is no binary filter in `DirectoryTraversal` — binary content is rejected later during detection and reported as `Skipped`.

## Verification

- `dotnet build EncodingChecker.sln -c Release`: 0 warnings, 0 errors.
- Full suite run twice: **278 passed, 0 failed** both times (209 before, +69).
- Focused runs: 69 passed across the five new files.
- Regression areas (backup, CSV, cancellation, preview, conversion matrix, stale state, exit codes): 80 passed.
- Real CLI: CSV header unchanged, convert+backup produces `.bak` at both depths, exit codes 0/1/2 intact, Preview leaves the file byte-identical.

Every fix was verified by reverting it and confirming the new tests fail — except the backup masking branch, for the reason given above.

## Not done

PUA (#5) untouched, as instructed. No redesign of conversion, verification, backup, atomic replacement, cancellation, detectors or ScanEngine. No interfaces, strategies, or DI. CSV schema and GUI behaviour unchanged.

Generated with [Claude Code](https://claude.com/claude-code)
