### PR TITLE
Bump version to 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
+﻿[![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.5.0
+# EncodingChecker v3.6.0
 
 File Encoding Checker detects, validates, and converts the text encoding of one or more files. It runs either as a Windows GUI app or as a command-line tool for scripting and CI, and shares one detection/conversion engine between both.
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -111,7 +111,7 @@ internal static class Program
     }
 
     private const string UsageText = """
-        EncodingChecker v3.5.0
+        EncodingChecker v3.6.0
 
         Usage:
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.0.0")]
-[assembly: AssemblyFileVersion("3.5.0.0")]
+[assembly: AssemblyVersion("3.6.0.0")]
+[assembly: AssemblyFileVersion("3.6.0.0")]


### PR DESCRIPTION
Minor rather than patch: the strict-fallback fix in #36 changes observable behaviour.

A file whose bytes its own codec cannot represent was previously converted with substituted characters and reported as `Converted`. It is now reported as `Error`, or skipped when the detector declines it. A pipeline gating on EC's exit code can see a new failure where it previously saw success — which is the point: the old success was silent data loss.

Version sites updated: `README.md`, `Program.cs` usage text, `AssemblyInfo.cs` (AssemblyVersion + AssemblyFileVersion).

307 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)