### PR TITLE
Stop claiming stateful 7-bit encodings as ASCII or UTF-8

### DIFF
--- a/sources/EncodingChecker/TextEncoding.cs
+++ b/sources/EncodingChecker/TextEncoding.cs
@@ -96,7 +96,7 @@ internal static class TextEncoding
         if (!stream.CanSeek)
         {
             throw new ArgumentException(
-                @"The stream must be seekable.",
+                "The stream must be seekable.",
                 nameof(stream));
         }
 

--- a/sources/EncodingChecker/UnicodeDetector.cs
+++ b/sources/EncodingChecker/UnicodeDetector.cs
@@ -4,18 +4,9 @@ using System.Text;
 namespace EncodingChecker;
 
 /// <summary>
-/// Detects Unicode text encodings from raw byte buffers.
-///
-/// Supported encodings:
-/// - ASCII
-/// - UTF-8 (with or without BOM)
-/// - UTF-16 Little Endian (with or without BOM)
-/// - UTF-16 Big Endian (with or without BOM)
-/// - UTF-32 Little Endian (with or without BOM)
-/// - UTF-32 Big Endian (with or without BOM)
-///
-/// BOM-less Unicode encodings are identified using encoding-specific
-/// byte-level heuristics and confirmed using <see cref="TextValidation"/>.
+/// Detects UTF-8, UTF-16, and UTF-32 encodings with or without a BOM.
+/// BOM-less encodings are identified using byte-level heuristics and
+/// validated with <see cref="TextValidation"/>.
 /// </summary>
 internal static class UnicodeDetector
 {
@@ -168,8 +159,8 @@ internal static class UnicodeDetector
 
 
     /// <summary>
-    /// Runs BOM-less Unicode encoding detection in a fixed order:
-    /// UTF-32, UTF-16, ASCII, then UTF-8.
+    /// Detects BOM-less Unicode encodings in this order:
+    /// UTF-32, UTF-16, then UTF-8.
     /// </summary>
     private static Encoding? CheckBomless(
         ReadOnlySpan<byte> buffer)
@@ -178,8 +169,7 @@ internal static class UnicodeDetector
         // Detection order:
         //   1. UTF-32
         //   2. UTF-16
-        //   3. ASCII
-        //   4. UTF-8
+        //   3. UTF-8
         //
         // Unknown or unsupported encodings return null.
 
@@ -200,12 +190,6 @@ internal static class UnicodeDetector
             return utf16;
 
         //
-        // ASCII-only data is also valid UTF-8, so classify it separately first.
-        //
-        if (IsAscii(buffer))
-            return Encoding.ASCII;
-
-        //
         // UTF-8 without BOM.
         //
         Encoding? utf8 = CheckUtf8(buffer);
@@ -215,6 +199,7 @@ internal static class UnicodeDetector
 
         //
         // Unknown or unsupported encoding.
+        // Handled downstream by UtfUnknown.
         //
         return null;
     }
@@ -419,31 +404,6 @@ internal static class UnicodeDetector
 
 
     /// <summary>
-    /// Determines whether the buffer contains only 7-bit ASCII bytes.
-    /// </summary>
-    private static bool IsAscii(
-        ReadOnlySpan<byte> buffer)
-    {
-        //
-        // ASCII-only data is valid UTF-8, but normally provides insufficient
-        // evidence to classify the sample specifically as UTF-8.
-        //
-        foreach (byte b in buffer)
-        {
-            if (b != 0x09 &&
-                b != 0x0A &&
-                b != 0x0D &&
-                (b < 0x20 || b > 0x7E))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-
-    /// <summary>
     /// Detects BOM-less UTF-8 in the specified buffer.
     /// </summary>
     /// <param name="buffer">Buffer to examine.</param>
@@ -454,6 +414,13 @@ internal static class UnicodeDetector
         ReadOnlySpan<byte> buffer)
     {
         if (buffer.IsEmpty)
+            return null;
+
+        //
+        // Ignore ASCII and escape sequences used by stateful 7-bit encodings
+        // (ISO-2022-JP/KR/CN, HZ-GB-2312); handled downstream by UtfUnknown.
+        //
+        if (Ascii.IsValid(buffer))
             return null;
 
         //


### PR DESCRIPTION
## Problem

ISO-2022-JP/KR/CN and HZ-GB-2312 encode every character as bytes below `0x80`, so their output is **simultaneously valid ASCII and valid UTF-8** while decoding to entirely different text. The detector claimed such buffers itself, which denied UtfUnknown — which recognises them from their escape sequences — any chance to see them.

Found by benchmarking against the [UnicodeTestSuite](https://github.com/amrali-eg/UnicodeTestSuite) corpus: a file of Serbian Cyrillic in ISO-2022-KR was reported as `utf-8`.

The two families failed by different routes, so a single-point fix would have missed one:

| Encoding | Bytes emitted | Where it went wrong |
|---|---|---|
| ISO-2022-* | ESC (`0x1B`), SO/SI | `IsAscii` rejected the control bytes, so it fell through to `CheckUtf8` and was accepted — every byte really is 7-bit and the strict decode succeeds |
| HZ-GB-2312 | printable only | `IsAscii` matched, so it was reported as `ascii` |

## Change

Rather than enumerate escape designators, `CheckUtf8` now declines **any** all-ASCII buffer. Seven-bit content is not evidence of UTF-8 specifically, so it is passed to UtfUnknown instead.

That covers the whole family at once, including two cases a designator table would have needed extra entries for:

- **ISO-2022-CN** — .NET cannot resolve it to a code page at all, so it is now reported as undetected rather than as something it is not.
- **UTF-7** — .NET disables it outright (`Encoding.GetEncoding(65000)` throws `NotSupportedException`), so no result could be returned even if detected.

The dedicated ASCII fast path and `IsAscii` are removed with it, since UtfUnknown identifies plain ASCII as `us-ascii`.

## Verification

Against the full UnicodeTestSuite corpus (1,430 files):

| Case | Result |
|---|---|
| Pure-ASCII text (118 files) | `us-ascii` — all 118 |
| UTF-8 containing non-ASCII (133 files) | `utf-8` — all 133 |
| ISO-2022-KR carrying a designator (7 files) | `iso-2022-kr` — previously `utf-8` |
| Synthetic ISO-2022-JP, HZ-GB-2312 | correct |
| VT100 `ESC ( 0`, ANSI `ESC [ 31m` | `us-ascii` — not mistaken for ISO-2022 |
| 1-byte and whitespace-only ASCII | `us-ascii` |

**No pure-ASCII file is reported as a legacy code page.** The only non-`us-ascii` results among ASCII-byte files are NUL-bearing `13_Binary` fixtures, correctly `(Unknown)`.

Scan time over the corpus is unchanged (209–214 ms vs 212–216 ms before), so routing ASCII through UtfUnknown costs nothing measurable.

One ISO-2022-KR file is still reported `us-ascii`: it holds ASCII-only content, for which neither Python nor .NET writes a designator, so it is byte-identical to plain ASCII and carries no evidence of the encoding. `us-ascii` is the only available answer.

## Notes

- 290 existing tests pass, unmodified.
- The same fix is ported to LineEndingNormalizer, which shares this detector.
- Also drops a redundant verbatim string prefix in `TextEncoding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
