### PR TITLE
Refuse to convert when the bytes do not identify the encoding

### DIFF
--- a/sources/EncodingChecker.Tests/EncodingAmbiguityTests.cs
+++ b/sources/EncodingChecker.Tests/EncodingAmbiguityTests.cs
@@ -1,0 +1,120 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A corpus audit of 5,078 files found 262 where the bytes do not identify the encoding
+/// that wrote them: single-byte code pages map 256 values independently, so a file valid
+/// in windows-1252 is equally valid in iso-8859-1 and no inspection decides between them.
+/// Detection still answers, and converting on that answer rewrites the file into one of
+/// several possible readings without saying so.
+///
+/// These pin the distinction the refusal rests on. Two failure directions matter equally:
+/// converting a genuinely ambiguous file, and refusing one whose encoding the bytes do
+/// determine. A gate that refuses everything is not safe, it is broken.
+/// </summary>
+public sealed class EncodingAmbiguityTests
+{
+    private static AmbiguityAnalysis Analyze(string text, string charset) =>
+        EncodingAmbiguity.Analyze(
+            Encoding.GetEncoding(charset).GetBytes(text),
+            Encoding.GetEncoding(charset));
+
+    [Theory]
+    [InlineData("utf-8", "Hello 世界 café")]
+    [InlineData("shift_jis", "こんにちは世界。日本語のテキスト")]
+    [InlineData("euc-jp", "こんにちは世界")]
+    [InlineData("big5", "你好世界。這是繁體中文")]
+    [InlineData("gb18030", "这是简体中文文本")]
+    [InlineData("euc-kr", "안녕하세요 세계")]
+    [InlineData("utf-16", "Hello 世界 café")]
+    public void StructuredEncodingsAreNotTreatedAsAmbiguous(string charset, string text)
+    {
+        // These constrain their byte sequences, so a file valid under one was not valid
+        // by accident. Other codecs "reading" it differently are codecs that cannot
+        // refuse anything, which is not a competing claim.
+        AmbiguityAnalysis analysis = Analyze(text, charset);
+
+        Assert.NotEqual(AmbiguityClass.TextChanging, analysis.Class);
+        Assert.True(analysis.IsSafeToConvertAutomatically);
+    }
+
+    [Theory]
+    [InlineData("windows-1252", "Le café était déjà prêt")]
+    [InlineData("koi8-r", "Привет мир")]
+    [InlineData("iso-8859-7", "Γειά σου κόσμε")]
+    public void SingleByteTextWithNoDistinguishingStructureIsAmbiguous(
+        string charset, string text)
+    {
+        AmbiguityAnalysis analysis = Analyze(text, charset);
+
+        Assert.Equal(AmbiguityClass.TextChanging, analysis.Class);
+        Assert.False(analysis.IsSafeToConvertAutomatically);
+        Assert.NotEmpty(analysis.CompetingCandidates);
+    }
+
+    [Fact]
+    public void PureAsciiIsAmbiguousInLabelButNotInText()
+    {
+        // Every candidate agrees on what this file says, so the label is undetermined and
+        // the content is not. Refusing here would protect nothing.
+        AmbiguityAnalysis analysis = EncodingAmbiguity.Analyze(
+            "plain ascii, no high bytes at all"u8, Encoding.ASCII);
+
+        Assert.NotEqual(AmbiguityClass.TextChanging, analysis.Class);
+        Assert.True(analysis.IsSafeToConvertAutomatically);
+        Assert.Empty(analysis.CompetingCandidates);
+    }
+
+    [Fact]
+    public void TheRefusalNamesTheEncodingsActuallyInConflict()
+    {
+        // "Low confidence" gives a user nothing to act on. The competing encodings and
+        // the next step do.
+        AmbiguityAnalysis analysis = Analyze("Le café était déjà prêt", "windows-1252");
+
+        string message = analysis.Describe("windows-1252");
+
+        Assert.Contains("could not be determined uniquely", message);
+        Assert.Contains("windows-1252", message);
+        Assert.Contains("would produce different text", message);
+        Assert.Contains("specify the source encoding explicitly", message);
+    }
+
+    [Fact]
+    public void TheSameBytesAlwaysGetTheSameAnswer()
+    {
+        // An earlier version sampled probe positions randomly and moved with the seed on
+        // short files. Whether a conversion is refused must not depend on a random draw.
+        byte[] bytes = Encoding.GetEncoding("windows-1252").GetBytes("Le café était déjà prêt");
+        Encoding detected = Encoding.GetEncoding("windows-1252");
+
+        AmbiguityClass first = EncodingAmbiguity.Analyze(bytes, detected).Class;
+
+        for (int i = 0; i < 8; i++)
+            Assert.Equal(first, EncodingAmbiguity.Analyze(bytes, detected).Class);
+    }
+
+    [Fact]
+    public void AliasesOfOneEncodingAreNotCountedAsRivalReadings()
+    {
+        // The candidate set is deduplicated by code page. cp949 and ks_c_5601-1987 name
+        // one encoding, and listing both would manufacture a disagreement out of a
+        // spelling difference - a mistake this project has made before, in the audit that
+        // compared detector output by label.
+        AmbiguityAnalysis analysis = Analyze("안녕하세요 세계", "euc-kr");
+
+        Assert.Equal(
+            analysis.CompetingCandidates.Count,
+            analysis.CompetingCandidates.Distinct().Count());
+    }
+
+    [Fact]
+    public void AnEmptySampleIsNotClaimedToBeAmbiguous()
+    {
+        AmbiguityAnalysis analysis = EncodingAmbiguity.Analyze(
+            ReadOnlySpan<byte>.Empty, Encoding.UTF8);
+
+        Assert.True(analysis.IsSafeToConvertAutomatically);
+    }
+}

--- a/sources/EncodingChecker.Tests/ExplicitSourceEncodingTests.cs
+++ b/sources/EncodingChecker.Tests/ExplicitSourceEncodingTests.cs
@@ -1,0 +1,204 @@
+﻿using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// The contract for <c>-From</c>, and the escape from an ambiguity refusal.
+///
+/// The refusal message tells a user to specify the source encoding, so specifying it has
+/// to work — otherwise the safety feature issues advice its own interface cannot take.
+///
+/// But it replaces detection and nothing else. Every guarantee from the conversion engine
+/// still holds: the bytes must strictly decode as the named encoding, the output must
+/// re-decode to exactly the same text, and a failed backup still aborts. <c>-From</c>
+/// answers "which encoding is this?", not "convert it regardless".
+/// </summary>
+public sealed class ExplicitSourceEncodingTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_from_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string Write(string name, byte[] content)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    private List<ConversionReportEntry> Scan(string? from, bool backup = false)
+    {
+        var results = new List<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["*"],
+                Action = ScanAction.Convert,
+                TargetCharset = "utf-8",
+                TargetWriteBom = false,
+                SourceCharset = from,
+                Backup = backup,
+            },
+            results.Add,
+            CancellationToken.None);
+
+        return results;
+    }
+
+    [Fact]
+    public void AmbiguousAutoDetection_IsRefused()
+    {
+        Write("ambiguous.txt",
+            Encoding.GetEncoding("windows-1252").GetBytes("Le café était déjà prêt"));
+
+        ConversionReportEntry entry = Assert.Single(Scan(from: null));
+
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.Contains("could not be determined uniquely", entry.Diagnostic);
+    }
+
+    [Fact]
+    public void SameTextAlternativeCodecs_AreAllowed()
+    {
+        // Every candidate agrees on the content, so the label is undetermined and the
+        // text is not. There is nothing to protect the user from.
+        Write("ascii.txt", "plain ascii, no high bytes"u8.ToArray());
+
+        ConversionReportEntry entry = Assert.Single(Scan(from: null));
+
+        Assert.NotEqual(ConversionRowResult.Error, entry.Result);
+    }
+
+    [Fact]
+    public void ExplicitSource_LetsTheConversionProceed()
+    {
+        // The same file the detector refuses. Somebody has now said which encoding it is.
+        const string text = "Le café était déjà prêt";
+        string path = Write("resolved.txt",
+            Encoding.GetEncoding("windows-1252").GetBytes(text));
+
+        ConversionReportEntry entry = Assert.Single(Scan(from: "windows-1252"));
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.Equal(text, Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+        Assert.True(entry.SourceEncodingWasSpecified);
+    }
+
+    [Fact]
+    public void ExplicitSource_ChangesTheAnswerNotJustThePermission()
+    {
+        // Naming a different encoding for the same bytes must produce different text.
+        // If it did not, -From would be decoration rather than a decision.
+        byte[] bytes = Encoding.GetEncoding("windows-1252").GetBytes("café");
+        string path = Write("interpretation.txt", bytes);
+
+        Assert.Equal(ConversionRowResult.Converted,
+            Assert.Single(Scan(from: "koi8-r")).Result);
+
+        string asKoi8 = Encoding.UTF8.GetString(File.ReadAllBytes(path));
+
+        Assert.NotEqual("café", asKoi8);
+        Assert.Equal(Encoding.GetEncoding("koi8-r").GetString(bytes), asKoi8);
+    }
+
+    [Fact]
+    public void ExplicitSource_WithBytesItCannotDecode_IsStillRefused()
+    {
+        // EUC-JP bytes carrying a JIS X 0212 sequence code page 51932 cannot map.
+        // Naming the encoding does not make the bytes representable.
+        byte[] unrepresentable =
+            [0x8F, 0xB0, 0xDF, 0xB9, 0xA5, 0xA1, 0xA4, 0xC0, 0xA4, 0xB3];
+        string path = Write("undecodable.txt", unrepresentable);
+
+        ConversionReportEntry entry = Assert.Single(Scan(from: "euc-jp"));
+
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.Equal(unrepresentable, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ExplicitSource_WithContentTheTargetCannotHold_IsStillRefused()
+    {
+        // Converting to a target that cannot represent the text must fail whether the
+        // source encoding was detected or chosen.
+        string path = Path.Combine(_root, "unencodable.txt");
+        byte[] original = Encoding.UTF8.GetBytes("世界 مرحبا");
+        File.WriteAllBytes(path, original);
+
+        var results = new List<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["*"],
+                Action = ScanAction.Convert,
+                TargetCharset = "windows-1252",
+                TargetWriteBom = false,
+                SourceCharset = "utf-8",
+            },
+            results.Add,
+            CancellationToken.None);
+
+        ConversionReportEntry entry = Assert.Single(results);
+
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ExplicitSource_WithAFailingBackup_IsStillRefused()
+    {
+        byte[] original = Encoding.GetEncoding("windows-1252").GetBytes("café");
+        string path = Write("backupfail.txt", original);
+        Directory.CreateDirectory(path + ".bak");
+
+        ConversionReportEntry entry =
+            Assert.Single(Scan(from: "windows-1252", backup: true));
+
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ExplicitSource_StillWritesTheRecoveryRecord()
+    {
+        // Choosing the encoding does not opt out of being able to undo the result.
+        string path = Write("recorded.txt",
+            Encoding.GetEncoding("windows-1252").GetBytes("café"));
+
+        Assert.Equal(ConversionRowResult.Converted,
+            Assert.Single(Scan(from: "windows-1252", backup: true)).Result);
+
+        RestoreStatus status = ConversionMetadataStore.Inspect(path);
+
+        Assert.Equal(RestoreAvailability.Available, status.Availability);
+        Assert.Equal(1252, status.Metadata!.DetectedCodePage);
+    }
+
+    [Fact]
+    public void DetectionModeIsRecordedSoTheTwoClaimsStayDistinct()
+    {
+        // Detection can be wrong in ways an explicit choice cannot. A later journal
+        // needs to know which one produced a conversion.
+        Write("ascii.txt", "plain ascii"u8.ToArray());
+
+        Assert.False(Assert.Single(Scan(from: null)).SourceEncodingWasSpecified);
+        Assert.True(Assert.Single(Scan(from: "windows-1252")).SourceEncodingWasSpecified);
+    }
+}

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -47,6 +47,22 @@ internal sealed class ConversionReportEntry
     /// Internal state; not included in CSV output.
     /// </summary>
     internal string? CurrentCharsetLabel { get; set; }
+
+    /// <summary>
+    /// How far this file's bytes identify the encoding that wrote them, decided during
+    /// detection. Defaults to <see cref="AmbiguityClass.Unambiguous"/>, which is correct
+    /// for a caller that supplies the source encoding rather than having it detected:
+    /// there is nothing ambiguous about an answer somebody gave.
+    /// Internal state; not included in CSV output.
+    /// </summary>
+    internal AmbiguityClass Ambiguity { get; set; } = AmbiguityClass.Unambiguous;
+
+    /// <summary>
+    /// Encodings that read this file differently from the one detected. Empty unless
+    /// <see cref="Ambiguity"/> is <see cref="AmbiguityClass.TextChanging"/>.
+    /// Internal state; not included in CSV output.
+    /// </summary>
+    internal IReadOnlyList<string> CompetingEncodings { get; set; } = [];
 
     /// <summary>Additional error detail; not included in CSV output.</summary>
     internal string? Diagnostic { get; set; }

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -64,6 +64,21 @@ internal sealed class ConversionReportEntry
     /// </summary>
     internal IReadOnlyList<string> CompetingEncodings { get; set; } = [];
 
+    /// <summary>
+    /// Why this file received its <see cref="Ambiguity"/> classification.
+    /// Internal state; not included in CSV output.
+    /// </summary>
+    internal AmbiguityReason AmbiguityReason { get; set; } =
+        AmbiguityReason.ExplicitlySpecified;
+
+    /// <summary>
+    /// Whether the source encoding was chosen by the caller rather than detected.
+    /// Recorded because the two are different claims: detection can be wrong in ways an
+    /// explicit choice cannot, and a later journal should be able to say which was used.
+    /// Internal state; not included in CSV output.
+    /// </summary>
+    internal bool SourceEncodingWasSpecified { get; set; }
+
     /// <summary>Additional error detail; not included in CSV output.</summary>
     internal string? Diagnostic { get; set; }
 }

--- a/sources/EncodingChecker/EncodingAmbiguity.cs
+++ b/sources/EncodingChecker/EncodingAmbiguity.cs
@@ -1,0 +1,334 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EncodingChecker;
+
+/// <summary>How far the file's bytes determine which encoding wrote them.</summary>
+internal enum AmbiguityClass
+{
+    /// <summary>Only one supported codec reads these bytes at all.</summary>
+    Unambiguous,
+
+    /// <summary>
+    /// Several codecs read them, and every one yields the same text. The label is
+    /// undetermined; the content is not, so a conversion cannot lose anything.
+    /// </summary>
+    TextEquivalent,
+
+    /// <summary>
+    /// Several codecs read them and disagree about what they say. The bytes do not
+    /// determine the answer, and choosing wrongly changes the user's text.
+    /// </summary>
+    TextChanging,
+}
+
+internal sealed record AmbiguityAnalysis
+{
+    internal required AmbiguityClass Class { get; init; }
+
+    /// <summary>Supported codecs that strictly decode the sample, by name.</summary>
+    internal required IReadOnlyList<string> Candidates { get; init; }
+
+    /// <summary>Distinct readings those candidates produce.</summary>
+    internal required int DistinctReadings { get; init; }
+
+    /// <summary>
+    /// Codecs whose reading differs from the detected one. These are the competing
+    /// interpretations worth naming to a user, rather than the full candidate list.
+    /// </summary>
+    internal required IReadOnlyList<string> CompetingCandidates { get; init; }
+
+    internal bool IsSafeToConvertAutomatically => Class != AmbiguityClass.TextChanging;
+
+    /// <summary>A reason a person can act on, naming the codecs actually in conflict.</summary>
+    internal string Describe(string detectedName) =>
+        Class == AmbiguityClass.TextChanging
+            ? DescribeRefusal(detectedName, CompetingCandidates)
+            : string.Empty;
+
+    /// <summary>
+    /// The refusal message, phrased so the next step is obvious. "Low confidence" tells a
+    /// user nothing they can act on; naming the encodings actually in conflict does.
+    /// </summary>
+    internal static string DescribeRefusal(
+        string detectedName, IReadOnlyList<string> competingCandidates)
+    {
+        string competing = string.Join(", ", competingCandidates.Take(4));
+
+        if (competingCandidates.Count > 4)
+            competing += $", and {competingCandidates.Count - 4} more";
+
+        return "The encoding could not be determined uniquely from the file's contents. "
+               + $"{detectedName} and {competing} all match this file and would produce "
+               + "different text. No conversion was performed; specify the source "
+               + "encoding explicitly to convert it.";
+    }
+}
+
+/// <summary>
+/// Decides whether a file's bytes actually identify the encoding that wrote them.
+/// </summary>
+/// <remarks>
+/// A corpus audit of 5,078 files found 262 where they do not: single-byte code pages map
+/// 256 values independently, so a file valid in windows-1252 is equally valid in
+/// iso-8859-1, and no inspection of the bytes decides between them. Detection heuristics
+/// still answer, and on short or ASCII-heavy input that answer is close to a guess.
+/// <para>
+/// The distinction that matters is not how many codecs *can* read the bytes but whether
+/// they *disagree* about the result. A pure-ASCII file read as us-ascii or as UTF-8 is
+/// ambiguous in label and identical in text; the same file read as iso-8859-1 or
+/// windows-1252 with bytes in 0x80-0x9F is not.
+/// </para>
+/// </remarks>
+internal static class EncodingAmbiguity
+{
+    /// <summary>
+    /// Bytes examined. Matches the detector's own sample: asking a different question of
+    /// a different span could conclude "unambiguous" about a region the detector never saw.
+    /// </summary>
+    internal const int SampleBytes = 64 * 1024;
+
+    /// <summary>
+    /// The codecs EC can name, deduplicated by code page so aliases do not appear as
+    /// rival interpretations of the same bytes. Derived from what EC supports rather
+    /// than from any corpus - a candidate set drawn from test data makes the answer
+    /// depend on what the tests happened to contain.
+    /// </summary>
+    private static readonly Lazy<Encoding[]> Universe = new(() =>
+    {
+        var seen = new HashSet<int>();
+        var result = new List<Encoding>();
+
+        foreach (string name in TextEncoding.SupportedCharsets)
+        {
+            Encoding encoding;
+
+            try
+            {
+                encoding = Encoding.GetEncoding(
+                    name, EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+            {
+                continue;
+            }
+
+            if (seen.Add(encoding.CodePage))
+                result.Add(encoding);
+        }
+
+        return [.. result];
+    });
+
+    /// <summary>
+    /// Above this, the codec has some hold on the input.
+    /// </summary>
+    /// <remarks>
+    /// Set just above zero because the observed separation is not a matter of degree: a
+    /// single-byte code page with no undefined positions rejects *nothing*, measuring
+    /// exactly 0.000, while every multi-byte and Unicode encoding measured on real text
+    /// lands at 0.111 or above. A larger margin was tried first and put Shift_JIS at
+    /// 0.146 - above the line, but close enough that a different probe order moved it
+    /// across. The gap is zero versus non-zero; the threshold should say so rather than
+    /// invent a cutoff in the middle of empty space.
+    /// </remarks>
+    private const double ConstraintFloor = 0.02;
+
+    /// <summary>Probe positions; enough to characterise the input without scanning it all.</summary>
+    private const int ProbePositions = 256;
+
+    /// <summary>
+    /// How tightly a codec constrains these particular bytes: the fraction of small
+    /// mutations it rejects.
+    /// </summary>
+    /// <remarks>
+    /// This is what separates a real rival reading from a meaningless one. Every byte
+    /// sequence is "valid" iso-8859-1, so iso-8859-1 offering a different reading of a
+    /// UTF-8 file is not a competing claim - it is a codec that cannot refuse anything.
+    /// Valid UTF-8 is improbable by accident, so a file that survives mutation under it
+    /// was not valid by chance.
+    /// <para>
+    /// Asked of the bytes rather than of the codec, because single-byte does not imply
+    /// unconstrained: windows-1252 leaves 0x81, 0x8D, 0x8F, 0x90 and 0x9D undefined, so a
+    /// file containing one of them is constrained under it while another file is not.
+    /// </para>
+    /// <para>
+    /// Probes evenly-spaced positions rather than random ones. An earlier version sampled
+    /// randomly and gave answers that moved with the seed on short files - a conversion
+    /// refusing or proceeding should not depend on a random draw.
+    /// </para>
+    /// </remarks>
+    private static double ConstraintOn(ReadOnlySpan<byte> sample, Encoding encoding)
+    {
+        if (sample.Length < 2)
+            return 0.0;
+
+        int step = Math.Max(1, sample.Length / ProbePositions);
+        int rejected = 0;
+        int probes = 0;
+
+        byte[] flipped = sample.ToArray();
+        byte[] shortened = new byte[sample.Length - 1];
+
+        for (int i = 0; i < sample.Length; i += step)
+        {
+            // Deleting a byte tests alignment, which is the only structure a fixed-width
+            // encoding has: UTF-16 survives nearly any bit flip, because most flips just
+            // produce a different valid character, but losing one byte shifts every unit
+            // after it.
+            sample[..i].CopyTo(shortened);
+            sample[(i + 1)..].CopyTo(shortened.AsSpan(i));
+
+            probes++;
+            if (TryHash(shortened, encoding, flush: true) is null)
+                rejected++;
+
+            // Flipping the high bit tests the value, which is what the multi-byte pages
+            // constrain.
+            byte original = flipped[i];
+            flipped[i] ^= 0x80;
+
+            probes++;
+            if (TryHash(flipped, encoding, flush: true) is null)
+                rejected++;
+
+            flipped[i] = original;
+        }
+
+        return probes == 0 ? 0.0 : (double)rejected / probes;
+    }
+
+    internal static AmbiguityAnalysis Analyze(ReadOnlySpan<byte> sample, Encoding detected)
+    {
+        ArgumentNullException.ThrowIfNull(detected);
+
+        if (sample.Length > SampleBytes)
+            sample = sample[..SampleBytes];
+
+        string? detectedHash = null;
+        var byHash = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (Encoding candidate in Universe.Value)
+        {
+            string? hash = TryHash(sample, candidate);
+
+            if (hash is null)
+                continue;
+
+            if (!byHash.TryGetValue(hash, out List<string>? names))
+                byHash[hash] = names = [];
+
+            names.Add(candidate.WebName);
+
+            if (candidate.CodePage == detected.CodePage)
+                detectedHash = hash;
+        }
+
+        // The detected codec failing to decode its own sample is a detection problem,
+        // not an ambiguity one; leave it to strict decoding to reject.
+        if (detectedHash is null)
+        {
+            return new AmbiguityAnalysis
+            {
+                Class = AmbiguityClass.Unambiguous,
+                Candidates = [],
+                DistinctReadings = byHash.Count,
+                CompetingCandidates = [],
+            };
+        }
+
+        List<string> candidates = [.. byHash.Values.SelectMany(v => v)];
+
+        List<string> competing =
+        [
+            .. byHash
+                .Where(pair => !string.Equals(pair.Key, detectedHash, StringComparison.Ordinal))
+                .SelectMany(pair => pair.Value)
+                .Order(StringComparer.Ordinal)
+        ];
+
+        // Rival readings only compete when the detected codec has no hold on these
+        // bytes. If it does - valid UTF-8, valid Shift_JIS - the file's structure
+        // already picked it out, and codecs that accept every byte sequence are not
+        // offering an alternative so much as failing to object.
+        bool detectedIsDetermined =
+            competing.Count > 0 && ConstraintOn(sample, detected) >= ConstraintFloor;
+
+        if (detectedIsDetermined)
+            competing = [];
+
+        AmbiguityClass classification =
+            competing.Count > 0 ? AmbiguityClass.TextChanging
+            : candidates.Count > 1 ? AmbiguityClass.TextEquivalent
+            : AmbiguityClass.Unambiguous;
+
+        return new AmbiguityAnalysis
+        {
+            Class = classification,
+            Candidates = candidates,
+            DistinctReadings = byHash.Count,
+            CompetingCandidates = competing,
+        };
+    }
+
+    /// <summary>
+    /// SHA-256 over the decoded text, or <see langword="null"/> if this codec cannot
+    /// strictly decode the sample.
+    /// </summary>
+    /// <param name="flush">
+    /// Whether an incomplete trailing sequence counts as invalid.
+    /// <para>
+    /// False when asking which codecs read the real sample: it may genuinely cut a
+    /// character in half at 64 KiB, and a boundary artifact is not evidence.
+    /// </para>
+    /// <para>
+    /// True when measuring constraint against mutated copies, where an incomplete tail
+    /// is the whole point. Deleting a byte from a UTF-16 file leaves an odd length, and
+    /// tolerating that made fixed-width encodings look unconstrained - they survive
+    /// almost any bit flip, so alignment is the only structure they have to test.
+    /// </para>
+    /// </param>
+    private static string? TryHash(
+        ReadOnlySpan<byte> sample, Encoding encoding, bool flush = false)
+    {
+        char[] buffer;
+
+        try
+        {
+            buffer = new char[encoding.GetMaxCharCount(sample.Length)];
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+
+        int written;
+
+        try
+        {
+            Decoder decoder = TextEncoding.Strict(encoding).GetDecoder();
+            written = decoder.GetChars(sample, buffer, flush);
+        }
+        catch (Exception ex) when (ex is DecoderFallbackException or ArgumentException)
+        {
+            return null;
+        }
+
+        if (written == 0)
+            return null;
+
+        Span<byte> bytes = stackalloc byte[sizeof(char)];
+        using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        for (int i = 0; i < written; i++)
+        {
+            BitConverter.TryWriteBytes(bytes, buffer[i]);
+            sha.AppendData(bytes);
+        }
+
+        return Convert.ToHexStringLower(sha.GetHashAndReset());
+    }
+}

--- a/sources/EncodingChecker/EncodingAmbiguity.cs
+++ b/sources/EncodingChecker/EncodingAmbiguity.cs
@@ -25,9 +25,30 @@ internal enum AmbiguityClass
     TextChanging,
 }
 
+/// <summary>Why a file was placed in its <see cref="AmbiguityClass"/>.</summary>
+internal enum AmbiguityReason
+{
+    /// <summary>Only one supported codec reads these bytes.</summary>
+    SingleCandidate,
+
+    /// <summary>The detected codec constrains these bytes; rivals do not compete.</summary>
+    StructurallyDetermined,
+
+    /// <summary>Several codecs read them and produce the same text.</summary>
+    MultipleCodecsSameText,
+
+    /// <summary>Several codecs read them and produce different text.</summary>
+    MultipleCodecsDifferentText,
+
+    /// <summary>The source encoding was chosen rather than detected.</summary>
+    ExplicitlySpecified,
+}
+
 internal sealed record AmbiguityAnalysis
 {
     internal required AmbiguityClass Class { get; init; }
+
+    internal required AmbiguityReason Reason { get; init; }
 
     /// <summary>Supported codecs that strictly decode the sample, by name.</summary>
     internal required IReadOnlyList<string> Candidates { get; init; }
@@ -234,6 +255,7 @@ internal static class EncodingAmbiguity
             return new AmbiguityAnalysis
             {
                 Class = AmbiguityClass.Unambiguous,
+                Reason = AmbiguityReason.SingleCandidate,
                 Candidates = [],
                 DistinctReadings = byHash.Count,
                 CompetingCandidates = [],
@@ -265,9 +287,16 @@ internal static class EncodingAmbiguity
             : candidates.Count > 1 ? AmbiguityClass.TextEquivalent
             : AmbiguityClass.Unambiguous;
 
+        AmbiguityReason reason =
+            competing.Count > 0 ? AmbiguityReason.MultipleCodecsDifferentText
+            : detectedIsDetermined ? AmbiguityReason.StructurallyDetermined
+            : candidates.Count > 1 ? AmbiguityReason.MultipleCodecsSameText
+            : AmbiguityReason.SingleCandidate;
+
         return new AmbiguityAnalysis
         {
             Class = classification,
+            Reason = reason,
             Candidates = candidates,
             DistinctReadings = byHash.Count,
             CompetingCandidates = competing,

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -1132,32 +1132,9 @@ public partial class MainForm : Form
     // Matches encodings reported by UtfUnknown.Core.CodepageName.
     // UTF-7 is intentionally excluded because .NET disables it by default (SYSLIB0001)
     // and Encoding.GetEncoding throws NotSupportedException.
-    private static readonly string[] SupportedCharsets =
-    [
-        "ascii", "utf-8", "utf-16le", "utf-16be",
-        "utf-32le", "utf-32be",
-        "euc-jp", "euc-kr", "euc-tw",
-        "iso-2022-cn", "iso-2022-kr", "iso-2022-jp",
-        "x-cp50227",
-        "big5", "gb18030", "hz-gb-2312", "shift-jis",
-        "ks_c_5601-1987", "cp949",
-        "ibm852", "ibm855", "ibm866",
-        "iso-8859-1", "iso-8859-2", "iso-8859-3",
-        "iso-8859-4", "iso-8859-5", "iso-8859-6",
-        "iso-8859-7", "iso-8859-8", "iso-8859-9",
-        "iso-8859-10", "iso-8859-11", "iso-8859-13",
-        "iso-8859-15", "iso-8859-16",
-        "windows-1250", "windows-1251", "windows-1252",
-        "windows-1253", "windows-1255", "windows-1256",
-        "windows-1257", "windows-1258",
-        "x-mac-ce", "x-mac-cyrillic",
-        "koi8-r", "tis-620", "viscii",
-        "X-ISO-10646-UCS-4-3412",
-        "X-ISO-10646-UCS-4-2143"
-    ];
 
     private static string[] GetSupportedCharsets() =>
-        SupportedCharsets;
+        TextEncoding.SupportedCharsets;
 
     private void ShowWarning(
         string message,

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -99,6 +99,7 @@ internal static class Program
         internal List<string> Include = [];
         internal List<string> Exclude = [];
         internal string? Target;
+        internal string? From;
         internal string? ValidateCharsets;
         internal bool DetectOnly;
         internal string? ReportPath;
@@ -133,6 +134,18 @@ internal static class Program
                    The name of the encoding to convert files to, e.g.
                    "utf-8" or "utf-8-bom". Required unless -Validate or
                    -DetectOnly is given.
+
+              [-From "<encoding>"]
+                   Treat every file as this encoding instead of
+                   detecting it. Use when detection reports that a
+                   file's encoding cannot be determined from its
+                   contents, or when you already know it.
+
+                   This replaces detection and nothing else: the bytes
+                   must still decode strictly as this encoding, the
+                   output is still verified to hold exactly the same
+                   text, and a failed backup still aborts. Convert mode
+                   only.
 
               Modes:
                    Conversion is the default mode.
@@ -203,6 +216,8 @@ internal static class Program
 
           EncodingChecker.exe -BasePath . -Include "*" -Validate "utf-8,utf-8-bom" -Report report.csv
 
+          EncodingChecker.exe -BasePath . -Include "*.txt" -From "windows-1252" -Target "utf-8"
+
           EncodingChecker.exe -BasePath D:\NetworkShare -Include "*.txt" -Target "utf-8" -MaxParallelism 2 -FailOnChanges
         """;
 
@@ -263,6 +278,7 @@ internal static class Program
 
         var scanOptions = new ScanDirectoryOptions
         {
+            SourceCharset = options.From,
             BaseDirectory = options.BasePath!,
             IncludeSubdirectories = true,
             IncludePatterns = options.Include,
@@ -469,6 +485,17 @@ internal static class Program
                     }
                     break;
 
+                case "from":
+                    if (!TryTakeValue(
+                            args,
+                            ref i,
+                            out options.From))
+                    {
+                        error = "-From requires a value.";
+                        return false;
+                    }
+                    break;
+
                 case "validate":
                     if (!TryTakeValue(
                             args,
@@ -546,7 +573,7 @@ internal static class Program
     private static readonly HashSet<string> KnownFlagNames =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            "basepath", "include", "exclude", "target", "validate",
+            "basepath", "include", "exclude", "target", "from", "validate",
             "detectonly", "report", "maxparallelism", "failonchanges",
             "whatif", "backup", "quiet", "verbose",
         };
@@ -589,6 +616,26 @@ internal static class Program
         CliOptions options,
         [NotNullWhen(false)] out string? error)
     {
+        if (!string.IsNullOrWhiteSpace(options.From))
+        {
+            if (options.DetectOnly || !string.IsNullOrWhiteSpace(options.ValidateCharsets))
+            {
+                error = "-From applies to conversion only; it cannot be combined with "
+                        + "-DetectOnly or -Validate, which report what the detector finds.";
+                return false;
+            }
+
+            try
+            {
+                Encoding.GetEncoding(options.From!);
+            }
+            catch (ArgumentException)
+            {
+                error = $"'{options.From}' is not a recognized encoding.";
+                return false;
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(options.BasePath))
         {
             error = "-BasePath is required.";

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -315,6 +315,22 @@ internal static class ScanEngine
             Result = ConversionRowResult.Unchanged,
         };
 
+        // Classified here, beside the detection it qualifies, and carried on the entry.
+        // The conversion path then reads a decision rather than re-deriving one, and a
+        // caller who supplies the source encoding instead of detecting it gets the
+        // default - correctly, since there is nothing ambiguous about an answer somebody
+        // gave.
+        if (detected is not null && options.Action == ScanAction.Convert)
+        {
+            AmbiguityAnalysis? ambiguity = AnalyzeAmbiguity(path, detected);
+
+            if (ambiguity is not null)
+            {
+                entry.Ambiguity = ambiguity.Class;
+                entry.CompetingEncodings = ambiguity.CompetingCandidates;
+            }
+        }
+
         switch (options.Action)
         {
             case ScanAction.Detect:
@@ -400,6 +416,21 @@ internal static class ScanEngine
         if (alreadyMatches)
         {
             entry.Result = ConversionRowResult.Unchanged;
+            return;
+        }
+
+        // Refuse before touching anything when the file's bytes do not identify the
+        // encoding that wrote them and the rival readings disagree about the text.
+        //
+        // Detection still produces an answer for these; on short or ASCII-heavy input
+        // that answer is close to a guess, and acting on it rewrites the user's file
+        // into one of several possible readings without saying so. Skipped when the user
+        // named the source encoding, since then it is their answer, not a guess.
+        if (entry.Ambiguity == AmbiguityClass.TextChanging)
+        {
+            entry.Result = ConversionRowResult.Error;
+            entry.Diagnostic = AmbiguityAnalysis.DescribeRefusal(
+                sourceCharset, entry.CompetingEncodings);
             return;
         }
 
@@ -544,6 +575,38 @@ internal static class ScanEngine
             OutputTextSha256 = record.OutputTextSha256,
             UnicodeScalars = record.UnicodeScalars,
         });
+    }
+
+    /// <summary>
+    /// Reads the detector's sample again and asks whether it identifies one encoding.
+    /// Returns <see langword="null"/> when the file cannot be read, leaving the decision
+    /// to the conversion itself rather than refusing on an I/O error.
+    /// </summary>
+    private static AmbiguityAnalysis? AnalyzeAmbiguity(string path, Encoding sourceEncoding)
+    {
+        try
+        {
+            using FileStream stream = new(
+                path, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete,
+                4096, FileOptions.SequentialScan);
+
+            int length = (int)Math.Min(stream.Length, EncodingAmbiguity.SampleBytes);
+
+            if (length == 0)
+                return null;
+
+            byte[] buffer = new byte[length];
+            int read = stream.ReadAtLeast(buffer, length, throwOnEndOfStream: false);
+
+            return read == 0
+                ? null
+                : EncodingAmbiguity.Analyze(buffer.AsSpan(0, read), sourceEncoding);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
     }
 
     private static void CreateBackup(string path)

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -60,6 +60,23 @@ internal sealed class ScanDirectoryOptions
     /// <summary>Target charset for conversion, without "-bom".</summary>
     internal string? TargetCharset { get; init; }
 
+    /// <summary>
+    /// Source charset chosen by the caller, used instead of detection.
+    /// </summary>
+    /// <remarks>
+    /// This replaces detection, and nothing else. Every verification still applies: the
+    /// bytes must strictly decode as this encoding, the output must re-decode to exactly
+    /// the same text, the backup must verify, and the record must be written before
+    /// anything is installed. It answers "which encoding is this?", not "convert it
+    /// regardless".
+    /// <para>
+    /// It is also the escape from an ambiguity refusal. Where the bytes cannot identify
+    /// the encoding, someone who knows has to say - and saying so must be possible, or
+    /// the refusal is advice the user cannot take.
+    /// </para>
+    /// </remarks>
+    internal string? SourceCharset { get; init; }
+
     internal bool TargetWriteBom { get; init; }
 
     /// <summary>Simulate conversion without writing.</summary>
@@ -296,7 +313,25 @@ internal static class ScanEngine
         Encoding? targetEncoding,
         CancellationToken cancellationToken)
     {
-        Encoding? detected = TextEncoding.DetectFromFile(path);
+        bool sourceWasSpecified = !string.IsNullOrWhiteSpace(options.SourceCharset);
+
+        Encoding? detected;
+
+        if (sourceWasSpecified)
+        {
+            try
+            {
+                detected = Encoding.GetEncoding(options.SourceCharset!);
+            }
+            catch (ArgumentException)
+            {
+                detected = null;
+            }
+        }
+        else
+        {
+            detected = TextEncoding.DetectFromFile(path);
+        }
 
         bool hasBom =
             detected != null &&
@@ -320,13 +355,17 @@ internal static class ScanEngine
         // caller who supplies the source encoding instead of detecting it gets the
         // default - correctly, since there is nothing ambiguous about an answer somebody
         // gave.
-        if (detected is not null && options.Action == ScanAction.Convert)
+        entry.SourceEncodingWasSpecified = sourceWasSpecified;
+
+        if (detected is not null && options.Action == ScanAction.Convert
+            && !sourceWasSpecified)
         {
             AmbiguityAnalysis? ambiguity = AnalyzeAmbiguity(path, detected);
 
             if (ambiguity is not null)
             {
                 entry.Ambiguity = ambiguity.Class;
+                entry.AmbiguityReason = ambiguity.Reason;
                 entry.CompetingEncodings = ambiguity.CompetingCandidates;
             }
         }

--- a/sources/EncodingChecker/TextEncoding.cs
+++ b/sources/EncodingChecker/TextEncoding.cs
@@ -227,6 +227,41 @@ internal static class TextEncoding
     #region Helpers
 
     /// <summary>
+    /// Every charset EC can name or convert to.
+    /// </summary>
+    /// <remarks>
+    /// Shared with <see cref="EncodingAmbiguity"/>, which needs the same set to decide
+    /// whether a file's bytes identify one encoding or several. That question must be
+    /// answered against what EC actually supports; deriving the candidates from any
+    /// other source would make the answer depend on something the user cannot see.
+    /// </remarks>
+    internal static readonly string[] SupportedCharsets =
+    [
+        "ascii", "utf-8", "utf-16le", "utf-16be",
+        "utf-32le", "utf-32be",
+        "euc-jp", "euc-kr", "euc-tw",
+        "iso-2022-cn", "iso-2022-kr", "iso-2022-jp",
+        "x-cp50227",
+        "big5", "gb18030", "hz-gb-2312", "shift-jis",
+        "ks_c_5601-1987", "cp949",
+        "ibm852", "ibm855", "ibm866",
+        "iso-8859-1", "iso-8859-2", "iso-8859-3",
+        "iso-8859-4", "iso-8859-5", "iso-8859-6",
+        "iso-8859-7", "iso-8859-8", "iso-8859-9",
+        "iso-8859-10", "iso-8859-11", "iso-8859-13",
+        "iso-8859-15", "iso-8859-16",
+        "windows-1250", "windows-1251", "windows-1252",
+        "windows-1253", "windows-1255", "windows-1256",
+        "windows-1257", "windows-1258",
+        "x-mac-ce", "x-mac-cyrillic",
+        "koi8-r", "tis-620", "viscii",
+        "X-ISO-10646-UCS-4-3412",
+        "X-ISO-10646-UCS-4-2143"
+    ];
+
+
+
+    /// <summary>
     /// Returns an encoding whose decoder and encoder actually enforce strict fallback.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
The audit's largest remaining risk category: **262 of 5,078 files** where several encodings read the bytes and disagree about what they say. Single-byte code pages map 256 values independently, so a file valid in `windows-1252` is equally valid in `iso-8859-1`, and nothing in the bytes decides. Detection answers anyway — and on short or ASCII-heavy input that answer is close to a guess, which EC then acted on.

## Three outcomes, not two

| Class | Meaning | Action |
|---|---|---|
| `Unambiguous` | One codec reads these bytes | convert |
| `TextEquivalent` | Several read them, all agree on the text | convert |
| `TextChanging` | Several read them and **disagree** | **refuse** |

The middle case matters as much as the last. A pure-ASCII file is ambiguous in *label* and identical in *text* — refusing it would protect nothing. The test is whether the candidates produce different Unicode, not whether more than one can decode.

Observed end to end:

```
ambiguous_cp1252.txt   iso-8859-1  →  Error      (refused)
ambiguous_koi8r.txt    koi8-r      →  Error      (refused)
ascii_only.txt         us-ascii    →  Converted
determined_utf8.txt    utf-8       →  Unchanged
determined_sjis.txt    shift_jis   →  Converted
determined_big5.txt    big5        →  Converted
determined_utf16.txt   utf-16      →  Converted
```

## Candidate set and placement

Candidates come from **EC's supported encodings, deduplicated by code page** — never from a corpus. The audit already demonstrated that deriving candidates from test data makes the answer depend on what the tests happened to contain. That list moved from `MainForm` to `TextEncoding` so the engine can reach it.

The decision is made **beside the detection that produced it** and carried on the entry, so the conversion path reads a verdict rather than re-deriving one. A caller who supplies the source encoding rather than detecting it is unaffected — there is nothing ambiguous about an answer somebody gave.

## Two mistakes on the way, both caught by the existing tests

**Counting rival readings alone refused every UTF-8 file**, because `iso-8859-1` "reads" it too. A codec that cannot refuse anything is not offering an alternative. Fixed by requiring the detected codec to have no hold on the bytes before rivals count.

**Measuring that hold by bit flips alone refused UTF-16**, which survives nearly any flip — most produce another valid character. Fixed by also *deleting* a byte, which tests alignment, the only structure a fixed-width encoding has.

The measurement is **deterministic** — evenly-spaced probes, not random ones — after an earlier version gave answers that moved with the seed on short files. Whether a conversion is refused should not depend on a random draw.

The threshold sits just above zero because the separation is not a matter of degree: unconstrained single-byte pages reject **exactly nothing**, and every structured encoding measured on real text lands at 0.111 or above.

## The message

> The encoding could not be determined uniquely from the file's contents. `iso-8859-1` and `cp866`, `ibm852`, `ibm855`, `iso-8859-13`, and 17 more all match this file and would produce different text. No conversion was performed; specify the source encoding explicitly to convert it.

Rather than "low confidence", which gives a user nothing to act on.

**345 tests passing** (was 330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: `-From` folded in

The refusal told users to specify the source encoding, and the CLI had no way to do it — a safety feature issuing instructions its own interface could not follow. Fixed before merge:

```powershell
EncodingChecker.exe -BasePath . -Include "*.txt" -From "windows-1252" -Target "utf-8"
```

**It replaces detection and nothing else.** Verified end to end:

| | |
|---|---|
| Auto-detect on ambiguous file | `Error` + advice |
| Same file with `-From windows-1252` | `Converted`, text intact |
| `-From euc-jp` on undecodable bytes | **still refused** — `SourceDecodeError` |
| `-From` + target that cannot hold the content | **still refused** |
| `-From` + failing backup | **still refused** |
| `-From` + `-DetectOnly` / `-Validate` | rejected as meaningless |

It changes the *interpretation*, not the permission: naming `koi8-r` for windows-1252 bytes produces koi8-r text. The user is choosing a reading, not waiving a check. The recovery record is still written.

Also adds `AmbiguityReason` (`SingleCandidate`, `StructurallyDetermined`, `MultipleCodecsSameText`, `MultipleCodecsDifferentText`, `ExplicitlySpecified`) and records per entry whether the encoding was **detected or specified** — different claims, since detection can be wrong in ways an explicit choice cannot.

**354 tests passing** (was 345).
