### PR TITLE
Stop the tests losing entries to a race in their own harness

### DIFF
--- a/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
+++ b/sources/EncodingChecker.Tests/BackupIntegrityTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 
 namespace EncodingChecker.Tests;
@@ -41,7 +41,7 @@ public sealed class BackupIntegrityTests : IDisposable
             Backup = true,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);
@@ -76,7 +76,7 @@ public sealed class BackupIntegrityTests : IDisposable
             Backup = true,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         Assert.Equal(ConversionRowResult.Converted, Assert.Single(entries).Result);
@@ -105,7 +105,7 @@ public sealed class BackupIntegrityTests : IDisposable
             Backup = true,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         Assert.Equal(ConversionRowResult.Converted, Assert.Single(entries).Result);
@@ -135,7 +135,7 @@ public sealed class BackupIntegrityTests : IDisposable
             Backup = true,
         };
 
-        var firstRun = new List<ConversionReportEntry>();
+        var firstRun = new EntrySink();
         ScanEngine.ScanDirectory(options, firstRun.Add, CancellationToken.None);
         Assert.Equal(ConversionRowResult.Converted, Assert.Single(firstRun).Result);
 
@@ -145,7 +145,7 @@ public sealed class BackupIntegrityTests : IDisposable
 
         // Re-running over the same directory (now containing convert-me.txt.bak) must
         // still see only the one real source file, not the backup it just wrote.
-        var secondRun = new List<ConversionReportEntry>();
+        var secondRun = new EntrySink();
         ScanEngine.ScanDirectory(options, secondRun.Add, CancellationToken.None);
 
         ConversionReportEntry onlyEntry = Assert.Single(secondRun);
@@ -197,7 +197,7 @@ public sealed class BackupIntegrityTests : IDisposable
             Backup = true,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);
@@ -226,7 +226,7 @@ public sealed class BackupIntegrityTests : IDisposable
             Backup = true,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         Assert.Equal(ConversionRowResult.Unchanged, Assert.Single(entries).Result);

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -64,7 +64,7 @@ public sealed class ConversionConfirmationFormTests : IDisposable
     /// <summary>A plan over whatever is currently in the directory.</summary>
     private ConversionPlan Plan(bool backup = true, string target = "utf-8")
     {
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
 
         ScanEngine.ScanDirectory(
             new ScanDirectoryOptions

--- a/sources/EncodingChecker.Tests/ConversionIdempotencyTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionIdempotencyTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 
@@ -37,9 +37,9 @@ public sealed class ConversionIdempotencyTests : IDisposable
             TargetWriteBom = writeBom,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
-        return entries;
+        return entries.ToList();
     }
 
     [Theory]

--- a/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
@@ -238,7 +238,7 @@ public sealed class ConversionMetadataTests : IDisposable
                 TargetHasBom = false,
             };
 
-            var completed = new List<ConversionReportEntry>();
+            var completed = new EntrySink();
             ScanEngine.ConvertFiles(
                 [entry], "utf-8", targetWriteBom: false,
                 ScanEngine.DefaultMaxParallelism,

--- a/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
@@ -45,7 +45,7 @@ public sealed class ConversionOrchestrationTests : IDisposable
     /// <summary>The rows the GUI's View button produces, which Convert then acts on.</summary>
     private List<ConversionReportEntry> View()
     {
-        var scanned = new List<ConversionReportEntry>();
+        var scanned = new EntrySink();
 
         ScanEngine.ScanDirectory(
             new ScanDirectoryOptions
@@ -58,7 +58,7 @@ public sealed class ConversionOrchestrationTests : IDisposable
             scanned.Add,
             CancellationToken.None);
 
-        return scanned;
+        return scanned.ToList();
     }
 
     /// <summary>Everything the GUI's Convert button does, with a scripted user.</summary>
@@ -332,8 +332,15 @@ public sealed class ConversionOrchestrationTests : IDisposable
         OrchestrationResult result = Convert(
             View(),
             Proceed,
-            betweenPlanAndWrite: _ =>
-                File.WriteAllBytes(moving, Encoding.UTF8.GetBytes("changed underneath")));
+            betweenPlanAndWrite: plan =>
+            {
+                // Stated, because it is load-bearing and was once silently false: a file
+                // missing from the plan is a file FindStaleFiles never looks at, so a
+                // dropped entry turns this test's real subject into a pass.
+                Assert.Equal(2, plan.Files.Count);
+
+                File.WriteAllBytes(moving, Encoding.UTF8.GetBytes("changed underneath"));
+            });
 
         Assert.Equal(OrchestrationOutcome.PlanWentStale, result.Outcome);
         Assert.Contains("changed after the conversion was planned", result.Message);

--- a/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
@@ -44,7 +44,7 @@ public sealed class ConversionPolicyTests : IDisposable
     private List<ConversionReportEntry> ViewThenConvert(
         string target = "utf-8", bool whatIf = false)
     {
-        var scanned = new List<ConversionReportEntry>();
+        var scanned = new EntrySink();
 
         ScanEngine.ScanDirectory(
             new ScanDirectoryOptions
@@ -57,7 +57,7 @@ public sealed class ConversionPolicyTests : IDisposable
             scanned.Add,
             CancellationToken.None);
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             scanned,
@@ -69,7 +69,7 @@ public sealed class ConversionPolicyTests : IDisposable
             completed.Add,
             CancellationToken.None);
 
-        return completed;
+        return completed.ToList();
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public sealed class ConversionPolicyTests : IDisposable
         Dictionary<string, PlannedAction?> viaGui = ViewThenConvert(whatIf: true)
             .ToDictionary(e => Path.GetFileName(e.FilePath), e => e.Action);
 
-        var viaCli = new List<ConversionReportEntry>();
+        var viaCli = new EntrySink();
 
         ScanEngine.ScanDirectory(
             new ScanDirectoryOptions
@@ -197,7 +197,7 @@ public sealed class ConversionPolicyTests : IDisposable
             TargetHasBom = false,
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,
@@ -228,7 +228,7 @@ public sealed class ConversionPolicyTests : IDisposable
             SourceEncodingWasSpecified = true,
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,
@@ -274,7 +274,7 @@ public sealed class ConversionPolicyTests : IDisposable
 
         ChooseSourceEncoding(entry, "windows-1252");
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,
@@ -300,7 +300,7 @@ public sealed class ConversionPolicyTests : IDisposable
         ConversionReportEntry entry = Assert.Single(ViewThenConvert());
         ChooseSourceEncoding(entry, "koi8-r");
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,
@@ -361,7 +361,7 @@ public sealed class ConversionPolicyTests : IDisposable
 
         ChooseSourceEncoding(entry, "euc-jp");
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,
@@ -385,7 +385,7 @@ public sealed class ConversionPolicyTests : IDisposable
         // A directory where the .bak has to go: the copy cannot succeed.
         Directory.CreateDirectory(path + ".bak");
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,

--- a/sources/EncodingChecker.Tests/ConversionSafetyInvariantTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionSafetyInvariantTests.cs
@@ -132,7 +132,7 @@ public sealed class ConversionSafetyInvariantTests : IDisposable
             TargetHasBom = false,
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,
             ScanEngine.DefaultMaxParallelism,
@@ -162,7 +162,7 @@ public sealed class ConversionSafetyInvariantTests : IDisposable
             TargetHasBom = false,
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [entry], "utf-8", targetWriteBom: false,
             ScanEngine.DefaultMaxParallelism,
@@ -282,7 +282,7 @@ public sealed class ConversionSafetyInvariantTests : IDisposable
             TargetHasBom = false,
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [entry], target, targetWriteBom: false,
             ScanEngine.DefaultMaxParallelism,

--- a/sources/EncodingChecker.Tests/ConvertFilesPreviewAndBackupTests.cs
+++ b/sources/EncodingChecker.Tests/ConvertFilesPreviewAndBackupTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Text;
 
 namespace EncodingChecker.Tests;
@@ -47,7 +47,7 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
         string path = Path.Combine(_root, "f.txt");
         File.WriteAllText(path, TestContent.Ascii, Encoding.ASCII);
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [MakeAsciiEntry(path)],
             "utf-8",
@@ -69,7 +69,7 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
         File.WriteAllText(path, TestContent.Ascii, Encoding.ASCII);
         byte[] originalBytes = File.ReadAllBytes(path);
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [MakeAsciiEntry(path)],
             "utf-8",
@@ -94,7 +94,7 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
         byte[] originalBytes = File.ReadAllBytes(path);
         DateTime originalWriteTime = File.GetLastWriteTimeUtc(path);
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [MakeAsciiEntry(path)],
             "utf-8",
@@ -129,7 +129,7 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
             TargetEncoding = "utf-8",
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [entry],
             "utf-8",
@@ -205,7 +205,7 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
         File.WriteAllText(path, TestContent.Ascii, Encoding.ASCII);
         byte[] originalBytes = File.ReadAllBytes(path);
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             [MakeAsciiEntry(path)],
             "utf-8",

--- a/sources/EncodingChecker.Tests/DetectionCountTests.cs
+++ b/sources/EncodingChecker.Tests/DetectionCountTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 
@@ -54,7 +54,7 @@ public sealed class DetectionCountTests : IDisposable
 
     private List<ConversionReportEntry> View()
     {
-        var scanned = new List<ConversionReportEntry>();
+        var scanned = new EntrySink();
 
         ScanEngine.ScanDirectory(
             new ScanDirectoryOptions
@@ -67,7 +67,7 @@ public sealed class DetectionCountTests : IDisposable
             scanned.Add,
             CancellationToken.None);
 
-        return scanned;
+        return scanned.ToList();
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/EncodingConversionMatrixTests.cs
+++ b/sources/EncodingChecker.Tests/EncodingConversionMatrixTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 
@@ -76,7 +76,7 @@ public sealed class EncodingConversionMatrixTests : IDisposable
             TargetWriteBom = targetHasBom,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);
@@ -118,7 +118,7 @@ public sealed class EncodingConversionMatrixTests : IDisposable
             TargetWriteBom = false,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);

--- a/sources/EncodingChecker.Tests/EntrySink.cs
+++ b/sources/EncodingChecker.Tests/EntrySink.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Concurrent;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Collects the entries a scan or conversion reports, safely.
+/// </summary>
+/// <remarks>
+/// <see cref="ScanEngine.ScanDirectory"/> and <see cref="ScanEngine.ConvertFiles"/> invoke
+/// their callback concurrently from worker threads and say so; the caller has to
+/// synchronise. Both production callers use a <see cref="ConcurrentBag{T}"/>. The tests
+/// passed <c>List&lt;T&gt;.Add</c>, which is not thread-safe, and lost entries — measured
+/// at 3 runs in 40 over 200 files, dropping one or two each time.
+/// <para>
+/// That is worse in a test than in the product. A dropped entry does not throw; it
+/// silently removes a file from what the test then asserts about, so the test still
+/// passes and asserts less than it claims. It surfaced as a CI failure where a file
+/// modified after planning was not caught as stale — because the file had never made it
+/// into the plan.
+/// </para>
+/// <para>
+/// Enumerates in path order so a test reading two entries gets them in a fixed order.
+/// </para>
+/// </remarks>
+internal sealed class EntrySink : IEnumerable<ConversionReportEntry>
+{
+    private readonly ConcurrentBag<ConversionReportEntry> _entries = [];
+
+    /// <summary>Pass this as the <c>onEntry</c> callback.</summary>
+    internal void Add(ConversionReportEntry entry) => _entries.Add(entry);
+
+    internal List<ConversionReportEntry> ToList() =>
+    [
+        .. _entries.OrderBy(e => e.FilePath, StringComparer.OrdinalIgnoreCase)
+    ];
+
+    internal int Count => _entries.Count;
+
+    public IEnumerator<ConversionReportEntry> GetEnumerator() => ToList().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/sources/EncodingChecker.Tests/ExplicitSourceEncodingTests.cs
+++ b/sources/EncodingChecker.Tests/ExplicitSourceEncodingTests.cs
@@ -39,7 +39,7 @@ public sealed class ExplicitSourceEncodingTests : IDisposable
 
     private List<ConversionReportEntry> Scan(string? from, bool backup = false)
     {
-        var results = new List<ConversionReportEntry>();
+        var results = new EntrySink();
 
         ScanEngine.ScanDirectory(
             new ScanDirectoryOptions
@@ -56,7 +56,7 @@ public sealed class ExplicitSourceEncodingTests : IDisposable
             results.Add,
             CancellationToken.None);
 
-        return results;
+        return results.ToList();
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public sealed class ExplicitSourceEncodingTests : IDisposable
         byte[] original = Encoding.UTF8.GetBytes("世界 مرحبا");
         File.WriteAllBytes(path, original);
 
-        var results = new List<ConversionReportEntry>();
+        var results = new EntrySink();
 
         ScanEngine.ScanDirectory(
             new ScanDirectoryOptions

--- a/sources/EncodingChecker.Tests/MultibyteRoundTripTests.cs
+++ b/sources/EncodingChecker.Tests/MultibyteRoundTripTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 
@@ -53,7 +53,7 @@ public sealed class MultibyteRoundTripTests : IDisposable
         string targetCharset,
         bool targetWriteBom)
     {
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry],

--- a/sources/EncodingChecker.Tests/PrivateUseAreaDetectionTests.cs
+++ b/sources/EncodingChecker.Tests/PrivateUseAreaDetectionTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 
@@ -155,7 +155,7 @@ public sealed class PrivateUseAreaDetectionTests
                 TargetWriteBom = true,
             };
 
-            var entries = new List<ConversionReportEntry>();
+            var entries = new EntrySink();
             ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
             ConversionReportEntry entry = Assert.Single(entries);

--- a/sources/EncodingChecker.Tests/ReparsePointRootTests.cs
+++ b/sources/EncodingChecker.Tests/ReparsePointRootTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace EncodingChecker.Tests;
 
@@ -48,7 +48,7 @@ public sealed class ReparsePointRootTests
                     Action = ScanAction.Detect,
                 };
 
-                var entries = new List<ConversionReportEntry>();
+                var entries = new EntrySink();
 
                 Assert.Throws<ArgumentException>(() =>
                     ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None));

--- a/sources/EncodingChecker.Tests/ReportSelfExclusionTests.cs
+++ b/sources/EncodingChecker.Tests/ReportSelfExclusionTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Text;
 
 namespace EncodingChecker.Tests;
@@ -45,7 +45,7 @@ public sealed class ReportSelfExclusionTests : IDisposable
         };
 
         // Run 1: the report doesn't exist yet, but the path is already excluded.
-        var firstRun = new List<ConversionReportEntry>();
+        var firstRun = new EntrySink();
         ScanEngine.ScanDirectory(options, firstRun.Add, CancellationToken.None);
         Assert.Equal(sourcePath, Assert.Single(firstRun).FilePath);
 
@@ -53,7 +53,7 @@ public sealed class ReportSelfExclusionTests : IDisposable
 
         // Run 2: the report file now exists in the scanned tree; a broad -Include "*"
         // must still not pick it up, since it's excluded by exact full path.
-        var secondRun = new List<ConversionReportEntry>();
+        var secondRun = new EntrySink();
         ScanEngine.ScanDirectory(options, secondRun.Add, CancellationToken.None);
         Assert.Equal(sourcePath, Assert.Single(secondRun).FilePath);
     }
@@ -84,13 +84,13 @@ public sealed class ReportSelfExclusionTests : IDisposable
                 Action = ScanAction.Detect,
             };
 
-            var firstRun = new List<ConversionReportEntry>();
+            var firstRun = new EntrySink();
             ScanEngine.ScanDirectory(options, firstRun.Add, CancellationToken.None);
             Assert.Single(firstRun);
 
             File.WriteAllText(reportPath, "File,Encoding,BOM,Target,TargetBOM,Result\r\n", new UTF8Encoding(false));
 
-            var secondRun = new List<ConversionReportEntry>();
+            var secondRun = new EntrySink();
             ScanEngine.ScanDirectory(options, secondRun.Add, CancellationToken.None);
 
             ConversionReportEntry onlyEntry = Assert.Single(secondRun);

--- a/sources/EncodingChecker.Tests/ResultEntryReconciliationTests.cs
+++ b/sources/EncodingChecker.Tests/ResultEntryReconciliationTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Windows.Forms;
 
 namespace EncodingChecker.Tests;
@@ -220,7 +220,7 @@ public sealed class ResultEntryReconciliationTests : IDisposable
             TargetEncoding = "utf-8",
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [convertsEntry, failsEntry],

--- a/sources/EncodingChecker.Tests/ScanEngineValidationTests.cs
+++ b/sources/EncodingChecker.Tests/ScanEngineValidationTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Text;
 
 namespace EncodingChecker.Tests;
@@ -97,7 +97,7 @@ public sealed class ScanEngineValidationTests : IDisposable
             WhatIf = true,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
 
         Assert.ThrowsAny<ArgumentException>(
             () => ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None));
@@ -145,7 +145,7 @@ public sealed class ScanEngineValidationTests : IDisposable
             Action = ScanAction.Detect,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);
@@ -169,7 +169,7 @@ public sealed class ScanEngineValidationTests : IDisposable
             Action = ScanAction.Detect,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);
@@ -196,7 +196,7 @@ public sealed class ScanEngineValidationTests : IDisposable
             TargetCharset = "utf-8",
         };
 
-        var scanned = new List<ConversionReportEntry>();
+        var scanned = new EntrySink();
         ScanEngine.ScanDirectory(scanOptions, scanned.Add, CancellationToken.None);
 
         ConversionReportEntry scanEntry = Assert.Single(scanned);
@@ -236,7 +236,7 @@ public sealed class ScanEngineValidationTests : IDisposable
             Action = ScanAction.Detect,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);
@@ -319,7 +319,7 @@ public sealed class ScanEngineValidationTests : IDisposable
             },
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
         ScanEngine.ConvertFiles(
             entries,
             "utf-8",

--- a/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
+++ b/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
@@ -52,7 +52,7 @@ public sealed class StaleConversionStateTests : IDisposable
         bool whatIf = false,
         bool backup = false)
     {
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry],

--- a/sources/EncodingChecker.Tests/StrictFallbackEnforcementTests.cs
+++ b/sources/EncodingChecker.Tests/StrictFallbackEnforcementTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 
@@ -218,7 +218,7 @@ public sealed class StrictFallbackEnforcementTests : IDisposable
             TargetHasBom = false,
         };
 
-        var completed = new List<ConversionReportEntry>();
+        var completed = new EntrySink();
 
         ScanEngine.ConvertFiles(
             [entry],

--- a/sources/EncodingChecker.Tests/WhatIfSafetyTests.cs
+++ b/sources/EncodingChecker.Tests/WhatIfSafetyTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Text;
 
 namespace EncodingChecker.Tests;
@@ -43,7 +43,7 @@ public sealed class WhatIfSafetyTests : IDisposable
             Backup = true, // WhatIf must take precedence and skip this entirely.
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);
@@ -70,7 +70,7 @@ public sealed class WhatIfSafetyTests : IDisposable
             WhatIf = true,
         };
 
-        var entries = new List<ConversionReportEntry>();
+        var entries = new EntrySink();
         ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
 
         ConversionReportEntry entry = Assert.Single(entries);


### PR DESCRIPTION
## The CI flake was the test harness losing entries

`AFileChangedAfterTheConfirmation_StopsTheWholeRun` failed on master reporting `Converted` where it expected `PlanWentStale`.

**The staleness check did not fail.** The file modified after planning had never reached the plan, and `FindStaleFiles` only inspects files a plan actually schedules — so there was nothing to find stale.

### Cause

`ScanDirectory` and `ConvertFiles` invoke `onEntry` concurrently from worker threads, and say so:

> `onEntry` is invoked concurrently from worker threads; callers must synchronise.

Both production callers use a `ConcurrentBag`. The tests passed `List<T>.Add`.

### Measured, not assumed

A throwaway probe scanning 200 files, 40 times, comparing a `List` collector against a `ConcurrentBag` over identical scans:

```
attempts with a wrong count: 3/40; deltas: 1,1,2
```

Entries were being dropped. It did not reproduce in 12 local runs of the failing test, which is what a narrow race looks like.

### Why this is worse in a test than in the product

A dropped entry does not throw. It quietly removes a file from what the test then asserts about, so the test still passes while asserting less than it claims. Any of these could have been silently weakened; only the one whose subject *was* the dropped file failed visibly.

### Fix

`EntrySink` collects into a `ConcurrentBag` and enumerates in path order, so tests reading several entries also get a fixed order. Every `onEntry` callback in the suite now uses it — 20 test files.

The stale-plan test now asserts that both files reached the plan. **That** is the assertion that should fail if this regresses, rather than the outcome quietly changing.

No production code is touched. The concurrent `onEntry` contract is correct and documented; the tests were not honouring it.

**422 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
