### PR TITLE
One policy engine, and a GUI that asks before it writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,38 @@ The conversion that runs is the one shown. Nothing is detected a second time bet
 confirmation and the writing, so the dialog cannot describe one set of conclusions while
 a different set is carried out — the same property `-Apply` has.
 
-When files are refused, the dialog names the encodings actually in conflict and offers the
-one thing that resolves it: saying which encoding they are. That selection is the GUI's
-`-From`. It replaces detection for those files and nothing else — the bytes must still
-decode strictly as the chosen encoding, the output is still verified to hold exactly the
-same text, and a failed backup still stops the conversion.
+If the files change between the confirmation and the writing, **nothing is converted** —
+the same all-or-nothing check `-Apply` makes, for the same reason: a person reading a
+dialog takes time, and what they approved was the files as they were.
 
-The GUI and the CLI ask the same question of the same code. There is one policy engine
-([`ConversionPolicy`](sources/EncodingChecker/ConversionPolicy.cs)); detection or an
-explicit source produces a classification, the classification produces an action, and
-every surface acts on that action rather than reaching its own conclusion.
+When files are refused, the dialog lists them with the encodings actually in conflict and
+offers the one thing that resolves it: saying which encoding they are. That selection is
+the GUI's `-From`. It replaces detection for those files and nothing else — the bytes must
+still decode strictly as the chosen encoding, the output is still verified to hold exactly
+the same text, and a failed backup still stops the conversion.
+
+The choice applies only to the files you tick, and the button says how many. A batch can
+easily hold refused files in different encodings — Cyrillic in koi8-r beside French in
+windows-1252 — and one answer settles only the files it was given about. Imposing it on
+the rest would repeat, one level up, the mistake the refusal exists to prevent.
+
+### One policy engine
+
+The GUI and the CLI ask the same question of the same code:
+
+```
+detection / explicit source → classification → PlannedAction → CLI, GUI, plan
+```
+
+[`ConversionPolicy`](sources/EncodingChecker/ConversionPolicy.cs) decides; every surface
+acts on that decision rather than reaching its own. A missing classification is an
+internal error, never a safe state: an entry that reaches a conversion or a plan without
+one is refused or raises, rather than being treated as unambiguous.
+
+EC also counts how often it works out an encoding, and asserts in its test suite that a
+file is never examined twice — once when scanned, and never again between a decision being
+approved and carried out. Applying a plan, and confirming a GUI conversion, do no
+detection at all.
 
 ## Command-line usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Each [release](https://github.com/amrali-eg/EncodingChecker/releases) publishes 
 
 - Layered detection: byte-order-mark and heuristic checks for Unicode encodings, [UtfUnknown](https://github.com/CharsetDetector/UTF-unknown) for legacy code pages, each candidate independently verified by strict decoding before being trusted.
 - Lossless, safe conversion: every write is verified afterward by comparing a SHA-256 hash of the decoded content, so a silent encoder substitution (e.g. an unrepresentable character) is caught and reported as an error instead of corrupting the file.
-- Refuses to convert files whose encoding the bytes do not determine, naming the encodings actually in conflict, with `-From` to supply the answer yourself.
+- Refuses to convert files whose encoding the bytes do not determine, naming the encodings actually in conflict, with `-From` (or the GUI's source-encoding selection) to supply the answer yourself. One policy engine decides for every surface.
+- The GUI confirms before writing, showing exactly what will happen to each file and carrying out that same plan rather than re-deciding.
 - `-Plan`/`-Apply` preflight: review what a conversion would do, then carry out exactly that — the plan is bound to the files' hashes and is refused whole if they change.
 - Optional `.bak` backup before overwriting, and a `-WhatIf` dry-run mode that reports what would happen without touching any file.
 - Covered by an xUnit test suite exercising the detection/conversion engine, CLI argument parsing, and CSV report formatting across multilingual content and edge cases.
@@ -27,6 +28,43 @@ Two options apply to **Convert**:
 
 - **Back up original files before converting (.bak)** — keeps each original as `<file>.bak` before it is replaced. The equivalent of the CLI's `-Backup`.
 - **Preview changes without modifying files** — reports which files *would* be converted without writing anything and without creating any `.bak`. Previewed rows keep their current encoding and stay selected, so you can review the result and then convert for real. The equivalent of the CLI's `-WhatIf`.
+
+### Confirming a conversion
+
+**Convert** does not write anything immediately. It first works out what would happen to
+every selected file, then shows that for approval:
+
+```
+Convert 417 of 480 selected file(s) to utf-8 without BOM
+
+  386  Encoding determined by the file's own bytes            Will convert.
+   31  Encoding undetermined, every reading agrees on the text Will convert; the label
+                                                               is a choice, the content
+                                                               is not.
+   22  Encoding undetermined, readings disagree on the text    WILL NOT be converted.
+   39  Already in the target encoding                          Nothing to do.
+    2  Encoding could not be identified                        Left alone.
+
+Directory        C:\Source
+Source encoding  detected per file
+Backups          enabled — each original kept as <file>.bak
+Guarantees       strict codecs, verified output, atomic install, ambiguity refusal
+```
+
+The conversion that runs is the one shown. Nothing is detected a second time between the
+confirmation and the writing, so the dialog cannot describe one set of conclusions while
+a different set is carried out — the same property `-Apply` has.
+
+When files are refused, the dialog names the encodings actually in conflict and offers the
+one thing that resolves it: saying which encoding they are. That selection is the GUI's
+`-From`. It replaces detection for those files and nothing else — the bytes must still
+decode strictly as the chosen encoding, the output is still verified to hold exactly the
+same text, and a failed backup still stops the conversion.
+
+The GUI and the CLI ask the same question of the same code. There is one policy engine
+([`ConversionPolicy`](sources/EncodingChecker/ConversionPolicy.cs)); detection or an
+explicit source produces a classification, the classification produces an action, and
+every surface acts on that action rather than reaching its own conclusion.
 
 ## Command-line usage
 
@@ -219,8 +257,13 @@ These are the guarantees the implementation actually provides.
   opt-in, since a script can keep the report.
 - A conversion whose source encoding cannot be determined from the file's own
   bytes is refused rather than guessed at, when the competing encodings would
-  produce different text. `-From` overrides the detection, not the conversion
-  safeguards. See [Ambiguous encodings](#ambiguous-encodings-and--from).
+  produce different text. `-From`, and the GUI's source-encoding selection,
+  override the detection, not the conversion safeguards.
+  See [Ambiguous encodings](#ambiguous-encodings-and--from).
+  <br>That decision is made in one place for every surface, so the GUI and the
+  CLI cannot diverge on what is safe. They previously could, and did: the
+  classification ran only during a Convert-mode scan, the GUI scans in Detect
+  mode, and so the GUI converted the files the CLI refused.
 - A plan written by `-Plan` is bound to the SHA-256 of every file it schedules,
   to the directory those files are under, and to the conversion behaviour it was
   approved under. `-Apply` verifies all of them before writing anything and

--- a/sources/EncodingChecker.Tests/AssemblyInfo.cs
+++ b/sources/EncodingChecker.Tests/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+// DetectionCountTests measures process-global counters to assert that EC never works out
+// a file's encoding twice. Those counts are only meaningful if nothing else is detecting
+// at the same time, and xUnit runs test classes in parallel by default.
+//
+// The whole suite runs in well under a second, so serialising it costs nothing worth
+// weighing against being able to state that invariant as a test.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Windows.Forms;
 
 namespace EncodingChecker.Tests;
@@ -129,7 +129,7 @@ public sealed class ConversionConfirmationFormTests : IDisposable
         {
             using var form = new ConversionConfirmationForm(plan);
 
-            Assert.DoesNotContain("could not be determined", AllText(form));
+            Assert.DoesNotContain("need an explicit source encoding", AllText(form));
         });
     }
 
@@ -151,7 +151,7 @@ public sealed class ConversionConfirmationFormTests : IDisposable
 
             string text = AllText(form);
 
-            Assert.Contains("could not be determined", text);
+            Assert.Contains("need an explicit source encoding", text);
             Assert.Contains("Nothing to convert", text);
             Assert.DoesNotContain("Convert 1 file", text);
         });
@@ -190,6 +190,51 @@ public sealed class ConversionConfirmationFormTests : IDisposable
 
             Assert.True(chooser.Items.Count > 1);
             Assert.Contains("windows-1252", chooser.Items.Cast<string>());
+        });
+    }
+
+    [Fact]
+    public void ItMakesTheScopeOfAnEncodingChoiceUnmistakable()
+    {
+        // The button says how many files the choice would apply to, and the count moves
+        // with the ticks. A user must never have to infer how far their answer reaches.
+        Write("french.txt", "Le café était déjà prêt", "windows-1252");
+        Write("russian.txt", "Привет мир, это русский текст", "koi8-r");
+
+        ConversionPlan plan = Plan();
+
+        Assert.Equal(2, plan.Files.Count(f => f.Action == PlannedAction.Refuse));
+
+        OnUiThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            // ListView caches check state until it has a window handle, and only raises
+            // ItemChecked once it does. Nothing here pumps messages; the handle is enough.
+            form.CreateControl();
+            _ = form.Handle;
+
+            ListView list = Assert.Single(Descendants(form).OfType<ListView>());
+
+            list.CreateControl();
+            _ = list.Handle;
+
+            // Everything the dialog asked about starts ticked, and the button says so.
+            Assert.Equal(2, list.CheckedItems.Count);
+            Assert.Contains("for 2 file(s)", AllText(form));
+
+            list.Items[0].Checked = false;
+
+            Assert.Contains("for 1 file(s)", AllText(form));
+
+            // And with none ticked there is nothing to apply, so it cannot be pressed.
+            list.Items[1].Checked = false;
+
+            Button apply = Assert.Single(
+                Descendants(form).OfType<Button>(),
+                b => b.Text.StartsWith("Use this encoding"));
+
+            Assert.False(apply.Enabled);
         });
     }
 

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -1,0 +1,241 @@
+using System.Text;
+using System.Windows.Forms;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// The confirmation dialog is the only part of the safety model a GUI user ever reads,
+/// and until now it was also the only part no test had ever executed. Layout code that
+/// has never run is layout code that throws the first time somebody converts a directory
+/// with an unusual mix of outcomes — and it would throw at exactly the moment the user is
+/// being asked to approve something.
+///
+/// These build it against real plans rather than asserting on pixels: every outcome mix,
+/// on an STA thread, checking that it constructs and that what it says matches the plan
+/// it was given.
+/// </summary>
+public sealed class ConversionConfirmationFormTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_dialog_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    /// <summary>Runs <paramref name="body"/> on an STA thread, as WinForms requires.</summary>
+    private static void OnUiThread(Action body)
+    {
+        Exception? failure = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                body();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+
+        Assert.True(thread.Join(TimeSpan.FromSeconds(30)), "the dialog did not finish");
+
+        if (failure is not null)
+            throw new Xunit.Sdk.XunitException($"the dialog threw: {failure}");
+    }
+
+    private void Write(string name, string text, string charset) =>
+        File.WriteAllBytes(
+            Path.Combine(_root, name), Encoding.GetEncoding(charset).GetBytes(text));
+
+    /// <summary>A plan over whatever is currently in the directory.</summary>
+    private ConversionPlan Plan(bool backup = true, string target = "utf-8")
+    {
+        var entries = new List<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["*"],
+                Action = ScanAction.Convert,
+                TargetCharset = target,
+                TargetWriteBom = false,
+                WhatIf = true,
+            },
+            entries.Add,
+            CancellationToken.None);
+
+        return ConversionPlan.FromEntries(
+            entries, _root, target, targetHasBom: false,
+            backupEnabled: backup, explicitSource: null);
+    }
+
+    private static IEnumerable<Control> Descendants(Control root)
+    {
+        foreach (Control child in root.Controls)
+        {
+            yield return child;
+
+            foreach (Control nested in Descendants(child))
+                yield return nested;
+        }
+    }
+
+    private static string AllText(Control root) =>
+        string.Join("\n", Descendants(root).Select(c => c.Text));
+
+    [Fact]
+    public void ItBuildsForAMixOfEveryOutcome()
+    {
+        Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
+        Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
+        Write("plain.txt", "just ascii here", "ascii");
+        Write("already.txt", "already utf-8 世界", "utf-8");
+
+        ConversionPlan plan = Plan();
+
+        OnUiThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            Assert.NotEmpty(Descendants(form).ToList());
+        });
+    }
+
+    [Fact]
+    public void ItBuildsWhenNothingIsRefused()
+    {
+        // The common case, and the one where a refusal panel must not appear at all.
+        Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
+
+        ConversionPlan plan = Plan();
+
+        OnUiThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            Assert.DoesNotContain("could not be determined", AllText(form));
+        });
+    }
+
+    [Fact]
+    public void ItBuildsWhenEverythingIsRefused()
+    {
+        // Nothing to convert. The button has to say so rather than offering an action
+        // that would do nothing.
+        Write("a.txt", "Le café était déjà prêt", "windows-1252");
+        Write("b.txt", "Привет мир, это русский", "koi8-r");
+
+        ConversionPlan plan = Plan();
+
+        Assert.All(plan.Files, f => Assert.Equal(PlannedAction.Refuse, f.Action));
+
+        OnUiThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            string text = AllText(form);
+
+            Assert.Contains("could not be determined", text);
+            Assert.Contains("Nothing to convert", text);
+            Assert.DoesNotContain("Convert 1 file", text);
+        });
+    }
+
+    [Fact]
+    public void ItNamesTheCompetingEncodingsRatherThanJustReportingLowConfidence()
+    {
+        // "Could not be determined" on its own gives a user nothing to act on. The
+        // alternatives and the way out are what make the refusal actionable.
+        Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
+
+        ConversionPlan plan = Plan();
+        PlannedFile refused = Assert.Single(plan.Files);
+
+        Assert.NotEmpty(refused.CompetingEncodings);
+
+        OnUiThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            List<string> cells =
+            [
+                .. Descendants(form)
+                    .OfType<ListView>()
+                    .SelectMany(v => v.Items.Cast<ListViewItem>())
+                    .SelectMany(i => i.SubItems.Cast<ListViewItem.ListViewSubItem>())
+                    .Select(sub => sub.Text)
+            ];
+
+            Assert.Contains("ambiguous.txt", cells);
+            Assert.Contains(cells, c => c.Contains(refused.CompetingEncodings[0]));
+
+            // And the way out is offered, populated from the charsets EC supports.
+            ComboBox chooser = Assert.Single(Descendants(form).OfType<ComboBox>());
+
+            Assert.True(chooser.Items.Count > 1);
+            Assert.Contains("windows-1252", chooser.Items.Cast<string>());
+        });
+    }
+
+    [Fact]
+    public void ItSaysWhetherOriginalsWillBeKept()
+    {
+        // Whether a conversion is undoable is part of what is being approved.
+        Write("jp.txt", "こんにちは世界。テキスト", "shift_jis");
+
+        ConversionPlan withBackups = Plan(backup: true);
+        ConversionPlan without = Plan(backup: false);
+
+        OnUiThread(() =>
+        {
+            using var kept = new ConversionConfirmationForm(withBackups);
+            using var lost = new ConversionConfirmationForm(without);
+
+            Assert.Contains(".bak", AllText(kept));
+            Assert.Contains("DISABLED", AllText(lost));
+        });
+    }
+
+    [Fact]
+    public void ItReportsThePlanItWasGivenRatherThanRecountingTheDirectory()
+    {
+        // The dialog must describe the decisions that will execute. Recomputing here is
+        // how a confirmation ends up describing something other than what happens.
+        Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
+        Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
+
+        ConversionPlan plan = Plan();
+
+        int convert = plan.Files.Count(f => f.Action == PlannedAction.Convert);
+
+        // Change the directory after planning. The dialog must not notice.
+        File.Delete(Path.Combine(_root, "jp.txt"));
+        Write("late-arrival.txt", "added after the plan", "ascii");
+
+        OnUiThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            string text = AllText(form);
+
+            Assert.Contains($"Convert {convert} of {plan.Files.Count} selected", text);
+            Assert.DoesNotContain("late-arrival", text);
+        });
+    }
+}

--- a/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 
 namespace EncodingChecker.Tests;
@@ -41,6 +41,11 @@ public sealed class ConversionMetadataTests : IDisposable
             SourceHasBom = false,
             TargetEncoding = sourceCharset,
             TargetHasBom = false,
+
+            // These name the source encoding rather than having it detected, which is
+            // what -From means. Without saying so, the ambiguity gate correctly refuses
+            // single-byte content whose encoding its bytes do not identify.
+            SourceEncodingWasSpecified = true,
         };
 
         ScanEngine.ConvertFiles(

--- a/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
@@ -1,0 +1,416 @@
+﻿using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// The GUI's conversion sequence, end to end:
+///
+///   View → select rows → Convert → classify → confirm → carry out exactly that plan.
+///
+/// This exists because every component of that sequence was already correct and tested
+/// while the sequence itself was unsafe. Classification ran only in Convert-mode scans;
+/// the GUI scans in Detect mode; entries reached conversion carrying no classification at
+/// all, and the refusal never fired. No component test could have caught it — the defect
+/// was in the wiring between them, and the wiring lived in button handlers and
+/// background-worker callbacks where nothing could run it.
+///
+/// So the wiring is <see cref="ConversionOrchestrator"/> and these drive it, against the
+/// real conversion engine, on real files. Every case that must not modify anything reads
+/// the source bytes before and after and compares them.
+/// </summary>
+public sealed class ConversionOrchestrationTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_orch_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string Write(string name, string text, string charset)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllBytes(path, Encoding.GetEncoding(charset).GetBytes(text));
+        return path;
+    }
+
+    /// <summary>The rows the GUI's View button produces, which Convert then acts on.</summary>
+    private List<ConversionReportEntry> View()
+    {
+        var scanned = new List<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["*"],
+                Action = ScanAction.Detect,
+            },
+            scanned.Add,
+            CancellationToken.None);
+
+        return scanned;
+    }
+
+    /// <summary>Everything the GUI's Convert button does, with a scripted user.</summary>
+    private OrchestrationResult Convert(
+        IReadOnlyList<ConversionReportEntry> entries,
+        Func<ConversionPlan, ConfirmationResponse> confirm,
+        string target = "utf-8",
+        bool backup = false,
+        bool preview = false,
+        Action<ConversionPlan>? betweenPlanAndWrite = null)
+    {
+        return new ConversionOrchestrator(plan =>
+            {
+                ConfirmationResponse response = confirm(plan);
+
+                // A hook for the window between approving a plan and acting on it.
+                betweenPlanAndWrite?.Invoke(plan);
+
+                return response;
+            })
+            .Run(
+                entries, _root, target, targetWriteBom: false,
+                backup: backup, preview: preview,
+                ScanEngine.DefaultMaxParallelism,
+                _ => { },
+                CancellationToken.None);
+    }
+
+    private static ConfirmationResponse Proceed(ConversionPlan _) =>
+        ConfirmationResponse.Proceed;
+
+    // ----------------------------------------------------------- the three states
+
+    [Fact]
+    public void TextChangingAmbiguity_IsRefusedBeforeAnythingIsModified()
+    {
+        string path = Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
+        byte[] before = File.ReadAllBytes(path);
+
+        var shown = new List<ConversionPlan>();
+
+        OrchestrationResult result = Convert(View(), plan =>
+        {
+            shown.Add(plan);
+            return ConfirmationResponse.Proceed;
+        });
+
+        PlannedFile refused = Assert.Single(Assert.Single(shown).Files);
+
+        Assert.Equal(PlannedAction.Refuse, refused.Action);
+        Assert.True(refused.MayChangeText);
+        Assert.NotEmpty(refused.CompetingEncodings);
+
+        Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void TextEquivalentAmbiguity_IsConverted()
+    {
+        // The label is undetermined; the content is not. Refusing here protects nothing.
+        string path = Write("plain.txt", "plain ascii, no high bytes at all", "ascii");
+
+        OrchestrationResult result = Convert(View(), Proceed);
+
+        Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
+        Assert.Equal(
+            PlannedAction.Convert, Assert.Single(result.Plan!.Files).Action);
+        Assert.Equal(
+            "plain ascii, no high bytes at all",
+            Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+    }
+
+    [Fact]
+    public void UnambiguousEncoding_IsConverted()
+    {
+        const string text = "こんにちは世界。日本語のテキストです。";
+        string path = Write("jp.txt", text, "shift_jis");
+
+        OrchestrationResult result = Convert(View(), Proceed);
+
+        PlannedFile planned = Assert.Single(result.Plan!.Files);
+
+        Assert.Equal(PlannedAction.Convert, planned.Action);
+        Assert.Equal(AmbiguityClass.Unambiguous, planned.Ambiguity);
+        Assert.Equal(text, Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+    }
+
+    // ------------------------------------------------------------ explicit source
+
+    [Fact]
+    public void ExplicitSourceSelection_IsUsed_AndSafetyStillApplies()
+    {
+        byte[] bytes =
+            Encoding.GetEncoding("windows-1252").GetBytes("Le café était déjà prêt");
+        string path = Path.Combine(_root, "chosen.txt");
+        File.WriteAllBytes(path, bytes);
+
+        var plansShown = new List<ConversionPlan>();
+        var answered = false;
+
+        OrchestrationResult result = Convert(View(), plan =>
+        {
+            plansShown.Add(plan);
+
+            // Refused first; the user names an encoding; the plan comes back decided.
+            if (answered)
+                return ConfirmationResponse.Proceed;
+
+            answered = true;
+            return new ConfirmationResponse(
+                ConfirmationChoice.ChooseSourceEncoding, "koi8-r");
+        });
+
+        Assert.Equal(2, plansShown.Count);
+        Assert.Equal(PlannedAction.Refuse, Assert.Single(plansShown[0].Files).Action);
+
+        PlannedFile resolved = Assert.Single(plansShown[1].Files);
+
+        Assert.Equal(PlannedAction.Convert, resolved.Action);
+        Assert.Equal("koi8-r", resolved.SourceEncoding);
+        Assert.True(resolved.SourceWasSpecified);
+
+        // Used, not merely permitted: the chosen codec is what read the bytes.
+        Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
+        Assert.Equal(
+            Encoding.GetEncoding("koi8-r").GetString(bytes),
+            Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+    }
+
+    [Fact]
+    public void ExplicitSourceSelection_DoesNotSuspendStrictDecoding()
+    {
+        // EUC-JP bytes carrying a JIS X 0212 sequence code page 51932 cannot map.
+        // Naming the encoding does not make the bytes representable.
+        byte[] unrepresentable =
+            [0x8F, 0xB0, 0xDF, 0xB9, 0xA5, 0xA1, 0xA4, 0xC0, 0xA4, 0xB3];
+        string path = Path.Combine(_root, "undecodable.txt");
+        File.WriteAllBytes(path, unrepresentable);
+
+        var answered = false;
+
+        Convert(View(), _ =>
+        {
+            if (answered)
+                return ConfirmationResponse.Proceed;
+
+            answered = true;
+            return new ConfirmationResponse(
+                ConfirmationChoice.ChooseSourceEncoding, "euc-jp");
+        });
+
+        Assert.Equal(unrepresentable, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ExplicitSourceSelection_AppliesOnlyToTheFilesItWasAskedAbout()
+    {
+        // A mixed batch must not have one codec imposed on all of it because the user
+        // answered a question about two files.
+        const string japanese = "こんにちは世界。日本語のテキストです。";
+        string jp = Write("jp.txt", japanese, "shift_jis");
+        string ambiguous = Write("ambiguous.txt", "Le café était prêt", "windows-1252");
+
+        var answered = false;
+
+        Convert(View(), _ =>
+        {
+            if (answered)
+                return ConfirmationResponse.Proceed;
+
+            answered = true;
+            return new ConfirmationResponse(
+                ConfirmationChoice.ChooseSourceEncoding, "windows-1252");
+        });
+
+        // The Shift_JIS file was never in question and was not reinterpreted.
+        Assert.Equal(japanese, Encoding.UTF8.GetString(File.ReadAllBytes(jp)));
+        Assert.Equal(
+            "Le café était prêt", Encoding.UTF8.GetString(File.ReadAllBytes(ambiguous)));
+    }
+
+    [Fact]
+    public void ExplicitSourceSelection_AppliesOnlyToTheFilesTicked()
+    {
+        // A batch can hold refused files written in different encodings. One answer
+        // settles only the files it was given about, so the response carries its scope
+        // and the rest keep their refusal.
+        string french = Write("french.txt", "Le café était déjà prêt", "windows-1252");
+        string russian = Write("russian.txt", "Привет мир, это русский текст", "koi8-r");
+
+        byte[] russianBefore = File.ReadAllBytes(russian);
+        var answered = false;
+
+        OrchestrationResult result = Convert(View(), plan =>
+        {
+            if (answered)
+                return ConfirmationResponse.Proceed;
+
+            answered = true;
+
+            Assert.Equal(2, plan.Files.Count(f => f.Action == PlannedAction.Refuse));
+
+            return new ConfirmationResponse(
+                ConfirmationChoice.ChooseSourceEncoding,
+                "windows-1252",
+                [french]);
+        });
+
+        Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
+
+        // The one that was answered for converted, read as the chosen encoding.
+        Assert.Equal(
+            "Le café était déjà prêt",
+            Encoding.UTF8.GetString(File.ReadAllBytes(french)));
+
+        // The one that was not is still refused, and still exactly as it was.
+        Assert.Equal(russianBefore, File.ReadAllBytes(russian));
+        Assert.Equal(
+            PlannedAction.Refuse,
+            Assert.Single(result.Plan!.Files, f => f.RelativePath == "russian.txt").Action);
+    }
+
+    [Fact]
+    public void ChoosingAnEncodingForNoFilesChangesNothing()
+    {
+        // Unticking everything is a way of saying "none of these". It must not be read
+        // as approval of a conversion with an empty scope.
+        string path = Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
+        byte[] before = File.ReadAllBytes(path);
+
+        OrchestrationResult result = Convert(View(), _ => new ConfirmationResponse(
+            ConfirmationChoice.ChooseSourceEncoding, "windows-1252", []));
+
+        Assert.Equal(OrchestrationOutcome.Cancelled, result.Outcome);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    // ------------------------------------------------------- nothing gets modified
+
+    [Fact]
+    public void CancellingTheConfirmation_ModifiesNothing()
+    {
+        string jp = Write("jp.txt", "こんにちは世界。テキスト", "shift_jis");
+        string plain = Write("plain.txt", "plain ascii here", "ascii");
+
+        byte[] jpBefore = File.ReadAllBytes(jp);
+        byte[] plainBefore = File.ReadAllBytes(plain);
+
+        OrchestrationResult result = Convert(
+            View(), _ => ConfirmationResponse.Cancel, backup: true);
+
+        Assert.Equal(OrchestrationOutcome.Cancelled, result.Outcome);
+        Assert.Equal(jpBefore, File.ReadAllBytes(jp));
+        Assert.Equal(plainBefore, File.ReadAllBytes(plain));
+
+        // Not even a backup, which would be a modification of the directory.
+        Assert.Empty(Directory.GetFiles(_root, "*.bak"));
+    }
+
+    [Fact]
+    public void AFileChangedAfterTheConfirmation_StopsTheWholeRun()
+    {
+        // The user reads a dialog; that takes time. What they approved was the files as
+        // they were. All-or-nothing, as with -Apply: a plan is reviewed as a whole.
+        string stable = Write("stable.txt", "こんにちは世界。テキスト", "shift_jis");
+        string moving = Write("moving.txt", "さようなら世界。テキスト", "shift_jis");
+
+        byte[] stableBefore = File.ReadAllBytes(stable);
+
+        OrchestrationResult result = Convert(
+            View(),
+            Proceed,
+            betweenPlanAndWrite: _ =>
+                File.WriteAllBytes(moving, Encoding.UTF8.GetBytes("changed underneath")));
+
+        Assert.Equal(OrchestrationOutcome.PlanWentStale, result.Outcome);
+        Assert.Contains("changed after the conversion was planned", result.Message);
+
+        // Neither file, not just the one that moved.
+        Assert.Equal(stableBefore, File.ReadAllBytes(stable));
+        Assert.Equal("changed underneath", File.ReadAllText(moving));
+    }
+
+    [Fact]
+    public void AFailedBackup_LeavesTheSourceUntouched()
+    {
+        string path = Write("backupfail.txt", "こんにちは世界。テキスト", "shift_jis");
+        byte[] before = File.ReadAllBytes(path);
+
+        // A directory where the .bak must go: the copy cannot succeed.
+        Directory.CreateDirectory(path + ".bak");
+
+        Convert(View(), Proceed, backup: true);
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ContentTheTargetCannotHold_LeavesTheSourceUntouched()
+    {
+        // Post-conversion verification cannot pass, so nothing is installed.
+        string path = Write("unencodable.txt", "世界 مرحبا", "utf-8");
+        byte[] before = File.ReadAllBytes(path);
+
+        Convert(View(), Proceed, target: "windows-1252");
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void APreviewNeverAsksAndNeverWrites()
+    {
+        // A preview writes nothing, so it is its own answer. Asking would be asking
+        // permission to do nothing.
+        string path = Write("jp.txt", "こんにちは世界。テキスト", "shift_jis");
+        byte[] before = File.ReadAllBytes(path);
+
+        var asked = false;
+
+        OrchestrationResult result = Convert(
+            View(),
+            _ =>
+            {
+                asked = true;
+                return ConfirmationResponse.Proceed;
+            },
+            preview: true);
+
+        Assert.Equal(OrchestrationOutcome.Previewed, result.Outcome);
+        Assert.False(asked);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void AnUndecidedEntryStopsTheRunRatherThanBeingConverted()
+    {
+        // The shape of the original defect, driven through the real sequence. An entry
+        // nobody classified must never read as one that is safe to convert.
+        string path = Write("jp.txt", "こんにちは世界。テキスト", "shift_jis");
+        byte[] before = File.ReadAllBytes(path);
+
+        ConversionReportEntry entry = Assert.Single(View());
+
+        Assert.Null(entry.Action);
+        Assert.Null(entry.Ambiguity);
+
+        // A conversion pass is what decides. Planning without one cannot proceed.
+        Assert.Throws<InvalidOperationException>(() => ConversionPlan.FromEntries(
+            [entry], _root, "utf-8", targetHasBom: false,
+            backupEnabled: false, explicitSource: null));
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+}

--- a/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
@@ -1,0 +1,419 @@
+﻿using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// One policy engine, asked by every surface.
+///
+/// This exists because the GUI had quietly grown a second answer. Ambiguity was
+/// classified only during a Convert-mode scan; the GUI scans in Detect mode and converts
+/// the rows the user checks, so every entry arrived carrying the default "unambiguous"
+/// and the refusal never fired. The tool converted, on the strength of whatever detection
+/// returned, the exact files it tells CLI users it will not convert — and nothing failed,
+/// because no test drove the GUI's sequence.
+///
+/// The lesson is the one the audit already taught once: a safety rule enforced at one
+/// call site is a safety rule the next call site does not have. So the decision lives in
+/// <see cref="ConversionPolicy"/>, and these pin that every route reaches it.
+/// </summary>
+public sealed class ConversionPolicyTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_policy_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string Write(string name, string text, string charset)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllBytes(path, Encoding.GetEncoding(charset).GetBytes(text));
+        return path;
+    }
+
+    /// <summary>Detect-mode scan then convert the rows: what the GUI's buttons do.</summary>
+    private List<ConversionReportEntry> ViewThenConvert(
+        string target = "utf-8", bool whatIf = false)
+    {
+        var scanned = new List<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["*"],
+                Action = ScanAction.Detect,
+            },
+            scanned.Add,
+            CancellationToken.None);
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            scanned,
+            target,
+            targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: whatIf,
+            backup: false,
+            completed.Add,
+            CancellationToken.None);
+
+        return completed;
+    }
+
+    [Fact]
+    public void TheGuiSequenceRefusesWhatTheCliRefuses()
+    {
+        // The regression. Before the policy was extracted this converted the file.
+        byte[] original =
+            Encoding.GetEncoding("windows-1252").GetBytes("Le café était déjà prêt");
+        string path = Path.Combine(_root, "ambiguous.txt");
+        File.WriteAllBytes(path, original);
+
+        ConversionReportEntry entry = Assert.Single(ViewThenConvert());
+
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.Equal(AmbiguityClass.TextChanging, entry.Ambiguity);
+        Assert.Contains("could not be determined uniquely", entry.Diagnostic);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void TheGuiSequenceStillConvertsWhatIsSafe()
+    {
+        // The other direction. A gate that refuses everything is not safe, it is broken.
+        const string text = "こんにちは世界。日本語のテキストです。";
+        string path = Write("jp.txt", text, "shift_jis");
+
+        ConversionReportEntry entry = Assert.Single(ViewThenConvert());
+
+        Assert.Equal(PlannedAction.Convert, entry.Action);
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.Equal(text, Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+    }
+
+    [Fact]
+    public void BothSurfacesReachTheSameDecisionForTheSameFile()
+    {
+        // Stated directly rather than inferred from two separately-asserted outcomes.
+        Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
+        Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
+        Write("plain.txt", "just ascii here", "ascii");
+
+        Dictionary<string, PlannedAction?> viaGui = ViewThenConvert(whatIf: true)
+            .ToDictionary(e => Path.GetFileName(e.FilePath), e => e.Action);
+
+        var viaCli = new List<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["*"],
+                Action = ScanAction.Convert,
+                TargetCharset = "utf-8",
+                TargetWriteBom = false,
+                WhatIf = true,
+            },
+            viaCli.Add,
+            CancellationToken.None);
+
+        Assert.Equal(3, viaGui.Count);
+
+        foreach (ConversionReportEntry entry in viaCli)
+            Assert.Equal(entry.Action, viaGui[Path.GetFileName(entry.FilePath)]);
+    }
+
+    [Fact]
+    public void TheThreeClassificationsMapToTheirActions()
+    {
+        // Unambiguous converts; several codecs agreeing on the text converts, with the
+        // ambiguity disclosed; several codecs disagreeing refuses until somebody chooses.
+        // These three are the whole user-facing contract of the refusal.
+        AssertMaps(AmbiguityClass.Unambiguous, PlannedAction.Convert, discloses: false);
+        AssertMaps(AmbiguityClass.TextEquivalent, PlannedAction.Convert, discloses: true);
+        AssertMaps(AmbiguityClass.TextChanging, PlannedAction.Refuse, discloses: false);
+    }
+
+    private static void AssertMaps(
+        AmbiguityClass ambiguity, PlannedAction expected, bool discloses)
+    {
+        PlannedAction action = ConversionPolicy.Decide(
+            "windows-1252", sourceHasBom: false,
+            "utf-8", targetHasBom: false,
+            ambiguity, ["iso-8859-1"], out string? reason);
+
+        Assert.Equal(expected, action);
+
+        // A refusal always says why; a conversion never needs to.
+        Assert.Equal(expected == PlannedAction.Refuse, reason is not null);
+        Assert.Equal(discloses, ConversionPolicy.NeedsDisclosure(ambiguity));
+    }
+
+    [Fact]
+    public void AFileAlreadyInTheTargetEncodingIsNotRefusedForAmbiguity()
+    {
+        // Nothing is written, so there is no reading of it to get wrong. Refusing here
+        // would report a danger that does not exist.
+        Assert.Equal(
+            PlannedAction.Unchanged,
+            ConversionPolicy.Decide(
+                "utf-8", sourceHasBom: false,
+                "utf-8", targetHasBom: false,
+                AmbiguityClass.TextChanging, ["iso-8859-1"], out _));
+    }
+
+    [Fact]
+    public void AnUnidentifiedSourceIsSkippedByBothTheGuardAndThePolicy()
+    {
+        // ConvertFiles has to answer for an unidentified source before it can resolve an
+        // Encoding, so it cannot reach the policy. The two must not drift apart.
+        Assert.Equal(
+            PlannedAction.Skip,
+            ConversionPolicy.Decide(
+                ScanEngine.UNKNOWN_CHARSET, sourceHasBom: false,
+                "utf-8", targetHasBom: false,
+                AmbiguityClass.Unambiguous, [], out _));
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = Write("binary.bin", "irrelevant", "ascii"),
+            SourceEncoding = ScanEngine.UNKNOWN_CHARSET,
+            SourceHasBom = false,
+            TargetEncoding = "utf-8",
+            TargetHasBom = false,
+        };
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false, backup: false, completed.Add, CancellationToken.None);
+
+        Assert.Equal(PlannedAction.Skip, Assert.Single(completed).Action);
+    }
+
+    [Fact]
+    public void AnExplicitSourceSkipsClassificationButNotTheConversionSafeguards()
+    {
+        // Explicit source is an answer to "which encoding is this?", not permission to
+        // convert regardless. EUC-JP bytes carrying a JIS X 0212 sequence still cannot
+        // be decoded by code page 51932.
+        byte[] unrepresentable =
+            [0x8F, 0xB0, 0xDF, 0xB9, 0xA5, 0xA1, 0xA4, 0xC0, 0xA4, 0xB3];
+        string path = Path.Combine(_root, "named.txt");
+        File.WriteAllBytes(path, unrepresentable);
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "euc-jp",
+            SourceHasBom = false,
+            TargetEncoding = "euc-jp",
+            TargetHasBom = false,
+            SourceEncodingWasSpecified = true,
+        };
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false, backup: false, completed.Add, CancellationToken.None);
+
+        ConversionReportEntry result = Assert.Single(completed);
+
+        // The policy let it through - naming the encoding settled the ambiguity - and
+        // the conversion engine refused it anyway.
+        Assert.Equal(PlannedAction.Convert, result.Action);
+        Assert.Equal(ConversionRowResult.Error, result.Result);
+        Assert.Equal(unrepresentable, File.ReadAllBytes(path));
+    }
+
+    /// <summary>
+    /// What the confirmation dialog does when the user answers a refusal by naming the
+    /// encoding: the same override <c>-From</c> uses, applied to the refused entries.
+    /// </summary>
+    private static void ChooseSourceEncoding(
+        ConversionReportEntry entry, string charset)
+    {
+        entry.CurrentCharsetLabel = charset;
+        entry.SourceEncodingWasSpecified = true;
+        entry.Ambiguity = AmbiguityClass.Unambiguous;
+        entry.AmbiguityReason = AmbiguityReason.ExplicitlySpecified;
+        entry.CompetingEncodings = [];
+        entry.Diagnostic = null;
+        entry.Action = null;
+    }
+
+    [Fact]
+    public void ChoosingTheSourceEncodingResolvesARefusalInTheGui()
+    {
+        // The refusal tells the user to say which encoding it is. Saying so has to work,
+        // or the safety feature issues advice its own interface cannot take.
+        byte[] bytes = Encoding.GetEncoding("windows-1252").GetBytes("Le café était prêt");
+        string path = Path.Combine(_root, "ambiguous.txt");
+        File.WriteAllBytes(path, bytes);
+
+        ConversionReportEntry entry = Assert.Single(ViewThenConvert());
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+
+        ChooseSourceEncoding(entry, "windows-1252");
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false, backup: false, completed.Add, CancellationToken.None);
+
+        ConversionReportEntry result = Assert.Single(completed);
+
+        Assert.Equal(PlannedAction.Convert, result.Action);
+        Assert.Equal(ConversionRowResult.Converted, result.Result);
+        Assert.Equal("Le café était prêt", Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+    }
+
+    [Fact]
+    public void TheChosenEncodingIsWhatTheConversionActuallyUses()
+    {
+        // Not just permission to proceed. Naming a different encoding for the same bytes
+        // has to produce different text, or the choice is decoration.
+        byte[] bytes = Encoding.GetEncoding("windows-1252").GetBytes("café");
+        string path = Path.Combine(_root, "interpretation.txt");
+        File.WriteAllBytes(path, bytes);
+
+        ConversionReportEntry entry = Assert.Single(ViewThenConvert());
+        ChooseSourceEncoding(entry, "koi8-r");
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false, backup: false, completed.Add, CancellationToken.None);
+
+        Assert.Equal(ConversionRowResult.Converted, Assert.Single(completed).Result);
+
+        string text = Encoding.UTF8.GetString(File.ReadAllBytes(path));
+
+        Assert.NotEqual("café", text);
+        Assert.Equal(Encoding.GetEncoding("koi8-r").GetString(bytes), text);
+    }
+
+    [Fact]
+    public void APlanShowsTheChosenEncodingRatherThanTheDetectedOne()
+    {
+        // The confirmation is read after the choice is made. It has to describe the
+        // conversion that will happen, not the one that was refused.
+        File.WriteAllBytes(
+            Path.Combine(_root, "ambiguous.txt"),
+            Encoding.GetEncoding("windows-1252").GetBytes("Le café était prêt"));
+
+        ConversionReportEntry entry = Assert.Single(ViewThenConvert(whatIf: true));
+        Assert.NotEqual("koi8-r", entry.SourceEncoding);
+
+        ChooseSourceEncoding(entry, "koi8-r");
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: true, backup: false, _ => { }, CancellationToken.None);
+
+        ConversionPlan plan = ConversionPlan.FromEntries(
+            [entry], _root, "utf-8", targetHasBom: false,
+            backupEnabled: false, explicitSource: "koi8-r");
+
+        PlannedFile planned = Assert.Single(plan.Files);
+
+        Assert.Equal("koi8-r", planned.SourceEncoding);
+        Assert.Equal(PlannedAction.Convert, planned.Action);
+        Assert.True(planned.SourceWasSpecified);
+        Assert.False(planned.MayChangeText);
+    }
+
+    [Fact]
+    public void ChoosingAnEncodingTheBytesCannotBeIsStillRefused()
+    {
+        // Explicit source ends the ambiguity question, not the conversion safeguards.
+        // These EUC-JP bytes carry a JIS X 0212 sequence code page 51932 cannot map.
+        byte[] unrepresentable =
+            [0x8F, 0xB0, 0xDF, 0xB9, 0xA5, 0xA1, 0xA4, 0xC0, 0xA4, 0xB3];
+        string path = Path.Combine(_root, "undecodable.txt");
+        File.WriteAllBytes(path, unrepresentable);
+
+        List<ConversionReportEntry> scanned = ViewThenConvert(whatIf: true);
+        ConversionReportEntry entry = Assert.Single(scanned);
+
+        ChooseSourceEncoding(entry, "euc-jp");
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false, backup: false, completed.Add, CancellationToken.None);
+
+        Assert.Equal(ConversionRowResult.Error, Assert.Single(completed).Result);
+        Assert.Equal(unrepresentable, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ChoosingAnEncodingDoesNotSkipTheBackupRequirement()
+    {
+        byte[] original = Encoding.GetEncoding("windows-1252").GetBytes("café");
+        string path = Path.Combine(_root, "backupfail.txt");
+        File.WriteAllBytes(path, original);
+
+        ConversionReportEntry entry = Assert.Single(ViewThenConvert(whatIf: true));
+        ChooseSourceEncoding(entry, "windows-1252");
+
+        // A directory where the .bak has to go: the copy cannot succeed.
+        Directory.CreateDirectory(path + ".bak");
+
+        var completed = new List<ConversionReportEntry>();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false, backup: true, completed.Add, CancellationToken.None);
+
+        Assert.Equal(ConversionRowResult.Error, Assert.Single(completed).Result);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void AnEntryNobodyDecidedOnCannotReachAPlan()
+    {
+        // The shape of the bug this class exists for: an entry that never went through
+        // the policy must not be planned as a conversion by default.
+        var undecided = new ConversionReportEntry
+        {
+            FilePath = Write("undecided.txt", "text", "ascii"),
+            SourceEncoding = "us-ascii",
+            SourceHasBom = false,
+            TargetEncoding = "utf-8",
+            TargetHasBom = false,
+        };
+
+        Assert.Null(undecided.Action);
+
+        Assert.Throws<InvalidOperationException>(() => ConversionPlan.FromEntries(
+            [undecided], _root, "utf-8", targetHasBom: false,
+            backupEnabled: false, explicitSource: null));
+    }
+}

--- a/sources/EncodingChecker.Tests/DetectionCountTests.cs
+++ b/sources/EncodingChecker.Tests/DetectionCountTests.cs
@@ -1,0 +1,233 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// EC works out a file's encoding exactly once, and never again between the moment a
+/// decision is approved and the moment it is carried out.
+///
+/// That property is what makes a preview a promise rather than a demonstration. A second
+/// pass over the same bytes can answer differently — detection is a heuristic — and it
+/// was the first answer the user agreed to. Every surface is built not to do it. But
+/// "built not to" is an architectural claim, and this project has already been caught by
+/// one of those: the GUI was built to apply the ambiguity refusal too, and did not.
+///
+/// So it is counted. Two counts, because they are separate questions that fail the same
+/// way: <em>which encoding is this</em>, and <em>do the bytes settle it</em>.
+/// </summary>
+public sealed class DetectionCountTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_counts_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private void Write(string name, string text, string charset) =>
+        File.WriteAllBytes(
+            Path.Combine(_root, name), Encoding.GetEncoding(charset).GetBytes(text));
+
+    private void WriteThreeFiles()
+    {
+        Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
+        Write("zh.txt", "这是一段简体中文文本内容", "gb18030");
+        Write("plain.txt", "plain ascii, no high bytes at all", "ascii");
+    }
+
+    /// <summary>Counts what one operation costs, from zero.</summary>
+    private static (long Detections, long Classifications) Measure(Action operation)
+    {
+        DetectionCounters.Reset();
+        operation();
+
+        return (DetectionCounters.Detections, DetectionCounters.Classifications);
+    }
+
+    private List<ConversionReportEntry> View()
+    {
+        var scanned = new List<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["*"],
+                Action = ScanAction.Detect,
+            },
+            scanned.Add,
+            CancellationToken.None);
+
+        return scanned;
+    }
+
+    [Fact]
+    public void TheGuiSequenceWorksOutEachEncodingExactlyOnce()
+    {
+        WriteThreeFiles();
+
+        List<ConversionReportEntry> entries = [];
+
+        // View: three files, three detections, and nothing classified yet - which is
+        // precisely why the classification cannot live in the scan.
+        var view = Measure(() => entries = View());
+
+        Assert.Equal(3, view.Detections);
+        Assert.Equal(0, view.Classifications);
+
+        long confirmations = 0;
+        (long Detections, long Classifications) atConfirmation = (-1, -1);
+
+        var convert = Measure(() =>
+            new ConversionOrchestrator(plan =>
+                {
+                    confirmations++;
+
+                    // Building and reading the plan must cost nothing. A confirmation
+                    // that re-derives anything is a confirmation that can disagree with
+                    // what it is confirming.
+                    atConfirmation = (
+                        DetectionCounters.Detections,
+                        DetectionCounters.Classifications);
+
+                    return ConfirmationResponse.Proceed;
+                })
+                .Run(
+                    entries, _root, "utf-8", targetWriteBom: false,
+                    backup: false, preview: false,
+                    ScanEngine.DefaultMaxParallelism,
+                    _ => { },
+                    CancellationToken.None));
+
+        Assert.Equal(1, confirmations);
+
+        // Classified once each by the deciding pass; detected not at all, because View
+        // already answered that and the entries carry the answer.
+        Assert.Equal(3, atConfirmation.Classifications);
+        Assert.Equal(0, atConfirmation.Detections);
+
+        // And the pass that actually writes adds nothing to either count.
+        Assert.Equal(3, convert.Classifications);
+        Assert.Equal(0, convert.Detections);
+    }
+
+    [Fact]
+    public void AnsweringARefusalClassifiesOnlyTheFilesItWasAskedAbout()
+    {
+        // Re-planning after an explicit choice must not re-examine the whole batch.
+        Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
+        Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
+
+        List<ConversionReportEntry> entries = View();
+        var answered = false;
+
+        var convert = Measure(() =>
+            new ConversionOrchestrator(_ =>
+                {
+                    if (answered)
+                        return ConfirmationResponse.Proceed;
+
+                    answered = true;
+                    return new ConfirmationResponse(
+                        ConfirmationChoice.ChooseSourceEncoding, "windows-1252");
+                })
+                .Run(
+                    entries, _root, "utf-8", targetWriteBom: false,
+                    backup: false, preview: false,
+                    ScanEngine.DefaultMaxParallelism,
+                    _ => { },
+                    CancellationToken.None));
+
+        // Two on the first pass. The re-plan classifies nothing at all: the file the user
+        // named needs no examining, and the other one keeps the decision it already had.
+        Assert.Equal(2, convert.Classifications);
+        Assert.Equal(0, convert.Detections);
+    }
+
+    [Fact]
+    public void WritingAPlanDetectsOncePerFileAndApplyingItDetectsNothing()
+    {
+        WriteThreeFiles();
+
+        string planPath = Path.Combine(_root, "plan.json");
+
+        var plan = Measure(() => Assert.Equal(0, Cli(
+            "-BasePath", _root, "-Target", "utf-8",
+            "-Plan", planPath, "-Quiet")));
+
+        Assert.Equal(3, plan.Detections);
+        Assert.Equal(3, plan.Classifications);
+
+        // The whole point of a plan. Applying it re-asserts what was recorded; it does
+        // not go back to the bytes to ask again.
+        var apply = Measure(() => Assert.Equal(0, Cli("-Apply", planPath)));
+
+        Assert.Equal(0, apply.Detections);
+        Assert.Equal(0, apply.Classifications);
+    }
+
+    [Fact]
+    public void AnOrdinaryCommandLineConversionAlsoWorksOutEachEncodingOnce()
+    {
+        WriteThreeFiles();
+
+        var run = Measure(() => Assert.Equal(0, Cli(
+            "-BasePath", _root, "-Target", "utf-8", "-Quiet")));
+
+        Assert.Equal(3, run.Detections);
+        Assert.Equal(3, run.Classifications);
+    }
+
+    [Fact]
+    public void ReadingAPlanCostsNothing()
+    {
+        // Isolated from the surrounding sequence: constructing and inspecting a plan must
+        // never reach the bytes. This is the property the confirmation dialog rests on.
+        WriteThreeFiles();
+
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(0, Cli(
+            "-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+
+        var read = Measure(() =>
+        {
+            ConversionPlan? loaded = ConversionPlan.Load(planPath, out _);
+
+            Assert.NotNull(loaded);
+            Assert.NotEmpty(loaded.Summarize());
+            Assert.Empty(loaded.FindStaleFiles());
+        });
+
+        Assert.Equal(0, read.Detections);
+        Assert.Equal(0, read.Classifications);
+    }
+
+    private static int Cli(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+}

--- a/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
+++ b/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 
@@ -38,6 +38,11 @@ public sealed class StaleConversionStateTests : IDisposable
             SourceHasBom = sourceHasBom,
             TargetEncoding = sourceEncoding,
             TargetHasBom = sourceHasBom,
+
+            // These name the source encoding rather than having it detected, which is
+            // what -From means. Without saying so, the ambiguity gate correctly refuses
+            // single-byte content whose encoding its bytes do not identify.
+            SourceEncodingWasSpecified = true,
         };
 
     private static ConversionReportEntry Convert(

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -27,6 +27,7 @@ internal sealed class ConversionConfirmationForm : Form
     private readonly ConversionPlan _plan;
     private readonly ComboBox _sourceChoice = new();
     private readonly Button _resolve = new();
+    private ListView? _refusedList;
 
     /// <summary>
     /// The encoding the user chose for the refused files, or <see langword="null"/> if
@@ -38,6 +39,17 @@ internal sealed class ConversionConfirmationForm : Form
     /// safeguard still applies to the files it is used for.
     /// </remarks>
     internal string? ChosenSourceEncoding { get; private set; }
+
+    /// <summary>
+    /// The files <see cref="ChosenSourceEncoding"/> applies to, as full paths.
+    /// </summary>
+    /// <remarks>
+    /// A subset, not all of them, because a batch can hold refused files written in
+    /// different encodings - Cyrillic in koi8-r beside French in windows-1252 - and one
+    /// answer settles only the files it was given about. Imposing it on the rest would
+    /// repeat the mistake the refusal exists to prevent, one level up.
+    /// </remarks>
+    internal IReadOnlyList<string> ChosenFiles { get; private set; } = [];
 
     internal ConversionConfirmationForm(ConversionPlan plan)
     {
@@ -141,16 +153,20 @@ internal sealed class ConversionConfirmationForm : Form
             MaximumSize = new Size(620, 0),
             ForeColor = Color.FromArgb(150, 40, 0),
             Text =
-                $"The source encoding of {refused.Count} file(s) could not be determined "
-                + "uniquely. More than one encoding fits the bytes, and they produce "
-                + "different text, so converting would pick one reading without saying "
-                + "so. No changes will be made to these files.",
+                $"{refused.Count} file(s) need an explicit source encoding. More than "
+                + "one encoding fits their bytes, and those encodings produce different "
+                + "text, so converting would pick one reading without saying so. No "
+                + "changes will be made to them."
+                + Environment.NewLine + Environment.NewLine
+                + "Untick any that are not in the encoding you choose - the files here "
+                + "may well be in different ones.",
         };
 
         var list = new ListView
         {
             View = View.Details,
             FullRowSelect = true,
+            CheckBoxes = true,
             Height = 120,
             Dock = DockStyle.Top,
         };
@@ -169,8 +185,15 @@ internal sealed class ConversionConfirmationForm : Form
                 + (file.CompetingEncodings.Count > 6
                     ? $", and {file.CompetingEncodings.Count - 6} more"
                     : string.Empty),
-            ]));
+            ])
+            {
+                Checked = true,
+                Tag = _plan.ResolvePath(file),
+            });
         }
+
+        _refusedList = list;
+        list.ItemChecked += (_, _) => UpdateScopeLabel();
 
         var chooser = new FlowLayoutPanel
         {
@@ -183,7 +206,7 @@ internal sealed class ConversionConfirmationForm : Form
         {
             AutoSize = true,
             Padding = new Padding(0, 6, 0, 0),
-            Text = "If you know which encoding these files are, choose it:",
+            Text = "Source encoding for the ticked files:",
         });
 
         _sourceChoice.DropDownStyle = ComboBoxStyle.DropDownList;
@@ -196,18 +219,18 @@ internal sealed class ConversionConfirmationForm : Form
             _sourceChoice.Items.Add(charset);
 
         _sourceChoice.SelectedIndex = 0;
-        _sourceChoice.SelectedIndexChanged += (_, _) =>
-            _resolve.Enabled = _sourceChoice.SelectedIndex > 0;
+        _sourceChoice.SelectedIndexChanged += (_, _) => UpdateScopeLabel();
 
-        _resolve.Text = "Use this encoding";
         _resolve.AutoSize = true;
-        _resolve.Enabled = false;
         _resolve.Click += (_, _) =>
         {
             ChosenSourceEncoding = (string)_sourceChoice.SelectedItem!;
+            ChosenFiles = TickedFiles();
             DialogResult = DialogResult.Retry;
             Close();
         };
+
+        UpdateScopeLabel();
 
         chooser.Controls.Add(_sourceChoice);
         chooser.Controls.Add(_resolve);
@@ -233,6 +256,28 @@ internal sealed class ConversionConfirmationForm : Form
         explanation.Dock = DockStyle.Top;
 
         return panel;
+    }
+
+    /// <summary>The refused files currently ticked, as full paths.</summary>
+    private List<string> TickedFiles() =>
+    [
+        .. (_refusedList?.CheckedItems.Cast<ListViewItem>()
+            ?? Enumerable.Empty<ListViewItem>())
+            .Select(i => i.Tag as string)
+            .Where(p => p is not null)
+            .Select(p => p!)
+    ];
+
+    /// <summary>
+    /// Keeps the button saying exactly how many files the choice would apply to, so the
+    /// scope of the answer is never something the user has to infer.
+    /// </summary>
+    private void UpdateScopeLabel()
+    {
+        int ticked = _refusedList?.CheckedItems.Count ?? 0;
+
+        _resolve.Text = $"Use this encoding for {ticked} file(s)";
+        _resolve.Enabled = ticked > 0 && _sourceChoice.SelectedIndex > 0;
     }
 
     private Control BuildButtons()

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace EncodingChecker;
+
+/// <summary>
+/// Shows what a conversion is about to do, and asks.
+/// </summary>
+/// <remarks>
+/// Displays a plan that has already been decided rather than working out the answer for
+/// itself. That is the whole point: a dialog that describes one set of conclusions and a
+/// conversion that reaches its own is a dialog that can be wrong, and the user approved
+/// what the dialog said. The same entries that were classified here are the ones that
+/// convert - no second detection pass, the same property <c>-Apply</c> has.
+/// <para>
+/// The three outcomes it has to keep apart are the ones the classification draws:
+/// an encoding the bytes determine, several codecs that agree on the text, and several
+/// codecs that disagree. Only the third is refused, and for it the dialog names the
+/// alternatives and offers the one thing that resolves it - saying which encoding it is.
+/// </para>
+/// </remarks>
+internal sealed class ConversionConfirmationForm : Form
+{
+    private readonly ConversionPlan _plan;
+    private readonly ComboBox _sourceChoice = new();
+    private readonly Button _resolve = new();
+
+    /// <summary>
+    /// The encoding the user chose for the refused files, or <see langword="null"/> if
+    /// they did not choose one.
+    /// </summary>
+    /// <remarks>
+    /// Exactly what <c>-From</c> supplies on the command line: an answer to "which
+    /// encoding is this?", replacing detection and nothing else. Every conversion
+    /// safeguard still applies to the files it is used for.
+    /// </remarks>
+    internal string? ChosenSourceEncoding { get; private set; }
+
+    internal ConversionConfirmationForm(ConversionPlan plan)
+    {
+        _plan = plan;
+
+        Text = "Confirm conversion";
+        FormBorderStyle = FormBorderStyle.Sizable;
+        StartPosition = FormStartPosition.CenterParent;
+        MinimizeBox = false;
+        MaximizeBox = false;
+        ShowInTaskbar = false;
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new Size(680, 520);
+        MinimumSize = new Size(560, 420);
+
+        Controls.Add(BuildBody());
+        Controls.Add(BuildButtons());
+    }
+
+    private int Count(PlannedAction action) =>
+        _plan.Files.Count(f => f.Action == action);
+
+    private List<PlannedFile> Refused =>
+        [.. _plan.Files.Where(f => f is { Action: PlannedAction.Refuse, MayChangeText: true })];
+
+    private Control BuildBody()
+    {
+        var body = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            Padding = new Padding(12),
+            AutoScroll = true,
+        };
+
+        int convert = Count(PlannedAction.Convert);
+        int equivalent = _plan.Files.Count(
+            f => f.Action == PlannedAction.Convert
+                 && f.Ambiguity == AmbiguityClass.TextEquivalent);
+
+        List<PlannedFile> refused = Refused;
+
+        body.Controls.Add(Heading(
+            $"Convert {convert} of {_plan.Files.Count} selected file(s) to "
+            + _plan.TargetEncoding
+            + (_plan.TargetHasBom ? " with BOM" : " without BOM")));
+
+        // The three states, kept apart. The counts sum to the selected population.
+        body.Controls.Add(Rows(
+        [
+            ("Encoding determined by the file's own bytes", convert - equivalent,
+             "Will convert."),
+            ("Encoding undetermined, every reading agrees on the text", equivalent,
+             "Will convert; the label is a choice, the content is not."),
+            ("Encoding undetermined, readings disagree on the text", refused.Count,
+             "WILL NOT be converted."),
+            ("Already in the target encoding", Count(PlannedAction.Unchanged),
+             "Nothing to do."),
+            ("Encoding could not be identified", Count(PlannedAction.Skip),
+             "Left alone."),
+            ("Could not be read", Count(PlannedAction.Refuse) - refused.Count,
+             "Left alone."),
+        ]));
+
+        body.Controls.Add(Rule());
+
+        body.Controls.Add(Rows(
+        [
+            ("Directory", _plan.BaseDirectory),
+            ("Source encoding",
+             string.IsNullOrEmpty(_plan.ExplicitSourceEncoding)
+                 ? "detected per file"
+                 : $"{_plan.ExplicitSourceEncoding} (chosen; detection bypassed)"),
+            ("Backups", _plan.BackupEnabled
+                ? "enabled — each original kept as <file>.bak"
+                : "DISABLED — originals will not be kept"),
+            ("Guarantees", ConversionSemantics.Describes),
+        ]));
+
+        if (refused.Count > 0)
+            body.Controls.Add(BuildRefusalPanel(refused));
+
+        foreach (Control control in body.Controls)
+            control.Dock = DockStyle.Top;
+
+        // Docked children stack in reverse, so the first added must be added last.
+        var ordered = body.Controls.Cast<Control>().Reverse().ToArray();
+        body.Controls.Clear();
+        body.Controls.AddRange(ordered);
+
+        return body;
+    }
+
+    private Control BuildRefusalPanel(List<PlannedFile> refused)
+    {
+        var panel = new Panel { AutoSize = true, Padding = new Padding(0, 12, 0, 0) };
+
+        var explanation = new Label
+        {
+            AutoSize = true,
+            MaximumSize = new Size(620, 0),
+            ForeColor = Color.FromArgb(150, 40, 0),
+            Text =
+                $"The source encoding of {refused.Count} file(s) could not be determined "
+                + "uniquely. More than one encoding fits the bytes, and they produce "
+                + "different text, so converting would pick one reading without saying "
+                + "so. No changes will be made to these files.",
+        };
+
+        var list = new ListView
+        {
+            View = View.Details,
+            FullRowSelect = true,
+            Height = 120,
+            Dock = DockStyle.Top,
+        };
+
+        list.Columns.Add("File", 200);
+        list.Columns.Add("Detected", 110);
+        list.Columns.Add("Also fits, reading it differently", 300);
+
+        foreach (PlannedFile file in refused.Take(200))
+        {
+            list.Items.Add(new ListViewItem(
+            [
+                file.RelativePath,
+                file.SourceEncoding,
+                string.Join(", ", file.CompetingEncodings.Take(6))
+                + (file.CompetingEncodings.Count > 6
+                    ? $", and {file.CompetingEncodings.Count - 6} more"
+                    : string.Empty),
+            ]));
+        }
+
+        var chooser = new FlowLayoutPanel
+        {
+            AutoSize = true,
+            Dock = DockStyle.Top,
+            Padding = new Padding(0, 8, 0, 0),
+        };
+
+        chooser.Controls.Add(new Label
+        {
+            AutoSize = true,
+            Padding = new Padding(0, 6, 0, 0),
+            Text = "If you know which encoding these files are, choose it:",
+        });
+
+        _sourceChoice.DropDownStyle = ComboBoxStyle.DropDownList;
+        _sourceChoice.Width = 160;
+        _sourceChoice.Items.Add("(leave them alone)");
+
+        // The same set the classifier drew its candidates from, so anything it named as
+        // a competing reading can be chosen here.
+        foreach (string charset in TextEncoding.SupportedCharsets)
+            _sourceChoice.Items.Add(charset);
+
+        _sourceChoice.SelectedIndex = 0;
+        _sourceChoice.SelectedIndexChanged += (_, _) =>
+            _resolve.Enabled = _sourceChoice.SelectedIndex > 0;
+
+        _resolve.Text = "Use this encoding";
+        _resolve.AutoSize = true;
+        _resolve.Enabled = false;
+        _resolve.Click += (_, _) =>
+        {
+            ChosenSourceEncoding = (string)_sourceChoice.SelectedItem!;
+            DialogResult = DialogResult.Retry;
+            Close();
+        };
+
+        chooser.Controls.Add(_sourceChoice);
+        chooser.Controls.Add(_resolve);
+
+        var note = new Label
+        {
+            AutoSize = true,
+            MaximumSize = new Size(620, 0),
+            ForeColor = SystemColors.GrayText,
+            Dock = DockStyle.Top,
+            Text =
+                "Choosing an encoding replaces detection for these files and nothing "
+                + "else: the bytes must still decode strictly as it, the result is still "
+                + "verified to hold exactly the same text, and a failed backup still "
+                + "stops the conversion.",
+        };
+
+        panel.Controls.Add(note);
+        panel.Controls.Add(chooser);
+        panel.Controls.Add(list);
+        panel.Controls.Add(explanation);
+
+        explanation.Dock = DockStyle.Top;
+
+        return panel;
+    }
+
+    private Control BuildButtons()
+    {
+        var strip = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Bottom,
+            FlowDirection = FlowDirection.RightToLeft,
+            Padding = new Padding(12),
+            AutoSize = true,
+        };
+
+        var cancel = new Button
+        {
+            Text = "Cancel",
+            DialogResult = DialogResult.Cancel,
+            AutoSize = true,
+        };
+
+        int convert = Count(PlannedAction.Convert);
+
+        var proceed = new Button
+        {
+            Text = convert > 0 ? $"Convert {convert} file(s)" : "Nothing to convert",
+            DialogResult = DialogResult.OK,
+            AutoSize = true,
+            Enabled = convert > 0,
+        };
+
+        strip.Controls.Add(cancel);
+        strip.Controls.Add(proceed);
+
+        AcceptButton = proceed;
+        CancelButton = cancel;
+
+        return strip;
+    }
+
+    private static Label Heading(string text) => new()
+    {
+        AutoSize = true,
+        Font = new Font(SystemFonts.MessageBoxFont!, FontStyle.Bold),
+        MaximumSize = new Size(620, 0),
+        Padding = new Padding(0, 0, 0, 8),
+        Text = text,
+    };
+
+    private static Control Rule() => new Label
+    {
+        BorderStyle = BorderStyle.Fixed3D,
+        Height = 2,
+        Margin = new Padding(0, 8, 0, 8),
+    };
+
+    private static Control Rows(IReadOnlyList<(string Label, int Count, string Note)> rows)
+    {
+        var table = new TableLayoutPanel
+        {
+            ColumnCount = 3,
+            RowCount = rows.Count,
+            AutoSize = true,
+        };
+
+        foreach ((string label, int count, string note) in rows)
+        {
+            // Zero-count categories are dropped: a list of noughts buries the lines that
+            // actually say something.
+            if (count == 0)
+                continue;
+
+            table.Controls.Add(new Label
+            {
+                AutoSize = true,
+                Text = count.ToString(),
+                Font = new Font(SystemFonts.MessageBoxFont!, FontStyle.Bold),
+                TextAlign = ContentAlignment.MiddleRight,
+                Width = 44,
+            });
+
+            table.Controls.Add(new Label { AutoSize = true, Text = label });
+            table.Controls.Add(new Label
+            {
+                AutoSize = true,
+                ForeColor = SystemColors.GrayText,
+                Text = note,
+            });
+        }
+
+        return table;
+    }
+
+    private static Control Rows(IReadOnlyList<(string Label, string Value)> rows)
+    {
+        var table = new TableLayoutPanel
+        {
+            ColumnCount = 2,
+            RowCount = rows.Count,
+            AutoSize = true,
+        };
+
+        foreach ((string label, string value) in rows)
+        {
+            table.Controls.Add(new Label
+            {
+                AutoSize = true,
+                ForeColor = SystemColors.GrayText,
+                Text = label,
+            });
+
+            table.Controls.Add(new Label
+            {
+                AutoSize = true,
+                MaximumSize = new Size(480, 0),
+                Text = value,
+            });
+        }
+
+        return table;
+    }
+}

--- a/sources/EncodingChecker/ConversionOrchestrator.cs
+++ b/sources/EncodingChecker/ConversionOrchestrator.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace EncodingChecker;
+
+/// <summary>What the person being asked said.</summary>
+internal enum ConfirmationChoice
+{
+    /// <summary>Carry out the plan as shown.</summary>
+    Proceed,
+
+    /// <summary>Change nothing.</summary>
+    Cancel,
+
+    /// <summary>Answer the refusal by naming the source encoding, then ask again.</summary>
+    ChooseSourceEncoding,
+}
+
+/// <summary>The answer, the encoding chosen when there was one, and what it applies to.</summary>
+/// <param name="Files">
+/// The files the chosen encoding applies to, or <see langword="null"/> for every refused
+/// file. Never every <em>selected</em> file: a batch can hold refused files in different
+/// encodings, and one answer is only an answer for the files it was given about.
+/// </param>
+internal readonly record struct ConfirmationResponse(
+    ConfirmationChoice Choice,
+    string? SourceEncoding = null,
+    IReadOnlyList<string>? Files = null)
+{
+    internal static readonly ConfirmationResponse Proceed = new(ConfirmationChoice.Proceed);
+
+    internal static readonly ConfirmationResponse Cancel = new(ConfirmationChoice.Cancel);
+}
+
+/// <summary>How a run ended.</summary>
+internal enum OrchestrationOutcome
+{
+    /// <summary>The conversion ran.</summary>
+    Converted,
+
+    /// <summary>A preview: what would happen, with nothing written.</summary>
+    Previewed,
+
+    /// <summary>The user declined. Nothing was written.</summary>
+    Cancelled,
+
+    /// <summary>Files changed between the plan and the confirmation. Nothing was written.</summary>
+    PlanWentStale,
+
+    /// <summary>The run could not be planned at all. Nothing was written.</summary>
+    CouldNotPlan,
+}
+
+/// <summary>The result of a run, and the plan the user was actually shown.</summary>
+internal sealed record OrchestrationResult
+{
+    internal required OrchestrationOutcome Outcome { get; init; }
+
+    /// <summary>The plan as confirmed, or <see langword="null"/> if it never got that far.</summary>
+    internal ConversionPlan? Plan { get; init; }
+
+    /// <summary>What to tell the user when nothing ran.</summary>
+    internal string? Message { get; init; }
+}
+
+/// <summary>
+/// Decide, then ask, then carry out exactly what was agreed.
+/// </summary>
+/// <remarks>
+/// This lives outside the form on purpose. The defect that prompted it - the GUI
+/// converting files the CLI refuses - was not in any component. Every component was
+/// correct and tested. It was in the sequence: a Detect-mode scan feeding entries into a
+/// conversion, with no step in between that classified them. Sequences that live inside a
+/// <c>Form</c>, spread across button handlers and background-worker callbacks, are
+/// sequences nothing can run end to end, and this project has now been shown what that
+/// costs.
+/// <para>
+/// So the sequence is a class, the confirmation is a delegate, and the conversion engine
+/// underneath is the real one. A test can drive the whole thing and read the bytes on
+/// disk afterwards.
+/// </para>
+/// </remarks>
+internal sealed class ConversionOrchestrator
+{
+    private readonly Func<ConversionPlan, ConfirmationResponse> _confirm;
+
+    /// <param name="confirm">
+    /// Shows a decided plan and returns what the user said. Called on whatever thread the
+    /// orchestrator runs on; a UI caller marshals inside it.
+    /// </param>
+    internal ConversionOrchestrator(Func<ConversionPlan, ConfirmationResponse> confirm) =>
+        _confirm = confirm;
+
+    /// <summary>
+    /// Runs one conversion: a pass that decides, a confirmation, and a pass that acts.
+    /// </summary>
+    /// <param name="entries">
+    /// The files to convert. Mutated in place, and the same objects are used by both
+    /// passes - which is what stops the second pass from classifying anything again.
+    /// </param>
+    /// <param name="preview">
+    /// When true, only the deciding pass runs. A preview writes nothing, so it is its own
+    /// answer and there is nothing to confirm.
+    /// </param>
+    internal OrchestrationResult Run(
+        IReadOnlyList<ConversionReportEntry> entries,
+        string baseDirectory,
+        string targetCharset,
+        bool targetWriteBom,
+        bool backup,
+        bool preview,
+        int maxParallelism,
+        Action<ConversionReportEntry> onEntry,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        // Pass one. Decides, writes nothing, and leaves the decision on each entry.
+        RunPass(
+            entries, targetCharset, targetWriteBom,
+            backup, whatIf: true, maxParallelism, onEntry, cancellationToken);
+
+        if (preview)
+            return new OrchestrationResult { Outcome = OrchestrationOutcome.Previewed };
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        while (true)
+        {
+            ConversionPlan plan;
+
+            try
+            {
+                plan = ConversionPlan.FromEntries(
+                    entries, baseDirectory, targetCharset, targetWriteBom, backup,
+                    explicitSource: entries.All(e => e.SourceEncodingWasSpecified)
+                                    && entries.Count > 0
+                        ? entries[0].EffectiveSourceLabel
+                        : null);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // An entry that got here undecided or unclassified is a bug in the
+                // caller. Nothing has been written, and nothing will be.
+                return new OrchestrationResult
+                {
+                    Outcome = OrchestrationOutcome.CouldNotPlan,
+                    Message = ex.Message,
+                };
+            }
+
+            ConfirmationResponse response = _confirm(plan);
+
+            if (response.Choice == ConfirmationChoice.Cancel)
+            {
+                return new OrchestrationResult
+                {
+                    Outcome = OrchestrationOutcome.Cancelled,
+                    Plan = plan,
+                };
+            }
+
+            if (response.Choice == ConfirmationChoice.ChooseSourceEncoding)
+            {
+                // The user answered the refusal. Only the files it was about change, so a
+                // mixed batch does not have one codec imposed on all of it.
+                if (!ApplyChosenSource(
+                        response.SourceEncoding, response.Files, entries))
+                {
+                    return new OrchestrationResult
+                    {
+                        Outcome = OrchestrationOutcome.Cancelled,
+                        Plan = plan,
+                    };
+                }
+
+                RunPass(
+                    entries, targetCharset, targetWriteBom,
+                    backup, whatIf: true, maxParallelism, onEntry, cancellationToken);
+
+                continue;
+            }
+
+            // Confirmed. The same check -Apply makes, for the same reason: the plan was
+            // approved for the files as they were, and a person reading a dialog takes
+            // time. All-or-nothing, because a plan is reviewed as a whole.
+            IReadOnlyList<string> stale = plan.FindStaleFiles();
+
+            if (stale.Count > 0)
+            {
+                return new OrchestrationResult
+                {
+                    Outcome = OrchestrationOutcome.PlanWentStale,
+                    Plan = plan,
+                    Message =
+                        $"{stale.Count} file(s) changed after the conversion was planned, "
+                        + "so nothing was converted. Run View again to start from the "
+                        + "files as they are now."
+                        + Environment.NewLine + Environment.NewLine
+                        + string.Join(Environment.NewLine, stale.Take(10)),
+                };
+            }
+
+            // Carried again at the moment of installation, so the window between the
+            // check above and each individual write is narrowed too.
+            BindToPlannedBytes(entries, plan);
+
+            RunPass(
+                entries, targetCharset, targetWriteBom,
+                backup, whatIf: false, maxParallelism, onEntry, cancellationToken);
+
+            return new OrchestrationResult
+            {
+                Outcome = OrchestrationOutcome.Converted,
+                Plan = plan,
+            };
+        }
+    }
+
+    private static void RunPass(
+        IReadOnlyList<ConversionReportEntry> entries,
+        string targetCharset,
+        bool targetWriteBom,
+        bool backup,
+        bool whatIf,
+        int maxParallelism,
+        Action<ConversionReportEntry> onEntry,
+        CancellationToken cancellationToken) =>
+        ScanEngine.ConvertFiles(
+            entries,
+            targetCharset,
+            targetWriteBom,
+            maxParallelism,
+            whatIf: whatIf,
+            backup: backup,
+            onEntry,
+            cancellationToken);
+
+    /// <summary>
+    /// Replaces detection with the user's answer, for the refused files only.
+    /// </summary>
+    /// <returns><see langword="false"/> if there was nothing to apply it to.</returns>
+    private static bool ApplyChosenSource(
+        string? charset,
+        IReadOnlyList<string>? files,
+        IReadOnlyList<ConversionReportEntry> entries)
+    {
+        if (string.IsNullOrWhiteSpace(charset))
+            return false;
+
+        HashSet<string>? scope = files is null
+            ? null
+            : new HashSet<string>(files, StringComparer.OrdinalIgnoreCase);
+
+        var changed = false;
+
+        foreach (ConversionReportEntry entry in entries)
+        {
+            if (entry.Action != PlannedAction.Refuse || !entry.MayChangeText())
+                continue;
+
+            if (scope is not null && !scope.Contains(entry.FilePath))
+                continue;
+
+            // The engine's existing override point: SourceEncoding keeps the scan's
+            // answer for the report, and this is what the conversion reads.
+            entry.CurrentCharsetLabel = charset;
+            entry.SourceEncodingWasSpecified = true;
+            entry.CompetingEncodings = [];
+            entry.Diagnostic = null;
+
+            // Cleared together so the policy decides again rather than reusing the
+            // refusal, and re-records the classification for the new source.
+            entry.Action = null;
+            entry.Ambiguity = null;
+
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Ties each entry to the bytes the plan was approved for.
+    /// </summary>
+    private static void BindToPlannedBytes(
+        IReadOnlyList<ConversionReportEntry> entries, ConversionPlan plan)
+    {
+        Dictionary<string, string> hashes = plan.Files
+            .Where(f => f.Action == PlannedAction.Convert)
+            .ToDictionary(
+                f => plan.ResolvePath(f) ?? f.RelativePath,
+                f => f.Sha256,
+                StringComparer.OrdinalIgnoreCase);
+
+        foreach (ConversionReportEntry entry in entries)
+        {
+            entry.ExpectedSourceSha256 =
+                hashes.TryGetValue(entry.FilePath, out string? hash) ? hash : null;
+        }
+    }
+}

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -262,7 +262,10 @@ internal sealed record ConversionPlan
                 SourceCodePage = codePage,
                 SourceHasBom = sourceHasBom,
                 SourceWasSpecified = entry.SourceEncodingWasSpecified,
-                Ambiguity = entry.Ambiguity,
+                Ambiguity = entry.Ambiguity
+                    ?? throw new InvalidOperationException(
+                        $"'{entry.FilePath}' reached a conversion plan without being "
+                        + "classified."),
                 AmbiguityReason = entry.AmbiguityReason,
                 CompetingEncodings = entry.CompetingEncodings,
                 Reason = string.IsNullOrEmpty(entry.Diagnostic) ? null : entry.Diagnostic,

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -207,13 +207,15 @@ internal sealed record ConversionPlan
 
         foreach (ConversionReportEntry entry in entries)
         {
-            PlannedAction action = entry.Result switch
-            {
-                ConversionRowResult.Unchanged => PlannedAction.Unchanged,
-                ConversionRowResult.Skipped => PlannedAction.Skip,
-                ConversionRowResult.Error => PlannedAction.Refuse,
-                _ => PlannedAction.Convert,
-            };
+            // Taken from the decision itself rather than re-derived from the row result,
+            // which cannot tell a refusal apart from a conversion that failed. An
+            // undecided entry is a caller that skipped the policy, and planning a
+            // conversion nobody decided on is the failure this whole mechanism exists to
+            // prevent - so it is raised, not defaulted.
+            PlannedAction action = entry.Action
+                ?? throw new InvalidOperationException(
+                    $"'{entry.FilePath}' reached a conversion plan without a decision. "
+                    + "Entries must go through a conversion pass before being planned.");
 
             string hash;
             long size;
@@ -232,11 +234,18 @@ internal sealed record ConversionPlan
                 action = PlannedAction.Refuse;
             }
 
+            // What the conversion will actually read the file as, which is not always
+            // the scan's original answer: a user may have named the encoding since.
+            ScanEngine.ParseCharsetLabel(
+                entry.EffectiveSourceLabel,
+                out string sourceCharset,
+                out bool sourceHasBom);
+
             int codePage = 0;
 
             try
             {
-                codePage = Encoding.GetEncoding(entry.SourceEncoding).CodePage;
+                codePage = Encoding.GetEncoding(sourceCharset).CodePage;
             }
             catch (ArgumentException)
             {
@@ -249,9 +258,9 @@ internal sealed record ConversionPlan
                 Size = size,
                 Sha256 = hash,
                 Action = action,
-                SourceEncoding = entry.SourceEncoding,
+                SourceEncoding = sourceCharset,
                 SourceCodePage = codePage,
-                SourceHasBom = entry.SourceHasBom,
+                SourceHasBom = sourceHasBom,
                 SourceWasSpecified = entry.SourceEncodingWasSpecified,
                 Ambiguity = entry.Ambiguity,
                 AmbiguityReason = entry.AmbiguityReason,

--- a/sources/EncodingChecker/ConversionPolicy.cs
+++ b/sources/EncodingChecker/ConversionPolicy.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+
+namespace EncodingChecker;
+
+/// <summary>
+/// The one place that decides what happens to a file.
+/// </summary>
+/// <remarks>
+/// Every surface - the CLI, a written plan, and the GUI - asks this and acts on the
+/// answer, rather than each working out for itself what is safe. That is not tidiness.
+/// The GUI previously reached its own conclusion by omission: ambiguity was classified
+/// only during a Convert-mode scan, and the GUI scans in Detect mode, so every entry
+/// arrived at conversion carrying the default "unambiguous" and the refusal that the
+/// CLI applied never fired. The tool converted, on the strength of whatever detection
+/// returned, the exact files it tells CLI users it will not convert.
+/// <para>
+/// A safety rule that lives at one call site is a safety rule the next call site does
+/// not have.
+/// </para>
+/// </remarks>
+internal static class ConversionPolicy
+{
+    /// <summary>
+    /// Decides what to do with one file, given what is known about its encoding.
+    /// </summary>
+    /// <param name="reason">
+    /// Why, in words a user can act on, when the answer is not a plain conversion.
+    /// </param>
+    internal static PlannedAction Decide(
+        string sourceCharset,
+        bool sourceHasBom,
+        string targetCharset,
+        bool targetHasBom,
+        AmbiguityClass ambiguity,
+        IReadOnlyList<string> competingEncodings,
+        out string? reason)
+    {
+        reason = null;
+
+        if (string.Equals(
+                sourceCharset, ScanEngine.UNKNOWN_CHARSET, StringComparison.Ordinal))
+        {
+            reason = "The file's encoding could not be identified from its contents.";
+            return PlannedAction.Skip;
+        }
+
+        // Checked before ambiguity on purpose: a file already in the target encoding is
+        // not written at all, so there is no reading of it to get wrong.
+        if (string.Equals(sourceCharset, targetCharset, StringComparison.OrdinalIgnoreCase)
+            && sourceHasBom == targetHasBom)
+        {
+            return PlannedAction.Unchanged;
+        }
+
+        // The bytes do not identify the encoding that wrote them, and the readings that
+        // fit disagree about the text. Detection still produced an answer; acting on it
+        // rewrites the file into one of several possible readings without saying so.
+        if (ambiguity == AmbiguityClass.TextChanging)
+        {
+            reason = AmbiguityAnalysis.DescribeRefusal(sourceCharset, competingEncodings);
+            return PlannedAction.Refuse;
+        }
+
+        return PlannedAction.Convert;
+    }
+
+    /// <summary>
+    /// How an action reads in a report row.
+    /// </summary>
+    internal static ConversionRowResult ToRowResult(PlannedAction action) => action switch
+    {
+        PlannedAction.Unchanged => ConversionRowResult.Unchanged,
+        PlannedAction.Skip => ConversionRowResult.Skipped,
+        PlannedAction.Refuse => ConversionRowResult.Error,
+        _ => ConversionRowResult.Converted,
+    };
+
+    /// <summary>
+    /// Whether converting this file could change its Unicode content, as opposed to only
+    /// re-labelling it.
+    /// </summary>
+    /// <remarks>
+    /// The distinction a confirmation has to draw. A file whose encoding is undetermined
+    /// but whose candidate readings all agree on the text - plain ASCII being the common
+    /// case - is not something to warn about; a file whose candidates disagree is.
+    /// </remarks>
+    internal static bool NeedsDisclosure(AmbiguityClass ambiguity) =>
+        ambiguity == AmbiguityClass.TextEquivalent;
+}

--- a/sources/EncodingChecker/ConversionPolicy.cs
+++ b/sources/EncodingChecker/ConversionPolicy.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace EncodingChecker;
@@ -32,7 +32,7 @@ internal static class ConversionPolicy
         bool sourceHasBom,
         string targetCharset,
         bool targetHasBom,
-        AmbiguityClass ambiguity,
+        AmbiguityClass? ambiguity,
         IReadOnlyList<string> competingEncodings,
         out string? reason)
     {
@@ -62,6 +62,19 @@ internal static class ConversionPolicy
             return PlannedAction.Refuse;
         }
 
+        // Nobody looked. That is a bug in the caller, not a property of the file, and it
+        // must not read as permission - which is exactly how the GUI's conversions were
+        // being allowed. Refused rather than thrown because this runs inside a parallel
+        // conversion loop, where refusing leaves every file intact and throwing would
+        // take down a run mid-flight.
+        if (ambiguity is null)
+        {
+            reason = "This file was never classified, so whether converting it would "
+                     + "change its text is unknown. No conversion was performed. This is "
+                     + "an internal error; please report it.";
+            return PlannedAction.Refuse;
+        }
+
         return PlannedAction.Convert;
     }
 
@@ -85,6 +98,6 @@ internal static class ConversionPolicy
     /// but whose candidate readings all agree on the text - plain ASCII being the common
     /// case - is not something to warn about; a file whose candidates disagree is.
     /// </remarks>
-    internal static bool NeedsDisclosure(AmbiguityClass ambiguity) =>
+    internal static bool NeedsDisclosure(AmbiguityClass? ambiguity) =>
         ambiguity == AmbiguityClass.TextEquivalent;
 }

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -87,6 +87,37 @@ internal sealed class ConversionReportEntry
     /// </summary>
     internal string? ExpectedSourceSha256 { get; set; }
 
+    /// <summary>
+    /// What <see cref="ConversionPolicy"/> decided for this file, or
+    /// <see langword="null"/> while nothing has decided yet.
+    /// Internal state; not included in CSV output.
+    /// </summary>
+    /// <remarks>
+    /// Nullable so that "nobody has decided" cannot be mistaken for "convert it". An
+    /// entry that reaches a plan undecided is a bug, and one that used to exist: the GUI
+    /// built conversions from entries whose ambiguity had never been classified.
+    /// </remarks>
+    internal PlannedAction? Action { get; set; }
+
+    /// <summary>
+    /// Whether converting this file could change its Unicode content rather than only
+    /// its encoding label.
+    /// </summary>
+    internal bool MayChangeText() => Ambiguity == AmbiguityClass.TextChanging;
+
+    /// <summary>
+    /// The charset label the next conversion will read this file as.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CurrentCharsetLabel"/> when something has overridden or superseded the
+    /// original detection - a completed conversion, or a user naming the source encoding
+    /// - and the scan's own answer otherwise. Both the conversion engine and a written
+    /// plan use this, so what a plan says a file will be read as is what it is read as.
+    /// </remarks>
+    internal string EffectiveSourceLabel =>
+        CurrentCharsetLabel
+        ?? ScanEngine.FormatCharsetLabel(SourceEncoding, SourceHasBom);
+
     /// <summary>Additional error detail; not included in CSV output.</summary>
     internal string? Diagnostic { get; set; }
 }

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -49,13 +49,17 @@ internal sealed class ConversionReportEntry
     internal string? CurrentCharsetLabel { get; set; }
 
     /// <summary>
-    /// How far this file's bytes identify the encoding that wrote them, decided during
-    /// detection. Defaults to <see cref="AmbiguityClass.Unambiguous"/>, which is correct
-    /// for a caller that supplies the source encoding rather than having it detected:
-    /// there is nothing ambiguous about an answer somebody gave.
+    /// How far this file's bytes identify the encoding that wrote them, or
+    /// <see langword="null"/> while nothing has looked.
     /// Internal state; not included in CSV output.
     /// </summary>
-    internal AmbiguityClass Ambiguity { get; set; } = AmbiguityClass.Unambiguous;
+    /// <remarks>
+    /// Nullable because "not classified" and "classified as unambiguous" are different
+    /// facts, and defaulting the first to the second is how the GUI came to convert files
+    /// the CLI refuses: its entries were never classified, and the gate read the default
+    /// as an answer. A missing classification is an internal error, never a safe state.
+    /// </remarks>
+    internal AmbiguityClass? Ambiguity { get; set; }
 
     /// <summary>
     /// Encodings that read this file differently from the one detected. Empty unless

--- a/sources/EncodingChecker/DetectionCounters.cs
+++ b/sources/EncodingChecker/DetectionCounters.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+
+namespace EncodingChecker;
+
+/// <summary>
+/// Counts how often EC works out an encoding, so that "it is never worked out twice" can
+/// be asserted rather than argued.
+/// </summary>
+/// <remarks>
+/// The conversion that runs must be the conversion that was approved. That holds only if
+/// nothing between the approval and the write reaches its own conclusion about a file:
+/// a second pass over the same bytes can answer differently, and it was the first answer
+/// the user agreed to. Every surface is built to detect once — the CLI scan, the plan,
+/// the GUI's confirmation — but "built to" is an architectural claim, and this project
+/// has already been caught by one of those. The GUI was built to apply the ambiguity
+/// refusal too.
+/// <para>
+/// So the property is measured. Two counts, because they are separate questions with the
+/// same failure mode: <em>which encoding is this</em>, and <em>do the bytes settle it</em>.
+/// </para>
+/// <para>
+/// Two interlocked increments on a conversion that reads the whole file are not worth
+/// optimising away.
+/// </para>
+/// </remarks>
+internal static class DetectionCounters
+{
+    private static long _detections;
+    private static long _classifications;
+
+    /// <summary>Times an encoding has been worked out from bytes.</summary>
+    internal static long Detections => Interlocked.Read(ref _detections);
+
+    /// <summary>Times bytes have been examined to see whether they settle the encoding.</summary>
+    internal static long Classifications => Interlocked.Read(ref _classifications);
+
+    internal static void RecordDetection() => Interlocked.Increment(ref _detections);
+
+    internal static void RecordClassification() =>
+        Interlocked.Increment(ref _classifications);
+
+    /// <summary>Zeroes both counts. For tests measuring one operation.</summary>
+    internal static void Reset()
+    {
+        Interlocked.Exchange(ref _detections, 0);
+        Interlocked.Exchange(ref _classifications, 0);
+    }
+}

--- a/sources/EncodingChecker/EncodingAmbiguity.cs
+++ b/sources/EncodingChecker/EncodingAmbiguity.cs
@@ -224,6 +224,8 @@ internal static class EncodingAmbiguity
 
     internal static AmbiguityAnalysis Analyze(ReadOnlySpan<byte> sample, Encoding detected)
     {
+        DetectionCounters.RecordClassification();
+
         ArgumentNullException.ThrowIfNull(detected);
 
         if (sample.Length > SampleBytes)

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -28,11 +28,14 @@ public partial class MainForm : Form
     private sealed class ConvertWorkerArgs
     {
         internal required List<ConversionReportEntry> Entries;
+        internal required string BaseDirectory;
         internal required string TargetBaseCharset;
         internal required bool TargetWriteBom;
-        internal required bool WhatIf;
+        internal required bool Preview;
         internal required bool Backup;
         internal required ConcurrentBag<ConversionReportEntry> Completed;
+        internal required Func<ConversionPlan, ConfirmationResponse> Confirm;
+        internal OrchestrationResult? Outcome;
         internal CancellationToken CancellationToken;
     }
 
@@ -63,14 +66,10 @@ public partial class MainForm : Form
     // actual conversion from preview ("would be converted").
     private bool _convertWasPreview;
 
-    // A real conversion runs twice: once with WhatIf to decide what would happen, and
-    // again to carry out what the user confirmed. The second pass reuses the same entry
-    // objects, which already carry their decisions, so it does not classify anything a
-    // second time - the conversion that happens is the one that was shown.
-    private bool _convertWasPlanningPass;
-
-    // Held between the two passes so the confirmed plan is what executes.
-    private List<ConversionReportEntry>? _plannedEntries;
+    // Held so the completion handler can read how the run ended, as reported by
+    // ConversionOrchestrator: converted, previewed, cancelled, or stopped because the
+    // files moved underneath the plan. The worker method is static and writes into it.
+    private ConvertWorkerArgs? _convertArgs;
 
     // Indices into imgsResults (see SetKeyName calls in MainForm.Designer.cs).
     // Reuses the existing Failed and Warning icons; the Warning icon carries the
@@ -522,36 +521,12 @@ public partial class MainForm : Form
             entries.Add(entry);
         }
 
-        // A preview writes nothing, so it is its own answer and needs no confirmation.
-        // A real conversion is decided first and carried out second.
-        StartConvertPass(
-            entries,
-            itemsByPath,
-            targetLabel,
-            targetBaseCharset,
-            writeBom,
-            planningPass: !chkPreviewChanges.Checked);
-    }
-
-    /// <summary>
-    /// Runs one conversion pass: the WhatIf pass that decides, or the pass that acts.
-    /// </summary>
-    private void StartConvertPass(
-        List<ConversionReportEntry> entries,
-        Dictionary<string, ListViewItem> itemsByPath,
-        string targetLabel,
-        string targetBaseCharset,
-        bool targetWriteBom,
-        bool planningPass)
-    {
         var completed = new ConcurrentBag<ConversionReportEntry>();
 
         _convertItemsByPath = itemsByPath;
         _convertTargetLabel = targetLabel;
         _convertResults = completed;
         _convertWasPreview = chkPreviewChanges.Checked;
-        _convertWasPlanningPass = planningPass;
-        _plannedEntries = entries;
         _currentAction = CurrentAction.Convert;
 
         UpdateControlsOnActionStart();
@@ -562,102 +537,38 @@ public partial class MainForm : Form
         var args = new ConvertWorkerArgs
         {
             Entries = entries,
+            BaseDirectory = lstBaseDirectory.Text,
             TargetBaseCharset = targetBaseCharset,
-            TargetWriteBom = targetWriteBom,
-
-            // The planning pass never writes, whatever the backup box says.
-            WhatIf = planningPass || chkPreviewChanges.Checked,
+            TargetWriteBom = writeBom,
+            Preview = chkPreviewChanges.Checked,
             Backup = chkCreateBackup.Checked,
             Completed = completed,
+
+            // Runs on the worker thread, so the dialog is marshalled back here. The
+            // orchestrator does not know or care which thread it is on.
+            Confirm = plan => (ConfirmationResponse)Invoke(() => Confirm(plan)),
             CancellationToken = _actionCancellation.Token,
         };
 
+        _convertArgs = args;
         _actionWorker.RunWorkerAsync(args);
     }
 
-    /// <summary>
-    /// Shows what the planning pass decided and, if the user agrees, carries it out.
-    /// </summary>
-    /// <returns>
-    /// <see langword="true"/> when a second pass was started and the caller should leave
-    /// the results alone until it finishes.
-    /// </returns>
-    private bool ConfirmAndCarryOutPlan(
-        Dictionary<string, ListViewItem> itemsByPath, string targetLabel)
+    /// <summary>Shows a decided plan and reports what the user said.</summary>
+    private ConfirmationResponse Confirm(ConversionPlan plan)
     {
-        List<ConversionReportEntry> entries = _plannedEntries ?? [];
+        using var dialog = new ConversionConfirmationForm(plan);
 
-        if (entries.Count == 0)
-            return false;
-
-        ScanEngine.ParseCharsetLabel(
-            targetLabel, out string targetBaseCharset, out bool targetWriteBom);
-
-        ConversionPlan plan;
-
-        try
+        return dialog.ShowDialog(this) switch
         {
-            plan = ConversionPlan.FromEntries(
-                entries,
-                lstBaseDirectory.Text,
-                targetBaseCharset,
-                targetWriteBom,
-                chkCreateBackup.Checked,
-                explicitSource: entries.All(e => e.SourceEncodingWasSpecified)
-                    ? entries[0].EffectiveSourceLabel
-                    : null);
-        }
-        catch (InvalidOperationException ex)
-        {
-            // An entry that reached here without a decision is a bug, not a user error.
-            ShowWarning("The conversion could not be planned: {0}", ex.Message);
-            return false;
-        }
-
-        using var confirmation = new ConversionConfirmationForm(plan);
-        DialogResult answer = confirmation.ShowDialog(this);
-
-        // The user answered the refusal by naming the encoding. That replaces detection
-        // for those files and nothing else, so they go back through the same decision.
-        if (answer == DialogResult.Retry &&
-            confirmation.ChosenSourceEncoding is { } chosen)
-        {
-            foreach (ConversionReportEntry entry in entries)
-            {
-                if (entry.Action != PlannedAction.Refuse || !entry.MayChangeText())
-                    continue;
-
-                // The engine's existing override point. SourceEncoding keeps the
-                // scan's answer for the report; this is what the conversion reads.
-                entry.CurrentCharsetLabel = chosen;
-                entry.SourceEncodingWasSpecified = true;
-                entry.Ambiguity = AmbiguityClass.Unambiguous;
-                entry.AmbiguityReason = AmbiguityReason.ExplicitlySpecified;
-                entry.CompetingEncodings = [];
-                entry.Diagnostic = null;
-
-                // Cleared so the policy decides again rather than reusing the refusal.
-                entry.Action = null;
-            }
-
-            StartConvertPass(
-                entries, itemsByPath, targetLabel,
-                targetBaseCharset, targetWriteBom, planningPass: true);
-
-            return true;
-        }
-
-        if (answer != DialogResult.OK)
-        {
-            UpdateControlsOnActionDone("Conversion cancelled. No files were modified.");
-            return true;
-        }
-
-        StartConvertPass(
-            entries, itemsByPath, targetLabel,
-            targetBaseCharset, targetWriteBom, planningPass: false);
-
-        return true;
+            DialogResult.OK => ConfirmationResponse.Proceed,
+            DialogResult.Retry when dialog.ChosenSourceEncoding is { } chosen =>
+                new ConfirmationResponse(
+                    ConfirmationChoice.ChooseSourceEncoding,
+                    chosen,
+                    dialog.ChosenFiles),
+            _ => ConfirmationResponse.Cancel,
+        };
     }
 
     private void OnCancelAction(object? sender, EventArgs e)
@@ -734,13 +645,14 @@ public partial class MainForm : Form
     {
         try
         {
-            ScanEngine.ConvertFiles(
+            args.Outcome = new ConversionOrchestrator(args.Confirm).Run(
                 args.Entries,
+                args.BaseDirectory,
                 args.TargetBaseCharset,
                 args.TargetWriteBom,
-                ScanEngine.DefaultMaxParallelism,
-                whatIf: args.WhatIf,
                 backup: args.Backup,
+                preview: args.Preview,
+                ScanEngine.DefaultMaxParallelism,
                 onEntry: args.Completed.Add,
                 args.CancellationToken);
         }
@@ -849,22 +761,30 @@ public partial class MainForm : Form
         Dictionary<string, ListViewItem> itemsByPath = _convertItemsByPath!;
         ConcurrentBag<ConversionReportEntry> completed = _convertResults ?? [];
         bool wasPreview = _convertWasPreview;
-        bool wasPlanningPass = _convertWasPlanningPass;
+        OrchestrationResult? outcome = _convertArgs?.Outcome;
 
         _convertItemsByPath = null;
         _convertTargetLabel = null;
         _convertResults = null;
         _convertWasPreview = false;
-        _convertWasPlanningPass = false;
+        _convertArgs = null;
 
-        // Nothing was written yet. Show what was decided and ask before anything is.
-        if (e.Error is null && !e.Cancelled && wasPlanningPass &&
-            ConfirmAndCarryOutPlan(itemsByPath, targetLabel))
+        // Every one of these leaves the files untouched. Reported before the rows are
+        // updated, because there is nothing to update.
+        if (e.Error is null && !e.Cancelled && outcome is not null &&
+            outcome.Outcome is not (OrchestrationOutcome.Converted
+                                    or OrchestrationOutcome.Previewed))
         {
+            if (outcome.Message is not null)
+                ShowWarning("{0}", outcome.Message);
+
+            UpdateControlsOnActionDone(
+                outcome.Outcome == OrchestrationOutcome.Cancelled
+                    ? "Conversion cancelled. No files were modified."
+                    : "Conversion did not run. No files were modified.");
+
             return;
         }
-
-        _plannedEntries = null;
 
         if (e.Error != null)
         {

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -63,6 +63,15 @@ public partial class MainForm : Form
     // actual conversion from preview ("would be converted").
     private bool _convertWasPreview;
 
+    // A real conversion runs twice: once with WhatIf to decide what would happen, and
+    // again to carry out what the user confirmed. The second pass reuses the same entry
+    // objects, which already carry their decisions, so it does not classify anything a
+    // second time - the conversion that happens is the one that was shown.
+    private bool _convertWasPlanningPass;
+
+    // Held between the two passes so the confirmed plan is what executes.
+    private List<ConversionReportEntry>? _plannedEntries;
+
     // Indices into imgsResults (see SetKeyName calls in MainForm.Designer.cs).
     // Reuses the existing Failed and Warning icons; the Warning icon carries the
     // preview/would-change state.
@@ -513,12 +522,36 @@ public partial class MainForm : Form
             entries.Add(entry);
         }
 
+        // A preview writes nothing, so it is its own answer and needs no confirmation.
+        // A real conversion is decided first and carried out second.
+        StartConvertPass(
+            entries,
+            itemsByPath,
+            targetLabel,
+            targetBaseCharset,
+            writeBom,
+            planningPass: !chkPreviewChanges.Checked);
+    }
+
+    /// <summary>
+    /// Runs one conversion pass: the WhatIf pass that decides, or the pass that acts.
+    /// </summary>
+    private void StartConvertPass(
+        List<ConversionReportEntry> entries,
+        Dictionary<string, ListViewItem> itemsByPath,
+        string targetLabel,
+        string targetBaseCharset,
+        bool targetWriteBom,
+        bool planningPass)
+    {
         var completed = new ConcurrentBag<ConversionReportEntry>();
 
         _convertItemsByPath = itemsByPath;
         _convertTargetLabel = targetLabel;
         _convertResults = completed;
         _convertWasPreview = chkPreviewChanges.Checked;
+        _convertWasPlanningPass = planningPass;
+        _plannedEntries = entries;
         _currentAction = CurrentAction.Convert;
 
         UpdateControlsOnActionStart();
@@ -530,14 +563,101 @@ public partial class MainForm : Form
         {
             Entries = entries,
             TargetBaseCharset = targetBaseCharset,
-            TargetWriteBom = writeBom,
-            WhatIf = chkPreviewChanges.Checked,
+            TargetWriteBom = targetWriteBom,
+
+            // The planning pass never writes, whatever the backup box says.
+            WhatIf = planningPass || chkPreviewChanges.Checked,
             Backup = chkCreateBackup.Checked,
             Completed = completed,
             CancellationToken = _actionCancellation.Token,
         };
 
         _actionWorker.RunWorkerAsync(args);
+    }
+
+    /// <summary>
+    /// Shows what the planning pass decided and, if the user agrees, carries it out.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when a second pass was started and the caller should leave
+    /// the results alone until it finishes.
+    /// </returns>
+    private bool ConfirmAndCarryOutPlan(
+        Dictionary<string, ListViewItem> itemsByPath, string targetLabel)
+    {
+        List<ConversionReportEntry> entries = _plannedEntries ?? [];
+
+        if (entries.Count == 0)
+            return false;
+
+        ScanEngine.ParseCharsetLabel(
+            targetLabel, out string targetBaseCharset, out bool targetWriteBom);
+
+        ConversionPlan plan;
+
+        try
+        {
+            plan = ConversionPlan.FromEntries(
+                entries,
+                lstBaseDirectory.Text,
+                targetBaseCharset,
+                targetWriteBom,
+                chkCreateBackup.Checked,
+                explicitSource: entries.All(e => e.SourceEncodingWasSpecified)
+                    ? entries[0].EffectiveSourceLabel
+                    : null);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // An entry that reached here without a decision is a bug, not a user error.
+            ShowWarning("The conversion could not be planned: {0}", ex.Message);
+            return false;
+        }
+
+        using var confirmation = new ConversionConfirmationForm(plan);
+        DialogResult answer = confirmation.ShowDialog(this);
+
+        // The user answered the refusal by naming the encoding. That replaces detection
+        // for those files and nothing else, so they go back through the same decision.
+        if (answer == DialogResult.Retry &&
+            confirmation.ChosenSourceEncoding is { } chosen)
+        {
+            foreach (ConversionReportEntry entry in entries)
+            {
+                if (entry.Action != PlannedAction.Refuse || !entry.MayChangeText())
+                    continue;
+
+                // The engine's existing override point. SourceEncoding keeps the
+                // scan's answer for the report; this is what the conversion reads.
+                entry.CurrentCharsetLabel = chosen;
+                entry.SourceEncodingWasSpecified = true;
+                entry.Ambiguity = AmbiguityClass.Unambiguous;
+                entry.AmbiguityReason = AmbiguityReason.ExplicitlySpecified;
+                entry.CompetingEncodings = [];
+                entry.Diagnostic = null;
+
+                // Cleared so the policy decides again rather than reusing the refusal.
+                entry.Action = null;
+            }
+
+            StartConvertPass(
+                entries, itemsByPath, targetLabel,
+                targetBaseCharset, targetWriteBom, planningPass: true);
+
+            return true;
+        }
+
+        if (answer != DialogResult.OK)
+        {
+            UpdateControlsOnActionDone("Conversion cancelled. No files were modified.");
+            return true;
+        }
+
+        StartConvertPass(
+            entries, itemsByPath, targetLabel,
+            targetBaseCharset, targetWriteBom, planningPass: false);
+
+        return true;
     }
 
     private void OnCancelAction(object? sender, EventArgs e)
@@ -729,11 +849,22 @@ public partial class MainForm : Form
         Dictionary<string, ListViewItem> itemsByPath = _convertItemsByPath!;
         ConcurrentBag<ConversionReportEntry> completed = _convertResults ?? [];
         bool wasPreview = _convertWasPreview;
+        bool wasPlanningPass = _convertWasPlanningPass;
 
         _convertItemsByPath = null;
         _convertTargetLabel = null;
         _convertResults = null;
         _convertWasPreview = false;
+        _convertWasPlanningPass = false;
+
+        // Nothing was written yet. Show what was decided and ask before anything is.
+        if (e.Error is null && !e.Cancelled && wasPlanningPass &&
+            ConfirmAndCarryOutPlan(itemsByPath, targetLabel))
+        {
+            return;
+        }
+
+        _plannedEntries = null;
 
         if (e.Error != null)
         {

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -313,7 +313,9 @@ internal static class Program
                     TargetEncoding = plan.TargetEncoding,
                     TargetHasBom = plan.TargetHasBom,
                     // The plan already settled this. Re-deriving it would be the second
-                    // detection pass the plan exists to avoid.
+                    // detection pass the plan exists to avoid; carrying the decision
+                    // across is what tells the engine not to classify again.
+                    Action = f.Action,
                     Ambiguity = f.Ambiguity,
                     AmbiguityReason = f.AmbiguityReason,
                     CompetingEncodings = f.CompetingEncodings,

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -441,16 +441,23 @@ internal static class ScanEngine
         // be the second detection pass a plan exists to avoid, and its answer, not this
         // one, is what the user approved. The policy below still re-asserts the gate
         // from what the plan recorded.
-        if (entry.Action is null && !entry.SourceEncodingWasSpecified)
+        if (entry.SourceEncodingWasSpecified)
+        {
+            // Recorded rather than left unset: there is nothing ambiguous about an answer
+            // somebody gave, and that is a classification, not the absence of one.
+            entry.Ambiguity = AmbiguityClass.Unambiguous;
+            entry.AmbiguityReason = AmbiguityReason.ExplicitlySpecified;
+            entry.CompetingEncodings = [];
+        }
+        else if (entry.Action is null)
         {
             AmbiguityAnalysis? analysis = AnalyzeAmbiguity(path, sourceEncoding);
 
-            if (analysis is not null)
-            {
-                entry.Ambiguity = analysis.Class;
-                entry.AmbiguityReason = analysis.Reason;
-                entry.CompetingEncodings = analysis.CompetingCandidates;
-            }
+            // A file with no bytes to examine has nothing that could be misread, so this
+            // is an answer and not a failure to reach one.
+            entry.Ambiguity = analysis?.Class ?? AmbiguityClass.Unambiguous;
+            entry.AmbiguityReason = analysis?.Reason ?? AmbiguityReason.SingleCandidate;
+            entry.CompetingEncodings = analysis?.CompetingCandidates ?? [];
         }
 
         PlannedAction action = ConversionPolicy.Decide(

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -239,17 +239,17 @@ internal static class ScanEngine
                 // with the old encoding can silently produce mojibake that neither strict
                 // decoding nor hash verification catches, since both would use the same
                 // wrong encoding.
-                string effectiveLabel =
-                    entry.CurrentCharsetLabel
-                    ?? FormatCharsetLabel(entry.SourceEncoding, entry.SourceHasBom);
-
                 ParseCharsetLabel(
-                    effectiveLabel,
+                    entry.EffectiveSourceLabel,
                     out string sourceCharset,
                     out bool sourceHasBom);
 
+                // Stands in for ConversionPolicy's answer for an unidentified source,
+                // which has to be given before Encoding.GetEncoding is reached rather
+                // than inside ApplyConversion. Pinned as agreeing in ConversionPolicyTests.
                 if (sourceCharset == UNKNOWN_CHARSET)
                 {
+                    entry.Action = PlannedAction.Skip;
                     entry.Result = ConversionRowResult.Skipped;
                     return entry;
                 }
@@ -357,19 +357,6 @@ internal static class ScanEngine
         // gave.
         entry.SourceEncodingWasSpecified = sourceWasSpecified;
 
-        if (detected is not null && options.Action == ScanAction.Convert
-            && !sourceWasSpecified)
-        {
-            AmbiguityAnalysis? ambiguity = AnalyzeAmbiguity(path, detected);
-
-            if (ambiguity is not null)
-            {
-                entry.Ambiguity = ambiguity.Class;
-                entry.AmbiguityReason = ambiguity.Reason;
-                entry.CompetingEncodings = ambiguity.CompetingCandidates;
-            }
-        }
-
         switch (options.Action)
         {
             case ScanAction.Detect:
@@ -443,33 +430,44 @@ internal static class ScanEngine
         entry.TargetEncoding = targetCharset;
         entry.TargetHasBom = targetWriteBom;
 
-        // Compared against the file's current state, not entry.SourceEncoding, which
-        // stays at its original-scan value for reporting even after a conversion.
-        bool alreadyMatches =
-            string.Equals(
-                sourceCharset,
-                targetCharset,
-                StringComparison.OrdinalIgnoreCase) &&
-            sourceHasBom == targetWriteBom;
-
-        if (alreadyMatches)
+        // Classified here, at the point where the decision is actually made, so that
+        // every caller reaching a conversion has it - the CLI's Convert scan, a plan
+        // being written, and the GUI alike. Doing it during the scan instead meant the
+        // GUI, which scans in Detect mode, never had it.
+        //
+        // Skipped when the user named the source encoding: there is nothing ambiguous
+        // about an answer somebody gave. Skipped too when the entry already carries a
+        // decision, which means a plan made it earlier - classifying again there would
+        // be the second detection pass a plan exists to avoid, and its answer, not this
+        // one, is what the user approved. The policy below still re-asserts the gate
+        // from what the plan recorded.
+        if (entry.Action is null && !entry.SourceEncodingWasSpecified)
         {
-            entry.Result = ConversionRowResult.Unchanged;
-            return;
+            AmbiguityAnalysis? analysis = AnalyzeAmbiguity(path, sourceEncoding);
+
+            if (analysis is not null)
+            {
+                entry.Ambiguity = analysis.Class;
+                entry.AmbiguityReason = analysis.Reason;
+                entry.CompetingEncodings = analysis.CompetingCandidates;
+            }
         }
 
-        // Refuse before touching anything when the file's bytes do not identify the
-        // encoding that wrote them and the rival readings disagree about the text.
-        //
-        // Detection still produces an answer for these; on short or ASCII-heavy input
-        // that answer is close to a guess, and acting on it rewrites the user's file
-        // into one of several possible readings without saying so. Skipped when the user
-        // named the source encoding, since then it is their answer, not a guess.
-        if (entry.Ambiguity == AmbiguityClass.TextChanging)
+        PlannedAction action = ConversionPolicy.Decide(
+            sourceCharset,
+            sourceHasBom,
+            targetCharset,
+            targetWriteBom,
+            entry.Ambiguity,
+            entry.CompetingEncodings,
+            out string? policyReason);
+
+        entry.Action = action;
+
+        if (action != PlannedAction.Convert)
         {
-            entry.Result = ConversionRowResult.Error;
-            entry.Diagnostic = AmbiguityAnalysis.DescribeRefusal(
-                sourceCharset, entry.CompetingEncodings);
+            entry.Result = ConversionPolicy.ToRowResult(action);
+            entry.Diagnostic = policyReason;
             return;
         }
 

--- a/sources/EncodingChecker/TextEncoding.cs
+++ b/sources/EncodingChecker/TextEncoding.cs
@@ -171,6 +171,10 @@ internal static class TextEncoding
 
         buffer = buffer[..bytesToExamine];
 
+        // Every detection route funnels through here, so this is the one place that has
+        // to record it. See DetectionCounters for why the count exists.
+        DetectionCounters.RecordDetection();
+
         // Reject high-entropy data as likely binary.
         if (buffer.Length >= MinimumEntropyProbeBytes &&
             BinaryEntropy(buffer) > BinaryEntropyThreshold)


### PR DESCRIPTION
## Phase E — one policy engine, and a GUI that asks before it writes

Building the GUI on the same model as the CLI turned up the reason it needed to be.

### The GUI was not applying the ambiguity refusal at all

Classification ran only during a Convert-mode scan. The GUI scans in **Detect** mode and converts the rows the user checks, so every entry reached conversion carrying the default `Unambiguous` and the gate never fired.

The tool converted, on the strength of whatever detection returned, the exact files it tells CLI users it will not convert. Nothing failed, because no test drove the GUI's sequence — View, *then* Convert — as a sequence.

Verified before fixing, not inferred:

```
classification=Unambiguous  result=Converted  converted=True
```

on a windows-1252 file the CLI refuses. `ConversionPolicyTests.TheGuiSequenceRefusesWhatTheCliRefuses` is that probe, kept.

This is the same lesson as the audit: **a safety rule enforced at one call site is a safety rule the next call site does not have.**

### The fix: `ConversionPolicy`

```
Detection / explicit source → classification → PlannedAction → CLI / GUI / plan
```

The decision moves into one place and every route asks it. It is asked at the **point of decision** rather than during the scan, which is what makes it reachable from all three.

Entries carry the answer, and an entry that reaches a plan without one now **raises** rather than defaulting to `Convert` — defaulting is the exact shape of the bug.

Applying a plan still does not classify again: an entry that arrives already decided keeps its decision, so `-Apply` re-asserts the gate from what the plan recorded instead of recomputing it. That property is preserved deliberately and tested.

### The confirmation

`Convert` now runs a WhatIf pass that decides, then a pass that carries out what was confirmed. Both use the **same entry objects**, so the second classifies nothing — the conversion that happens is the one that was shown, the same property `-Apply` has. A preview run is its own answer and skips the dialog, since it writes nothing to confirm.

```
Convert 417 of 480 selected file(s) to utf-8 without BOM

  386  Encoding determined by the file's own bytes             Will convert.
   31  Encoding undetermined, every reading agrees on the text  Will convert; the label
                                                                is a choice, the content
                                                                is not.
   22  Encoding undetermined, readings disagree on the text     WILL NOT be converted.
   39  Already in the target encoding                           Nothing to do.
    2  Encoding could not be identified                         Left alone.

Directory        C:\Source
Source encoding  detected per file
Backups          enabled — each original kept as <file>.bak
Guarantees       strict codecs, verified output, atomic install, ambiguity refusal
```

For refusals it names the encodings actually in conflict, per file, and offers the one thing that resolves it — saying which encoding they are.

### Explicit source ≠ bypass safety

The GUI's selection is `-From`, using the engine's existing `CurrentCharsetLabel` override rather than a new path. It replaces detection for those files and nothing else. Tested: the choice **changes the resulting text** (so it is a decision, not decoration); bytes that cannot strictly decode as the chosen encoding are still refused; a failed backup still aborts.

Scope note: the selection applies to the refused files — the ones the dialog is asking about — rather than the whole run. Same mechanism as `-From`, narrowed to the question being answered.

### Three test files started failing, correctly

They construct entries directly and convert single-byte content. Once the gate actually reached them, it refused — rightly. They name a source encoding rather than having it detected, which is what `-From` means, and they now say so.

### The dialog is tested

On an STA thread, against real plans: every outcome mix, nothing-refused, everything-refused, that it names competing encodings rather than reporting low confidence, that it says whether originals are kept, and that it reports **the plan it was handed** rather than recounting a directory that has since changed.

It is the only part of the safety model a GUI user reads, and was the only part no test had ever executed.

**402 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second round: the orchestration gap, closed

The defect was not in a component. Every component was correct and tested; the **sequence** between them was not, and it lived in button handlers and background-worker callbacks where nothing could run it. Fixing the defect without fixing that leaves the same gap open for the next one.

### The sequence is now a class

`ConversionOrchestrator` does the whole of it — decide, ask, carry out what was agreed — with the confirmation as a delegate and the real conversion engine underneath. `MainForm` keeps the thread marshalling and nothing else.

**14 orchestration tests**, against real files. Every case that must not modify anything reads the source bytes before and after:

| case | outcome |
|---|---|
| text-changing ambiguity | refused, bytes unchanged |
| text-equivalent ambiguity | converted |
| unambiguous | converted |
| explicit source chosen | that codec is what reads the bytes |
| explicit source, undecodable | still refused |
| user cancels | nothing modified, not even a `.bak` |
| file changes after planning | **whole run stops**, neither file touched |
| backup fails | source untouched |
| target cannot hold the content | source untouched |
| preview | never asks, never writes |
| undecided entry | stops rather than converting |

### Two gaps that only appeared once the sequence was testable

1. **The GUI's second pass did not carry the planned hashes.** It had no equivalent of `-Apply`'s staleness check — a file could change while the user read the dialog and be converted anyway. It now runs the same all-or-nothing check *and* binds each entry to the bytes it was approved for.
2. **An explicit encoding was applied to every refused file at once** — wrong for the same reason applying it to the whole batch would be. The choice now carries its scope, the dialog ticks the files it applies to, and the button says how many. Tested with French windows-1252 beside Russian koi8-r: answering for one leaves the other refused and byte-identical.

### Detection is counted, not asserted architecturally

`DetectionCounters` records every time EC works out an encoding or classifies one. Measured, not claimed:

| operation | detections | classifications |
|---|---|---|
| GUI View (3 files) | 3 | 0 |
| at the confirmation | +0 | 3 |
| GUI execution pass | +0 | +0 |
| `-Plan` (3 files) | 3 | 3 |
| `-Apply` | **0** | **0** |
| reading a plan | 0 | 0 |

Test parallelism is disabled so those counts mean something; the suite runs in two seconds.

### "No classification is not a safe state", throughout

`ConversionReportEntry.Ambiguity` is nullable, an explicit source *records* `Unambiguous` rather than relying on a field default, and the policy refuses an unclassified file. It refuses rather than throwing because it runs inside a parallel conversion loop, where refusing leaves every file intact.

**422 passing.**

Still manual, as agreed: a real Windows GUI smoke test.
