### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.3.1
+# EncodingChecker v3.4.0
 
 File Encoding Checker detects, validates, and converts the text encoding of one or more files. It runs either as a Windows GUI app or as a command-line tool for scripting and CI, and shares one detection/conversion engine between both.
 
@@ -33,8 +33,8 @@ Launch `EncodingChecker.exe` with arguments to run in console mode instead. Run 
 ```
 EncodingChecker.exe
     -BasePath <directory>
-    [-Include "<pattern1,pattern2,...>"]
-    [-Exclude "<pattern1,pattern2,...>"]
+    [-Include "<pattern1,pattern2,...>"]   # repeatable; patterns accumulate
+    [-Exclude "<pattern1,pattern2,...>"]   # repeatable; patterns accumulate
 
     -Target "<encoding>"          # Convert mode (default); e.g. "utf-8" or "utf-8-bom"
     -Validate "<charset1,...>"    # Validate mode: flag files not in this list
@@ -51,7 +51,7 @@ EncodingChecker.exe
                                    # -Validate, fails) conversion — useful as a CI gate
 ```
 
-`-Include`/`-Exclude` are comma-separated wildcard patterns. A pattern with no `/` or `\` matches just the filename (e.g. `*.cs` matches at any depth); a pattern containing a separator matches the path relative to `-BasePath` instead (e.g. `src/*.cs` matches only under `src`, `\` and `/` behave the same way). `.git`, `.svn`, `.hg`, `.vs`, `.idea`, `bin`, `obj`, `node_modules`, `packages`, `dist`, `build`, and `target` directories are always skipped. Convert, Validate, and Detect-only are mutually exclusive modes.
+`-Include`/`-Exclude` are comma-separated wildcard patterns, and both options may be repeated — patterns from every occurrence accumulate, so `-Include "*.cs" -Include "*.txt"` is equivalent to `-Include "*.cs,*.txt"`. A pattern with no `/` or `\` matches just the filename (e.g. `*.cs` matches at any depth); a pattern containing a separator matches the path relative to `-BasePath` instead (e.g. `src/*.cs` matches only under `src`, `\` and `/` behave the same way). `.git`, `.svn`, `.hg`, `.vs`, `.idea`, `bin`, `obj`, `node_modules`, `packages`, `dist`, `build`, and `target` directories are always skipped. Convert, Validate, and Detect-only are mutually exclusive modes.
 
 `-Backup` only ever writes a `.bak` when a real conversion happens: a file that already matches the target is left alone, and under `-WhatIf` nothing is written at all, so no backup is created.
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -111,7 +111,7 @@ internal static class Program
     }
 
     private const string UsageText = """
-        EncodingChecker v3.3.1
+        EncodingChecker v3.4.0
 
         Usage:
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.3.1.0")]
-[assembly: AssemblyFileVersion("3.3.1.0")]
+[assembly: AssemblyVersion("3.4.0.0")]
+[assembly: AssemblyFileVersion("3.4.0.0")]


### PR DESCRIPTION
Version bump for the audit-queue hardening merged in #29.

**Minor, not patch** — this release changes CLI behaviour, not just fixes:

- `-Validate` combined with `-Target` is now rejected instead of silently running Validate and ignoring `-Target`.
- Repeated `-Include`/`-Exclude` accumulate instead of the last occurrence winning.

Both are breaking for a script that relied on the old handling, though in each case that script was already getting a result it had not asked for.

**Not major**: neither combination ever did what the caller intended, so these read as fixes to behaviour rather than a change of contract. CSV schema and exit codes are unchanged.

Files: `AssemblyInfo.cs`, `Program.cs` usage header, README heading, plus README documentation of the repeatable pattern options to match the usage text.

Verified: Release build clean (0 warnings), 278 tests passing, `-?` reports `EncodingChecker v3.4.0`.

Generated with [Claude Code](https://claude.com/claude-code)
