### PR TITLE
Fix CorpusTesters detector parity branch

### DIFF
--- a/.github/workflows/detector-parity.yml
+++ b/.github/workflows/detector-parity.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           repository: amrali-eg/CorpusTesters
-          ref: master
+          ref: main
           path: corpus-testers
 
       - name: Verify shared Unicode detector


### PR DESCRIPTION
Fixes the parity workflow to check out CorpusTesters from its default \main\ branch. The previous \master\ reference does not exist, so the workflow failed before comparing detector sources.