### PR TITLE
Guard the private-use test fixtures against silent mangling

### DIFF
--- a/sources/EncodingChecker.Tests/PrivateUseAreaDetectionTests.cs
+++ b/sources/EncodingChecker.Tests/PrivateUseAreaDetectionTests.cs
@@ -14,9 +14,14 @@ namespace EncodingChecker.Tests;
 /// </summary>
 public sealed class PrivateUseAreaDetectionTests
 {
-    // U+F015 is the Font Awesome "home" glyph; U+E000 is the first private-use scalar.
-    private const string HomeIcon = "";
-    private const string FirstPua = "";
+    // Private-use characters render as nothing and have been silently emptied by
+    // file-editing tools in this repository before. TheFixtureConstantsAreActuallyPrivateUse
+    // below fails loudly if that happens, rather than leaving these tests asserting
+    // against ordinary text.
+    private const string HomeIcon = "";     // Font Awesome "home"
+    private const string ProfileIcon = "";
+    private const string SaveIcon = "";
+    private const string FirstPua = "";     // first private-use scalar
 
     private static string? Detect(string text, Encoding encoding) =>
         TextEncoding.DetectFromBuffer(encoding.GetBytes(text))?.WebName;
@@ -30,17 +35,34 @@ public sealed class PrivateUseAreaDetectionTests
         [new UnicodeEncoding(false, false), "utf-16"],
     ];
 
+    [Fact]
+    public void TheFixtureConstantsAreActuallyPrivateUse()
+    {
+        // If any of these were emptied or flattened to ordinary characters, every test
+        // below would still pass while testing nothing.
+        foreach (string s in new[] { HomeIcon, ProfileIcon, SaveIcon, FirstPua })
+        {
+            Rune rune = Assert.Single(s.EnumerateRunes());
+
+            Assert.Equal(
+                System.Globalization.UnicodeCategory.PrivateUse,
+                Rune.GetUnicodeCategory(rune));
+        }
+    }
+
     [Theory]
     [MemberData(nameof(Encodings))]
     public void IconFontMarkup_IsDetected(Encoding encoding, string expected)
     {
         // The reported case: markup carrying icon glyphs was skipped entirely.
         string markup =
-            $"<nav class=\"menu\">\n" +
-            $"  <i class=\"icon\">{HomeIcon}</i> Home\n" +
-            $"  <i class=\"icon\"></i> Profile\n" +
-            $"  <i class=\"icon\"></i> Save\n" +
-            $"</nav>\n";
+            $"""
+             <nav class="menu">
+               <i class="icon">{HomeIcon}</i> Home
+               <i class="icon">{ProfileIcon}</i> Profile
+               <i class="icon">{SaveIcon}</i> Save
+             </nav>
+             """;
 
         Assert.Equal(expected, Detect(markup, encoding));
     }


### PR DESCRIPTION
Closes the asymmetry noted after LineEndingNormalizer#4: LEN's private-use tests carry a fixture-integrity guard and EncodingChecker's did not.

## Why it matters

Private-use characters render as nothing, and file-editing tools in this repository have emptied them before — not hypothetically. The same constants in LineEndingNormalizer were silently reduced to empty strings while writing the equivalent tests, and **four of them passed against ordinary text** until an unrelated rune-count assertion happened to catch it.

EncodingChecker's constants are currently intact, so its tests are genuine. This makes sure that stays true rather than depending on luck.

## What changed

- `TheFixtureConstantsAreActuallyPrivateUse` asserts each constant is exactly one scalar in `UnicodeCategory.PrivateUse`.
- The two private-use characters that were **inline in the icon-font markup** are now named constants too — a constant-only guard would not have covered them.
- The markup moved to a raw string literal in the same edit, since the escaped form did not survive rewriting.

## Verified, not assumed

Emptied one constant and re-ran:

```
Failed: 1, Passed: 11
```

The guard fails while the other eleven tests **keep passing** — which is precisely the silent degradation it exists to catch. Without it, that mangling goes unnoticed.

## Verification

- Release build clean, 0 warnings.
- Full suite twice: **290 passed, 0 failed** (289 before).

Tests only; no production change, so no version bump — v3.4.1 remains current.

Generated with [Claude Code](https://claude.com/claude-code)
