### PR TITLE
Bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
       CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
 


### PR DESCRIPTION
`actions/checkout@v4` and `setup-dotnet@v4` target Node 20. GitHub already forces them onto Node 24 with a deprecation warning on every run, and that shim will eventually be withdrawn.

| Action | From | To | Majors |
|---|---|---|---:|
| `actions/checkout` | v4 | **v7** | 3 |
| `actions/setup-dotnet` | v4 | **v6** | 2 |

Release notes read rather than assumed. Nothing in them affects these workflows:

- **checkout v5** — Node 24; requires runner ≥ 2.327.1, and hosted runners are well past that.
- **checkout v6** — changes where credentials are persisted; only matters to workflows that read them back.
- **checkout v7** — ESM conversion, and blocks checking out a fork PR under `pull_request_target`/`workflow_run`. Neither trigger is used here.
- **setup-dotnet v5/v6** — Node 24 runtime updates. Every input used here still exists in v6.

CI passing on this PR is the actual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)