### PR TITLE
Stop rejecting text over a single private-use character

### DIFF
--- a/sources/EncodingChecker.Tests/PrivateUseAreaDetectionTests.cs
+++ b/sources/EncodingChecker.Tests/PrivateUseAreaDetectionTests.cs
@@ -1,0 +1,173 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// LooksLikeText used to return false on the first private-use scalar, so one icon-font
+/// glyph made an entire file undetectable - reported (Unknown) and skipped, never
+/// converted. It also did so inconsistently: only the first 500 scalars are examined, so
+/// the same character further into the file was accepted.
+///
+/// Private-use scalars are now excluded from the printable ratio like control characters,
+/// which keeps the binary evidence (a buffer that is largely private-use still fails)
+/// without rejecting ordinary text over a single character.
+/// </summary>
+public sealed class PrivateUseAreaDetectionTests
+{
+    // U+F015 is the Font Awesome "home" glyph; U+E000 is the first private-use scalar.
+    private const string HomeIcon = "";
+    private const string FirstPua = "";
+
+    private static string? Detect(string text, Encoding encoding) =>
+        TextEncoding.DetectFromBuffer(encoding.GetBytes(text))?.WebName;
+
+    private static string Repeat(string s, int times) =>
+        string.Concat(Enumerable.Repeat(s, times));
+
+    public static IEnumerable<object[]> Encodings() =>
+    [
+        [new UTF8Encoding(false), "utf-8"],
+        [new UnicodeEncoding(false, false), "utf-16"],
+    ];
+
+    [Theory]
+    [MemberData(nameof(Encodings))]
+    public void IconFontMarkup_IsDetected(Encoding encoding, string expected)
+    {
+        // The reported case: markup carrying icon glyphs was skipped entirely.
+        string markup =
+            $"<nav class=\"menu\">\n" +
+            $"  <i class=\"icon\">{HomeIcon}</i> Home\n" +
+            $"  <i class=\"icon\"></i> Profile\n" +
+            $"  <i class=\"icon\"></i> Save\n" +
+            $"</nav>\n";
+
+        Assert.Equal(expected, Detect(markup, encoding));
+    }
+
+    [Theory]
+    [MemberData(nameof(Encodings))]
+    public void OnePrivateUseScalarInOrdinaryText_IsDetected(Encoding encoding, string expected)
+    {
+        string text =
+            $"A perfectly ordinary sentence with one {FirstPua} private-use character in it. " +
+            "Followed by more ordinary prose so the sample is comfortably text-like.";
+
+        Assert.Equal(expected, Detect(text, encoding));
+    }
+
+    [Fact]
+    public void PositionOfThePrivateUseScalar_NoLongerChangesTheOutcome()
+    {
+        // The old behaviour depended on whether the scalar fell inside the 500-rune
+        // sampling window, so identical content detected or not based on placement.
+        string early = HomeIcon + Repeat("ordinary text ", 60);
+        string late = Repeat("ordinary text ", 60) + HomeIcon;
+
+        var utf8 = new UTF8Encoding(false);
+
+        Assert.Equal("utf-8", Detect(early, utf8));
+        Assert.Equal("utf-8", Detect(late, utf8));
+        Assert.Equal(Detect(early, utf8), Detect(late, utf8));
+    }
+
+    [Fact]
+    public void MostlyPrivateUseContent_IsStillRejected()
+    {
+        // The binary evidence the check exists to find must survive the change.
+        Assert.Null(TextEncoding.DetectFromBuffer(
+            new UTF8Encoding(false).GetBytes(Repeat(FirstPua, 400))));
+    }
+
+    [Fact]
+    public void PrivateUseUpToTheThreshold_IsAccepted()
+    {
+        // 50 private-use scalars in 500 leaves a printable ratio of exactly 0.90, the
+        // minimum the validator accepts.
+        string text = Repeat(FirstPua + Repeat("a", 9), 50);
+
+        Assert.Equal(500, text.EnumerateRunes().Count());
+        Assert.Equal("utf-8", Detect(text, new UTF8Encoding(false)));
+    }
+
+    [Fact]
+    public void PrivateUsePastTheThreshold_IsRejected()
+    {
+        // One in four is well past 10% non-printable.
+        string text = Repeat(FirstPua + "abc", 200);
+
+        Assert.Null(TextEncoding.DetectFromBuffer(
+            new UTF8Encoding(false).GetBytes(text)));
+    }
+
+    [Fact]
+    public void PrivateUseAndControlCharacters_ShareTheSameBudget()
+    {
+        // Both are excluded from the printable count, so they accumulate against one
+        // threshold rather than each getting their own allowance.
+        string text = Repeat(FirstPua + "" + Repeat("a", 8), 50);
+
+        Assert.Null(TextEncoding.DetectFromBuffer(
+            new UTF8Encoding(false).GetBytes(text)));
+    }
+
+    [Fact]
+    public void PrivateUseText_ConvertsRatherThanBeingSkipped()
+    {
+        // End to end: the practical consequence of the old behaviour was that these
+        // files could never be converted at all.
+        string root = Directory.CreateTempSubdirectory("ec_pua_convert_").FullName;
+
+        try
+        {
+            string path = Path.Combine(root, "icons.html");
+            string content = $"<i class=\"icon\">{HomeIcon}</i> Home\n";
+            File.WriteAllText(path, content, new UTF8Encoding(false));
+
+            var options = new ScanDirectoryOptions
+            {
+                BaseDirectory = root,
+                IncludePatterns = ["*.html"],
+                Action = ScanAction.Convert,
+                TargetCharset = "utf-8",
+                TargetWriteBom = true,
+            };
+
+            var entries = new List<ConversionReportEntry>();
+            ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
+
+            ConversionReportEntry entry = Assert.Single(entries);
+            Assert.Equal(ConversionRowResult.Converted, entry.Result);
+            Assert.Equal("utf-8", entry.SourceEncoding);
+
+            byte[] converted = File.ReadAllBytes(path);
+            Assert.Equal([0xEF, 0xBB, 0xBF], converted[..3]);
+            Assert.Equal(content, new UTF8Encoding(true).GetString(converted[3..]));
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch (IOException) { }
+        }
+    }
+
+    [Fact]
+    public void BinaryLikeBuffers_AreStillRejected()
+    {
+        // Guards the trade directly: relaxing the private-use rule must not let
+        // binary through. Real PE/PNG/TTF files are covered by the corpus run; these
+        // are the synthetic shapes closest to the relaxed rule.
+        var random = new Random(4242);
+
+        byte[] randomBytes = new byte[4096];
+        random.NextBytes(randomBytes);
+        Assert.Null(TextEncoding.DetectFromBuffer(randomBytes));
+
+        // A UTF-16 buffer that decodes largely into the private-use plane.
+        var puaHeavy = new StringBuilder();
+        for (int i = 0; i < 600; i++)
+            puaHeavy.Append((char)(0xE000 + (i % 0x1800)));
+
+        Assert.Null(TextEncoding.DetectFromBuffer(
+            new UnicodeEncoding(false, false).GetBytes(puaHeavy.ToString())));
+    }
+}

--- a/sources/EncodingChecker/TextValidation.cs
+++ b/sources/EncodingChecker/TextValidation.cs
@@ -152,14 +152,17 @@ internal static class TextValidation
             switch (Rune.GetUnicodeCategory(rune))
             {
                 //
-                // Treat PrivateUse characters as non-text.
+                // Control and private-use characters are excluded from the printable
+                // ratio rather than rejecting the sample outright.
+                //
+                // Rejecting on the first private-use scalar made a whole file
+                // undetectable over one character - icon-font glyphs in markup are the
+                // common case - and did so inconsistently, since only the first 500
+                // scalars are examined, so the same character later in the file was
+                // accepted. Excluding them still rejects a buffer that is largely
+                // private-use, which is the binary evidence the check exists to find.
                 //
                 case UnicodeCategory.PrivateUse:
-                    return false;
-
-                //
-                // Control characters are excluded from the printable ratio.
-                //
                 case UnicodeCategory.Control:
                     break;
 


### PR DESCRIPTION
Closes the last open item from the audit verification queue (#5), the only confirmed bug with a user-visible consequence on ordinary content.

## The bug

`LooksLikeText` returned `false` on the first `UnicodeCategory.PrivateUse` scalar. Because `IsValidText` gates the **Unicode** path as well as the legacy one, a UTF-8 or UTF-16 file containing a single icon-font glyph was reported `(Unknown)` and skipped entirely — never detected, never converted.

It was also inconsistent: only the first 500 scalars are examined, so the same character further into the file was accepted. Identical content passed or failed depending on where the character sat.

## The fix

Private-use scalars are excluded from the printable ratio like control characters, sharing one budget with them. A buffer that is largely private-use still fails — that is the binary evidence the check exists to find — but ordinary text carrying a few such characters is no longer thrown away.

This is the option chosen from the three the verification laid out. It is a one-line change to the `switch`, keeps the heuristic intact, and tolerates up to 10% non-printable.

## The trade, verified rather than assumed

Relaxing a binary-rejection rule is the risk here, so the corpus was re-run:

```
14 real binaries -> 14 Skipped
```

PE executables, DLLs, PNG, JPEG, ICO, PDB, and **three TrueType fonts** — fonts being the format that deliberately maps glyphs into the private-use plane, and so the most adversarial real input available. Random buffers and a UTF-16 buffer decoding mostly into the private-use plane are also rejected; both are pinned as tests rather than left to the corpus.

Ordinary text detection is unchanged (ASCII, UTF-8, UTF-8+BOM, multilingual all still detect correctly).

## Tests

Eleven new cases: icon-font markup and a single private-use scalar in both UTF-8 and UTF-16, position-independence, the threshold on both sides, the shared budget with control characters, an end-to-end case proving such a file now converts instead of being skipped, and the binary guards.

**Seven of the eleven fail against the previous behaviour.**

## Verification

- Release build clean, 0 warnings.
- Full suite run twice: **289 passed, 0 failed** (278 before).
- Real CLI: binary corpus 14/14 rejected, text detection unaffected.

Generated with [Claude Code](https://claude.com/claude-code)
