### PR TITLE
Record the v3.9.0 audited build in SAFETY-AUDIT

### DIFF
--- a/docs/SAFETY-AUDIT.md
+++ b/docs/SAFETY-AUDIT.md
@@ -64,6 +64,53 @@ The audit distinguishes detection identity, text-equivalent labels, unsupported 
 
 Current raw artifacts, methodology revisions, and results are published with CorpusTesters. Historical corpus figures must be read in their recorded taxonomy and build context; they are not a substitute for the current product policy above.
 
+### v3.9.0 audited build
+
+The v3.9.0 release was audited from a clean checkout of the commit it was tagged at, and the binary that was measured is the binary that was published.
+
+```
+commit    ef645f20a7bd0db42278e80140170d4829af40fa   (annotated tag v3.9.0)
+worktree  clean
+platform  .NET 10.0.400 - Windows 11 10.0.26200
+built     2026-08-30T22:22:29Z
+assembly  EncodingChecker.dll
+          a3e82da30bb8635ba71b4326c0f6bb716de388c2e9827771c4f689580fd71e4d
+```
+
+That digest is the SHA-256 of the managed assembly the audit loaded and exercised. It is **not** the digest of the apphost `EncodingChecker.exe`, and not of either release ZIP; GitHub publishes the digests for the downloads separately. Cite it as the assembly hash.
+
+Across 5,078 files in the four corpora, EC produced zero silent decoder-side losses and five substantive misdetections. Every other text-changing result was explicitly classified.
+
+| Outcome | Files | Meaning |
+|---|---:|---|
+| `PASS` | 4520 | Converted, text preserved exactly |
+| `ECCodecUnsupported` | 297 | Reference codec EC can name under no spelling - unmeasurable, unscored |
+| `MappingDifference` | 103 | Correct codec, different mapping profile |
+| `UnknownEncoding` | 42 | Not identified; left untouched |
+| `OutOfScope` | 39 | Excluded by EC's own traversal rules |
+| `RefusedByPolicy` | 29 | EC declined; nothing written |
+| `DecodeError` | 24 | Refused at strict decode; original intact |
+| `NoReferenceEncoding` | 16 | No ground truth to judge against |
+| `Misdetection` | 5 | Substantive: a different reading the bytes did distinguish |
+| `UnknownReferenceEncoding` | 2 | Codec the audit cannot construct |
+| `ReferenceDecodeError` | 1 | Corpus defect, not an EC one |
+| `SilentDecodeLoss` | 0 | Text lost without EC reporting it |
+
+Text preservation per corpus, excluding refusals from both numerator and denominator: uts3 1279/1280, chardet 2766/2818, charsetnormalizer 413/463, utfunknown26 62/62.
+
+**What this does not establish.** The 297 unsupported files are unscored in both directions - counting them as failures would blame EC for a conversion it was never offered, and counting them as passes would be the flattering half of the same error. The 103 mapping differences changed exact Unicode scalars; 90 are the documented JIS X 0208 vendor split, where JIS, Python and iconv map `0x8160` to U+301C while Microsoft, .NET and WHATWG map it to U+FF5E. Ground truth is the corpora's own metadata with Python as an operational reference decoder, so an EC/Python disagreement on a legacy mapping is a divergence between implementations, not proof about either. The audit supplies each corpus's reference codec explicitly, so it measures whether EC preserves text when told what the bytes are - not whether it can determine that unaided. GUI evidence is three scripted phases, not coverage.
+
+Reproducing it, with the corpora in place:
+
+```bash
+git clone https://github.com/amrali-eg/EncodingChecker.git && cd EncodingChecker
+git checkout v3.9.0
+dotnet build sources/EncodingChecker.sln --configuration Release
+sha256sum sources/EncodingChecker/bin/Release/net10.0-windows/EncodingChecker.dll
+```
+
+then, in CorpusTesters, `CORPUS_ROOT=<corpora> ./run-all.sh release`. Every run records `ECGitCommit`, `ECGitTreeDirty` and `ECAssemblySha256` in its `run.json`; this was the first run of these corpora with a clean worktree, and three separate builds produced identical counts.
+
 ## Known limits
 
 - No detector can recover an author's historical legacy encoding when the same bytes admit multiple plausible readings. EC refuses automatic legacy conversion instead of guessing.


### PR DESCRIPTION
The v3.9.0 release ships two binaries with an auto-generated changelog pointing at PR #54. The evidence that those binaries were audited across 5,078 files lived only outside this repository, so a reader of the safety claims had no path to the results behind them.

Adds a **v3.9.0 audited build** subsection to `docs/SAFETY-AUDIT.md`, under the existing *Independent audit* heading.

## What it records

- Provenance: commit `ef645f2`, clean worktree, .NET 10.0.400 / Windows 11, build timestamp
- `EncodingChecker.dll` SHA-256 `a3e82da3…`, labelled as the **assembly** hash — explicitly not the apphost `.exe` and not either release ZIP, whose digests GitHub publishes separately
- The eleven-row outcome table, `SilentDecodeLoss` 0 included
- Per-corpus text preservation, with refusals excluded from both numerator and denominator
- Reproduce steps

## What it also records

A *What this does not establish* paragraph at the same prominence as the results: the 297 unscored files, the 103 mapping differences that changed exact Unicode scalars (90 being the JIS X 0208 vendor split), Python as an operational rather than normative reference, explicit source codecs supplied throughout, and GUI evidence that is three scripted phases rather than coverage.

## Verification

Figures were taken from `runs/rel390` and cross-checked against the published record rather than copied from summary prose. The eleven outcome counts sum to 5,078. Provenance fields come from `run.json` (`ECGitCommit`, `ECGitTreeDirty`, `ECAssemblySha256`).

Documentation only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)