### PR TITLE
Bump version to 3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.4.0
+# EncodingChecker v3.4.1
 
 File Encoding Checker detects, validates, and converts the text encoding of one or more files. It runs either as a Windows GUI app or as a command-line tool for scripting and CI, and shares one detection/conversion engine between both.
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -111,7 +111,7 @@ internal static class Program
     }
 
     private const string UsageText = """
-        EncodingChecker v3.4.0
+        EncodingChecker v3.4.1
 
         Usage:
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.4.0.0")]
-[assembly: AssemblyFileVersion("3.4.0.0")]
+[assembly: AssemblyVersion("3.4.1.0")]
+[assembly: AssemblyFileVersion("3.4.1.0")]


### PR DESCRIPTION
Patch release for the private-use detection fix in #31.

A file carrying a single icon-font glyph was reported `(Unknown)` and skipped rather than converted, so this is worth shipping on its own rather than waiting for the next change.

No interface change: CSV schema, exit codes and CLI options are unchanged from 3.4.0.

Files: `AssemblyInfo.cs`, `Program.cs` usage header, README heading.

Verified: Release build clean, 289 tests passing, `-?` reports `EncodingChecker v3.4.1`.

Generated with [Claude Code](https://claude.com/claude-code)
