### PR TITLE
Bump version to 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.4.1
+# EncodingChecker v3.5.0
 
 File Encoding Checker detects, validates, and converts the text encoding of one or more files. It runs either as a Windows GUI app or as a command-line tool for scripting and CI, and shares one detection/conversion engine between both.
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -111,7 +111,7 @@ internal static class Program
     }
 
     private const string UsageText = """
-        EncodingChecker v3.4.1
+        EncodingChecker v3.5.0
 
         Usage:
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.4.1.0")]
-[assembly: AssemblyFileVersion("3.4.1.0")]
+[assembly: AssemblyVersion("3.5.0.0")]
+[assembly: AssemblyFileVersion("3.5.0.0")]


### PR DESCRIPTION
Detection gained the ability to identify stateful 7-bit encodings — ISO-2022-JP/KR/CN and HZ-GB-2312 — which were previously reported as UTF-8 or ASCII. New correct behaviour rather than a fix to existing behaviour, so a minor bump.

Updates all four places the version appears: `README.md`, the CLI usage banner in `Program.cs`, and `AssemblyVersion`/`AssemblyFileVersion` in `AssemblyInfo.cs`.

290 tests pass; Release build clean.

Tagging `v3.5.0` after merge triggers the release workflow, which builds and publishes both archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)