### PR TITLE
Harden conversion plans and recovery reporting for v3.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.9.0
+# EncodingChecker v3.9.1
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 

--- a/docs/RELEASE-NOTES-v3.9.1.md
+++ b/docs/RELEASE-NOTES-v3.9.1.md
@@ -1,0 +1,20 @@
+# EncodingChecker v3.9.1
+
+This patch release hardens saved conversion plans, recovery reporting, and malformed-input handling introduced in v3.9.0.
+
+## Fixes
+
+- Saved plans now validate every listed file, path, hash, and codec before any conversion begins. A malformed or stale row invalidates the whole plan, including rows marked to skip or refuse.
+- Unreadable files remain visible as explicit refusals instead of preventing plan creation.
+- Unsupported runtime codecs are reported cleanly throughout planning and journaling instead of causing an unexpected exception.
+- Files with repeated leading byte-order marks are refused before EC creates a backup or attempts conversion, with a clear diagnostic.
+- Conversion journals now record a backup whenever this run created one, even when a later conversion step failed. Recovery-metadata paths are recorded separately.
+- Journal construction is defensive against malformed paths and unsupported recorded codec names.
+
+## Interface and maintenance
+
+- Clarified conversion review and export wording.
+- Simplified conversion-policy flow and improved test documentation.
+- Added focused regression coverage for saved-plan validation, repeated BOMs, unreadable files, unsupported codecs, and backup/journal reconciliation.
+
+The strict streaming converter, atomic source-file installation, and the v3.9 legacy-source safety policy are unchanged.

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -352,8 +352,8 @@ public sealed class ConversionConfirmationFormTests : IDisposable
     [Fact]
     public void ItReportsThePlanItWasGivenRatherThanRecountingTheDirectory()
     {
-        // The dialog must describe the decisions that will execute. Recomputing here is
-        // how a confirmation ends up describing something other than what happens.
+        // The dialog must display the supplied plan. Rescanning or recounting here could
+        // make the confirmation describe a different decision from the one that executes.
         Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
         Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
 
@@ -361,7 +361,8 @@ public sealed class ConversionConfirmationFormTests : IDisposable
 
         int convert = plan.Files.Count(f => f.Action == PlannedAction.Convert);
 
-        // Change the directory after planning. The dialog must not notice.
+        // Change the directory after planning. The dialog must still show the existing
+        // plan, not the current directory contents.
         File.Delete(Path.Combine(_root, "jp.txt"));
         Write("late-arrival.txt", "added after the plan", "ascii");
 

--- a/sources/EncodingChecker.Tests/ConversionJournalTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionJournalTests.cs
@@ -111,6 +111,7 @@ public sealed class ConversionJournalTests : IDisposable
         Assert.Equal(ConversionMetadataStore.ComputeSha256(path), entry.Sha256After);
         Assert.NotEqual(entry.Sha256Before, entry.Sha256After);
         Assert.Equal("jp.txt.bak", entry.BackupPath);
+        Assert.Equal("jp.txt.ecmeta.json", entry.RecoveryMetadataPath);
     }
 
     [Fact]
@@ -307,14 +308,43 @@ public sealed class ConversionJournalTests : IDisposable
 
         Assert.Equal(3, Cli(
             "-BasePath", _root, "-Target", "windows-1252",
-            "-Journal", JournalPath, "-Quiet"));
+            "-Backup", "-Journal", JournalPath, "-Quiet"));
 
         JournalEntry entry = EntryFor("unencodable.txt");
 
         Assert.Equal(ConversionStatus.Failed, entry.Status);
         Assert.Equal(PlannedAction.Convert, entry.PlannedAction);
         Assert.Null(entry.Sha256After);
+        Assert.Equal("unencodable.txt.bak", entry.BackupPath);
+        Assert.Null(entry.RecoveryMetadataPath);
+        Assert.Equal(original, File.ReadAllBytes(path + ".bak"));
         Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void AnUnsupportedRecordedCodecCannotCrashJournalCreation()
+    {
+        string path = Write("unsupported.txt", "plain ascii", "ascii");
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-7",
+            TargetEncoding = "utf-8",
+            Result = ConversionRowResult.Error,
+            Action = PlannedAction.Refuse,
+            SourceInterpretation = SourceInterpretation.NotApplicable,
+            ResolvedSourceLabel = "utf-7",
+            ReasonCode = ConversionReasonCodes.UnsupportedSourceEncoding,
+        };
+
+        JournalEntry recorded = Assert.Single(
+            ConversionJournal.FromRun(
+                [entry], _root, "utf-8", targetHasBom: false,
+                backupEnabled: false, explicitSource: null,
+                surface: "Test", startedUtc: DateTime.UtcNow).Entries);
+
+        Assert.Equal(0, recorded.SourceCodePage);
+        Assert.Equal(ConversionStatus.Refused, recorded.Status);
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -170,10 +170,9 @@ public sealed class ConversionPlanTests : IDisposable
     [Fact]
     public void AFileChangedAfterPlanningInvalidatesTheWholePlan()
     {
-        // All-or-nothing on purpose. Converting the files that still match would apply a
-        // plan the user reviewed as a whole to a directory that is no longer the one they
-        // reviewed - and the files most likely to have changed are the ones something
-        // else is actively writing.
+        // A plan covers the whole reviewed set. If any source changes, converting only
+        // the files that still match would carry out a partial plan the user never
+        // approved; it would also race most often with files another process is writing.
         string stable = Write("stable.txt", "こんにちは世界。テキスト", "shift_jis");
         string moved = Write("moved.txt", "さようなら世界。テキスト", "shift_jis");
 
@@ -295,6 +294,28 @@ public sealed class ConversionPlanTests : IDisposable
         Rewrite(fields => fields["PlanVersion"] = JsonSerializer.SerializeToElement(99));
 
         Assert.Equal(1, Run("-Apply", PlanPath));
+    }
+
+    [Fact]
+    public void APlanWithAnIncompleteFileEntryIsRejectedBeforeExecution()
+    {
+        string path = Write("jp.txt", "こんにちは世界。テキスト", "shift_jis");
+        byte[] original = File.ReadAllBytes(path);
+        Assert.Equal(0, Plan("-From", "shift_jis"));
+
+        Rewrite(fields =>
+        {
+            List<Dictionary<string, JsonElement>> files = fields["Files"]
+                .EnumerateArray()
+                .Select(file => file.EnumerateObject()
+                    .ToDictionary(p => p.Name, p => p.Value.Clone()))
+                .ToList();
+            files[0]["SourceEncoding"] = JsonSerializer.SerializeToElement("");
+            fields["Files"] = JsonSerializer.SerializeToElement(files);
+        });
+
+        Assert.Equal(1, Run("-Apply", PlanPath));
+        Assert.Equal(original, File.ReadAllBytes(path));
     }
 
     [Fact]
@@ -538,6 +559,37 @@ public sealed class ConversionPlanTests : IDisposable
         {
             File.Delete(outside);
         }
+    }
+
+    [Fact]
+    public void ARefusedEntryReachingOutsideThePlanInvalidatesTheWholeRun()
+    {
+        // Every row belongs to the reviewed plan, including rows EC intends to leave
+        // alone. A malformed non-convert row must not be ignored while another row is
+        // converted and the journal later discovers the invalid path.
+        string valid = Path.Combine(_root, "utf8-bom.txt");
+        File.WriteAllText(valid, "hello world", new UTF8Encoding(true));
+        byte[] validBefore = File.ReadAllBytes(valid);
+        Write("legacy.txt", "Le café était déjà prêt", "windows-1252");
+
+        Assert.Equal(0, Plan());
+
+        Rewrite(fields =>
+        {
+            List<Dictionary<string, JsonElement>> files = fields["Files"]
+                .EnumerateArray()
+                .Select(file => file.EnumerateObject()
+                    .ToDictionary(p => p.Name, p => p.Value.Clone()))
+                .ToList();
+
+            Dictionary<string, JsonElement> refused = Assert.Single(
+                files, file => file["Action"].GetString() == nameof(PlannedAction.Refuse));
+            refused["RelativePath"] = JsonSerializer.SerializeToElement("..\\outside.txt");
+            fields["Files"] = JsonSerializer.SerializeToElement(files);
+        });
+
+        Assert.Equal(3, Run("-Apply", PlanPath));
+        Assert.Equal(validBefore, File.ReadAllBytes(valid));
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/ConversionSafetyInvariantTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionSafetyInvariantTests.cs
@@ -195,6 +195,43 @@ public sealed class ConversionSafetyInvariantTests : IDisposable
     }
 
     [Fact]
+    public void Utf8BomSource_ConvertsToUtf8WithoutBom()
+    {
+        const string text = "café — 日本語\r\n";
+        string path = Path.Combine(_root, "utf8-bom.txt");
+        File.WriteAllBytes(path, [.. Encoding.UTF8.Preamble, .. Encoding.UTF8.GetBytes(text)]);
+
+        ConversionResult result = EncodingConverter.Convert(
+            path, path, Encoding.UTF8, new UTF8Encoding(false), new ConversionOptions());
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.True(result.BomVerificationPassed);
+        Assert.False(File.ReadAllBytes(path).AsSpan().StartsWith(Encoding.UTF8.Preamble));
+        Assert.Equal(text, Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+    }
+
+    [Fact]
+    public void MultipleLeadingUtf8Boms_RefusesAndLeavesTheSourceUnchanged()
+    {
+        string path = Path.Combine(_root, "double-bom.txt");
+        byte[] original =
+        [
+            .. Encoding.UTF8.Preamble,
+            .. Encoding.UTF8.Preamble,
+            .. Encoding.UTF8.GetBytes("text\r\n"),
+        ];
+        File.WriteAllBytes(path, original);
+
+        ConversionResult result = EncodingConverter.Convert(
+            path, path, Encoding.UTF8, new UTF8Encoding(false), new ConversionOptions());
+
+        Assert.False(result.Success);
+        Assert.Equal(ConversionErrorCode.MultipleLeadingByteOrderMarks, result.ErrorCode);
+        Assert.Contains("multiple", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
     public void ASuccessfulConversionStillProvesPreservation()
     {
         // The invariant must not be satisfied by refusing everything. A file

--- a/sources/EncodingChecker.Tests/ConvertFilesPreviewAndBackupTests.cs
+++ b/sources/EncodingChecker.Tests/ConvertFilesPreviewAndBackupTests.cs
@@ -4,13 +4,14 @@ using System.Text;
 namespace EncodingChecker.Tests;
 
 /// <summary>
-/// ScanEngine.ConvertFiles's whatIf/backup parameters are what wire MainForm's
-/// chkPreviewChanges/chkCreateBackup checkboxes into the conversion pipeline
-/// (see MainForm.OnConvert: WhatIf = chkPreviewChanges.Checked, Backup =
-/// chkCreateBackup.Checked). These mirror WhatIfSafetyTests/BackupIntegrityTests,
-/// which exercise the same two ApplyConversion parameters through ScanDirectory
-/// (the CLI/View-then-Convert path), for ConvertFiles - the GUI's own entry point
-/// for converting an already-scanned selection.
+/// Covers the lower-level conversion pass used after a caller has already selected and
+/// classified files. The GUI orchestration is covered separately by
+/// <see cref="ConversionOrchestrationTests"/>; these tests pin the two safety switches
+/// passed into <see cref="ScanEngine.ConvertFiles"/> itself:
+/// <list type="bullet">
+/// <item><description>Preview reports what would happen without writing a file or backup.</description></item>
+/// <item><description>Backup preserves the original before a real conversion can replace it.</description></item>
+/// </list>
 /// </summary>
 public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
 {
@@ -87,6 +88,41 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
     }
 
     [Fact]
+    public void RepeatedLeadingBom_IsRefusedBeforeBackupOrMetadataIsCreated()
+    {
+        string path = Path.Combine(_root, "double-bom.txt");
+        byte[] bom = Encoding.UTF8.GetPreamble();
+        byte[] text = Encoding.UTF8.GetBytes("plain text");
+        File.WriteAllBytes(path, [.. bom, .. bom, .. text]);
+        byte[] original = File.ReadAllBytes(path);
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-8",
+            SourceHasBom = true,
+            TargetEncoding = "utf-8",
+        };
+
+        var completed = new EntrySink();
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false,
+            ScanEngine.DefaultMaxParallelism,
+            whatIf: false, backup: true,
+            completed.Add, CancellationToken.None);
+
+        ConversionReportEntry result = Assert.Single(completed);
+        Assert.Equal(ConversionRowResult.Refused, result.Result);
+        Assert.Equal(
+            ConversionReasonCodes.MultipleLeadingByteOrderMarks,
+            result.ReasonCode);
+        Assert.Contains("more than one byte-order mark", result.Diagnostic);
+        Assert.Equal(original, File.ReadAllBytes(path));
+        Assert.False(File.Exists(path + ".bak"));
+        Assert.False(File.Exists(ConversionMetadataStore.MetadataPathFor(path)));
+    }
+
+    [Fact]
     public void Preview_LeavesBytesUnchanged_CreatesNoBackupEvenIfRequested_ReportsWouldConvert()
     {
         string path = Path.Combine(_root, "f.txt");
@@ -101,13 +137,13 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
             targetWriteBom: true,
             ScanEngine.DefaultMaxParallelism,
             whatIf: true,
-            backup: true, // Both checkboxes checked - Preview must still win (see ApplyConversion).
+            // Preview takes precedence: it must not create a backup or write output.
+            backup: true,
             completed.Add,
             CancellationToken.None);
 
-        // "Converted" is this codebase's existing convention for "would be converted"
-        // under a dry run (see ConversionRowResult.Converted's own doc comment) - the
-        // same value WhatIfSafetyTests asserts for the ScanDirectory path.
+        // In a preview, Converted means "would convert". The source bytes, timestamp,
+        // and backup state prove that this result describes a plan rather than a write.
         Assert.Equal(ConversionRowResult.Converted, Assert.Single(completed).Result);
         Assert.Equal(originalBytes, File.ReadAllBytes(path));
         Assert.Equal(originalWriteTime, File.GetLastWriteTimeUtc(path));
@@ -147,8 +183,8 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
     [Fact]
     public void PreviewAndBackupTogether_NeverModifiesSource_NeverCreatesBackup_ReportsCorrectResults()
     {
-        // Mirrors the exact combination MainForm can produce: both checkboxes checked,
-        // over a mixed selection like OnConvert builds from lstResults.CheckedItems.
+        // Scenario: preview and backup are both requested for a mixed selection.
+        // Protection: preview wins for every row, including rows that would convert.
         string needsConversion = Path.Combine(_root, "a.txt");
         File.WriteAllText(needsConversion, TestContent.Ascii, Encoding.ASCII);
 
@@ -197,10 +233,9 @@ public sealed class ConvertFilesPreviewAndBackupTests : IDisposable
     [Fact]
     public void ExplicitFalseFalse_BehavesExactlyAsBeforeThisFeature()
     {
-        // Regression guard for every pre-existing caller (MainForm's non-preview/non-
-        // backup path, and every existing test): whatIf: false, backup: false is a real
-        // conversion with no backup, exactly as ConvertFiles behaved before it gained
-        // these two parameters.
+        // Scenario: neither optional safety switch is requested.
+        // Expected behavior: ConvertFiles performs its normal conversion without creating
+        // a backup. This keeps the lower-level API explicit for callers that opt out.
         string path = Path.Combine(_root, "f.txt");
         File.WriteAllText(path, TestContent.Ascii, Encoding.ASCII);
         byte[] originalBytes = File.ReadAllBytes(path);

--- a/sources/EncodingChecker.Tests/DetectionCountTests.cs
+++ b/sources/EncodingChecker.Tests/DetectionCountTests.cs
@@ -3,19 +3,16 @@
 namespace EncodingChecker.Tests;
 
 /// <summary>
-/// EC works out a file's encoding exactly once for each approved plan, and never again
-/// between the moment that plan is approved and the moment it is carried out.
+/// A conversion plan must identify each selected file once, then carry out that approved
+/// interpretation without detecting the file again.
 ///
-/// That property is what makes a preview a promise rather than a demonstration. A second
-/// pass over the same bytes can answer differently — detection is a heuristic — and it
-/// The View result is informational; planning deliberately refreshes selected files while
-/// binding detection to their hashes. Every surface is built not to detect after approval.
-/// But
-/// "built not to" is an architectural claim, and this project has already been caught by
-/// one of those: the GUI was built to apply the legacy-source rule too, and did not.
+/// View is informational. Planning deliberately takes one fresh, hash-bound snapshot of
+/// each selected automatic-source file because detection is a heuristic and the file may
+/// have changed since View. Once the user approves that plan, another detection pass could
+/// produce a different answer from the one the user reviewed.
 ///
-/// So it is counted. The two counts distinguish separate work: identifying the source
-/// encoding and applying the conversion policy.
+/// These tests count detection and policy classification separately. Counting makes the
+/// no-second-pass rule an observable contract instead of an assumption about the design.
 /// </summary>
 public sealed class DetectionCountTests : IDisposable
 {
@@ -79,8 +76,8 @@ public sealed class DetectionCountTests : IDisposable
 
         List<ConversionReportEntry> entries = [];
 
-        // View: three files, three detections, and nothing classified yet - which is
-        // precisely why the classification cannot live in the scan.
+        // Scenario: View identifies three files but makes no conversion decision.
+        // A decision belongs to planning because it depends on the requested target.
         var view = Measure(() => entries = View());
 
         Assert.Equal(3, view.Detections);
@@ -94,9 +91,8 @@ public sealed class DetectionCountTests : IDisposable
                 {
                     confirmations++;
 
-                    // Building and reading the plan must cost nothing. A confirmation
-                    // that re-derives anything is a confirmation that can disagree with
-                    // what it is confirming.
+                    // Risk: a confirmation that re-derives data can disagree with the
+                    // plan it presents. Reading this plan must not inspect any file again.
                     atConfirmation = (
                         DetectionCounters.Detections,
                         DetectionCounters.Classifications);
@@ -112,11 +108,12 @@ public sealed class DetectionCountTests : IDisposable
 
         Assert.Equal(1, confirmations);
 
-        // Planning refreshes the selected files once, then classifies that exact snapshot.
+        // Protection: planning refreshes each selected file once, then classifies that
+        // exact snapshot.
         Assert.Equal(3, atConfirmation.Classifications);
         Assert.Equal(3, atConfirmation.Detections);
 
-        // And the pass that actually writes adds nothing to either count.
+        // Carrying out the approved plan must add neither detection nor classification.
         Assert.Equal(3, convert.Classifications);
         Assert.Equal(3, convert.Detections);
     }
@@ -124,7 +121,8 @@ public sealed class DetectionCountTests : IDisposable
     [Fact]
     public void AnsweringARefusalClassifiesOnlyTheFilesItWasAskedAbout()
     {
-        // Re-planning after an explicit choice must not re-examine the whole batch.
+        // An explicit source choice changes only the files the user selected; it must not
+        // re-examine the rest of the batch.
         Write("jp.txt", "こんにちは世界。日本語のテキストです。", "shift_jis");
         Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
 
@@ -150,8 +148,8 @@ public sealed class DetectionCountTests : IDisposable
                     _ => { },
                     CancellationToken.None));
 
-        // Two on the first pass, then one more for the file whose source the user chose.
-        // The other entry keeps its existing decision.
+        // First pass: two detections. Re-plan: one classification for the file whose
+        // source was chosen. The other entry retains its existing decision.
         Assert.Equal(3, convert.Classifications);
         Assert.Equal(2, convert.Detections);
     }
@@ -170,8 +168,8 @@ public sealed class DetectionCountTests : IDisposable
         Assert.Equal(3, plan.Detections);
         Assert.Equal(3, plan.Classifications);
 
-        // The whole point of a plan. Applying it re-asserts what was recorded; it does
-        // not go back to the bytes to ask again.
+        // Applying a plan checks that the recorded source is still present; it does not
+        // return to the bytes to derive a new encoding decision.
         var apply = Measure(() => Assert.Equal(5, Cli("-Apply", planPath)));
 
         Assert.Equal(0, apply.Detections);
@@ -193,8 +191,8 @@ public sealed class DetectionCountTests : IDisposable
     [Fact]
     public void ReadingAPlanCostsNothing()
     {
-        // Isolated from the surrounding sequence: constructing and inspecting a plan must
-        // never reach the bytes. This is the property the confirmation dialog rests on.
+        // Constructing and inspecting a plan must not reach the source bytes. The
+        // confirmation dialog relies on this to show the already-approved decision.
         WriteThreeFiles();
 
         string planPath = Path.Combine(_root, "plan.json");

--- a/sources/EncodingChecker.Tests/EncodingConverterRobustnessTests.cs
+++ b/sources/EncodingChecker.Tests/EncodingConverterRobustnessTests.cs
@@ -205,7 +205,7 @@ public sealed class EncodingConverterRobustnessTests : IDisposable
         string path = WriteFile("noBomTarget.txt", TestContent.Ascii, Encoding.ASCII);
         byte[] originalBytes = File.ReadAllBytes(path);
 
-        // UTF-7 (and plain ASCII) have no byte-order mark to write.
+        // ASCII has no byte-order mark, so this request is impossible before any I/O.
         ConversionResult result = EncodingConverter.Convert(
             path, path, Encoding.ASCII, Encoding.ASCII, new ConversionOptions { WriteBom = true });
 

--- a/sources/EncodingChecker.Tests/EntrySink.cs
+++ b/sources/EncodingChecker.Tests/EntrySink.cs
@@ -4,20 +4,18 @@ using System.Collections.Concurrent;
 namespace EncodingChecker.Tests;
 
 /// <summary>
-/// Collects the entries a scan or conversion reports, safely.
+/// Collects concurrently reported entries safely and exposes them in a fixed order.
 /// </summary>
 /// <remarks>
 /// <see cref="ScanEngine.ScanDirectory"/> and <see cref="ScanEngine.ConvertFiles"/> invoke
-/// their callback concurrently from worker threads and say so; the caller has to
-/// synchronise. Both production callers use a <see cref="ConcurrentBag{T}"/>. The tests
-/// passed <c>List&lt;T&gt;.Add</c>, which is not thread-safe, and lost entries — measured
-/// at 3 runs in 40 over 200 files, dropping one or two each time.
+/// their callback concurrently. The collector must therefore synchronize internally;
+/// tests must never rely on each test author remembering that contract.
 /// <para>
-/// That is worse in a test than in the product. A dropped entry does not throw; it
-/// silently removes a file from what the test then asserts about, so the test still
-/// passes and asserts less than it claims. It surfaced as a CI failure where a file
-/// modified after planning was not caught as stale — because the file had never made it
-/// into the plan.
+/// Incident this prevents: tests previously passed <c>List&lt;T&gt;.Add</c>, which is not
+/// thread-safe, and lost one or two entries in 3 of 40 runs over 200 files. A dropped
+/// entry does not throw. It silently removes a file from the test's assertions, allowing
+/// the test to pass while proving less than it claims. One stale-plan test failed this
+/// way because its changed file had never reached the plan.
 /// </para>
 /// <para>
 /// Enumerates in path order so a test reading two entries gets them in a fixed order.

--- a/sources/EncodingChecker.Tests/ScanEngineValidationTests.cs
+++ b/sources/EncodingChecker.Tests/ScanEngineValidationTests.cs
@@ -340,6 +340,8 @@ public sealed class ScanEngineValidationTests : IDisposable
         ConversionReportEntry lockedEntry = entries.Single(
             e => string.Equals(e.FilePath, lockedPath, StringComparison.OrdinalIgnoreCase));
         Assert.Equal(ConversionRowResult.Error, lockedEntry.Result);
+        Assert.Equal(PlannedAction.Refuse, lockedEntry.Action);
+        Assert.Equal(SourceInterpretation.NotApplicable, lockedEntry.SourceInterpretation);
         Assert.NotNull(lockedEntry.Diagnostic);
 
         Assert.Contains(entries, e => e.FilePath.EndsWith("good1.txt") && e.Result != ConversionRowResult.Error);

--- a/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
+++ b/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Text;
+﻿using System.Text;
 
 namespace EncodingChecker.Tests;
 

--- a/sources/EncodingChecker.Tests/StrictFallbackEnforcementTests.cs
+++ b/sources/EncodingChecker.Tests/StrictFallbackEnforcementTests.cs
@@ -3,21 +3,21 @@
 namespace EncodingChecker.Tests;
 
 /// <summary>
-/// Pins the strict-fallback contract at the point where it is easy to lose.
+/// Pins the strict-fallback contract at the point where a seemingly correct change can
+/// silently reintroduce data loss.
 ///
-/// Assigning <see cref="Decoder.Fallback"/> or <see cref="Encoder.Fallback"/> after
-/// <see cref="Encoding.GetDecoder"/>/<see cref="Encoding.GetEncoder"/> compiles, reads as
-/// correct, and does nothing for the encodings that come from
-/// <see cref="CodePagesEncodingProvider"/>: those codecs capture their fallbacks from the
-/// parent <see cref="Encoding"/> when they are created. A build that regressed to that
-/// pattern would silently substitute characters for input its own codec cannot represent,
-/// and the conversion would still be reported as a success - the content digest compares
-/// decoded source against decoded target, so both sides pass through the same lossy
-/// decoder and agree.
+/// Former defect: assigning <see cref="Decoder.Fallback"/> or
+/// <see cref="Encoder.Fallback"/> after <see cref="Encoding.GetDecoder"/> or
+/// <see cref="Encoding.GetEncoder"/> appears correct but does not affect codecs from
+/// <see cref="CodePagesEncodingProvider"/>. Those codecs capture fallback behavior when
+/// their parent <see cref="Encoding"/> is created.
 ///
-/// The first two tests document the platform behaviour the fix exists for, so a future
-/// reader can see that the indirection in MakeStrictEncoding is load-bearing rather than
-/// ceremonial. The rest pin EC's own observable behaviour.
+/// Risk: the old pattern silently substituted characters the codec could not represent.
+/// EC could then report success because its content digest compared a lossy source decode
+/// with an output decoded from that same lossy text.
+///
+/// Protection: the first tests demonstrate the platform behavior; the remaining tests
+/// prove EC constructs strict codecs before it reads or writes data.
 /// </summary>
 public sealed class StrictFallbackEnforcementTests : IDisposable
 {

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -169,9 +169,7 @@ internal sealed class ConversionConfirmationForm : Form
         list.Columns.Add("File", 365);
         list.Columns.Add("Detected encoding", 165);
 
-        // The choice must cover every file the heading counts. Truncating this list made
-        // a large review say, for example, 310 files while the button could affect only
-        // the first 200.
+        // Show every refused file so the stated scope and the user's selection agree.
         foreach (PlannedFile file in refused)
         {
             list.Items.Add(new ListViewItem(

--- a/sources/EncodingChecker/ConversionJournal.cs
+++ b/sources/EncodingChecker/ConversionJournal.cs
@@ -100,6 +100,9 @@ internal sealed record JournalEntry
 
     /// <summary>Where the original was kept, when it was.</summary>
     public string? BackupPath { get; init; }
+
+    /// <summary>Where independently verifiable recovery metadata was written.</summary>
+    public string? RecoveryMetadataPath { get; init; }
 }
 
 /// <summary>
@@ -115,7 +118,7 @@ internal sealed record JournalEntry
 /// </remarks>
 internal sealed record ConversionJournal
 {
-    internal const int CurrentJournalVersion = 3;
+    internal const int CurrentJournalVersion = 4;
 
     public int JournalVersion { get; init; } = CurrentJournalVersion;
 
@@ -212,29 +215,19 @@ internal sealed record ConversionJournal
             };
 
             // Record the encoding actually used to read the source file.
-            ScanEngine.ParseCharsetLabel(
-                entry.ResolvedSourceLabel ?? entry.EffectiveSourceLabel,
-                out string sourceCharset,
-                out bool sourceHasBom);
+            string sourceLabel = entry.ResolvedSourceLabel ?? entry.EffectiveSourceLabel;
+            ScanEngine.ParseCharsetLabel(sourceLabel, out string sourceCharset, out bool sourceHasBom);
 
             int codePage = 0;
 
-            try
-            {
-                codePage = Encoding.GetEncoding(sourceCharset).CodePage;
-            }
-            catch (ArgumentException)
-            {
-                // Zero means EC could not resolve a code page for the recorded label.
-            }
+            if (TextEncoding.TryResolve(sourceCharset, out Encoding? sourceEncoding))
+                codePage = sourceEncoding!.CodePage;
 
             int? detectedCodePage = ResolveCodePage(entry.DetectedEncodingLabel);
 
-            string backupPath = entry.FilePath + ".bak";
-
             lines.Add(new JournalEntry
             {
-                RelativePath = Path.GetRelativePath(root, entry.FilePath),
+                RelativePath = SafeRelativePath(root, entry.FilePath),
                 // Reuse the plan's hash when available; avoid rereading the source.
                 Sha256Before = entry.JournalSourceSha256
                                ?? entry.ExpectedSourceSha256
@@ -263,11 +256,13 @@ internal sealed record ConversionJournal
                 Reason = string.IsNullOrEmpty(entry.Diagnostic) ? null : entry.Diagnostic,
                 ReasonCode = entry.ReasonCode,
                 BackupPath =
-                    status == ConversionStatus.Converted
-                    && backupEnabled
-                    && File.Exists(backupPath)
-                        ? Path.GetRelativePath(root, backupPath)
-                        : null,
+                    entry.BackupPath is null
+                        ? null
+                        : SafeRelativePath(root, entry.BackupPath),
+                RecoveryMetadataPath =
+                    entry.RecoveryMetadataPath is null
+                        ? null
+                        : SafeRelativePath(root, entry.RecoveryMetadataPath),
             });
         }
 
@@ -292,16 +287,24 @@ internal sealed record ConversionJournal
     /// <summary>The canonical code page for a label, or null when unresolved.</summary>
     private static int? ResolveCodePage(string? label)
     {
-        if (string.IsNullOrWhiteSpace(label))
-            return null;
+        return TextEncoding.TryResolve(label, out Encoding? encoding)
+            ? encoding!.CodePage
+            : null;
+    }
+
+    /// <summary>Returns a journal-safe path even when an entry is malformed.</summary>
+    private static string SafeRelativePath(string root, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "(unavailable)";
 
         try
         {
-            return Encoding.GetEncoding(label).CodePage;
+            return Path.GetRelativePath(root, path);
         }
-        catch (ArgumentException)
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
         {
-            return null;
+            return path;
         }
     }
 

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -179,9 +179,7 @@ internal sealed record ConversionPlan
 
             try
             {
-                // A conversion scan captures detection, BOM state, size, and hash from
-                // one read-only snapshot. Preserve that binding in the plan instead of
-                // pairing an earlier detection with bytes read later.
+                // Keep detection and its hash bound to the same source snapshot.
                 hash = entry.ExpectedSourceSha256
                        ?? ConversionMetadataStore.ComputeSha256(entry.FilePath);
                 size = entry.ExpectedSourceSize
@@ -203,14 +201,8 @@ internal sealed record ConversionPlan
 
             int codePage = 0;
 
-            try
-            {
-                codePage = Encoding.GetEncoding(sourceCharset).CodePage;
-            }
-            catch (ArgumentException)
-            {
-                // Zero indicates that no code page could be resolved.
-            }
+            if (TextEncoding.TryResolve(sourceCharset, out Encoding? encoding))
+                codePage = encoding!.CodePage;
 
             files.Add(new PlannedFile
             {
@@ -292,6 +284,26 @@ internal sealed record ConversionPlan
                 return null;
             }
 
+            if (string.IsNullOrWhiteSpace(plan.BaseDirectory) ||
+                string.IsNullOrWhiteSpace(plan.TargetEncoding) ||
+                plan.Files is null)
+            {
+                error = "The plan is missing required conversion information.";
+                return null;
+            }
+
+            foreach (PlannedFile? file in plan.Files)
+            {
+                if (file is null ||
+                    string.IsNullOrWhiteSpace(file.RelativePath) ||
+                    string.IsNullOrWhiteSpace(file.Sha256) ||
+                    string.IsNullOrWhiteSpace(file.SourceEncoding))
+                {
+                    error = "The plan contains an incomplete file entry.";
+                    return null;
+                }
+            }
+
             error = null;
             return plan;
         }
@@ -342,16 +354,40 @@ internal sealed record ConversionPlan
     {
         var stale = new List<string>();
 
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!TextEncoding.TryResolve(TargetEncoding, out _))
+            stale.Add($"Target encoding '{TargetEncoding}' is not available.");
+
         foreach (PlannedFile file in Files)
         {
-            if (file.Action != PlannedAction.Convert)
-                continue;
-
             string? path = ResolvePath(file);
 
             if (path is null)
             {
                 stale.Add($"{file.RelativePath} (resolves outside the plan's directory)");
+                continue;
+            }
+
+            if (!paths.Add(path))
+            {
+                stale.Add($"{path} (appears more than once in the plan)");
+                continue;
+            }
+
+            Encoding? sourceEncoding = null;
+
+            if (file.Action == PlannedAction.Convert &&
+                !TextEncoding.TryResolve(file.SourceEncoding, out sourceEncoding))
+            {
+                stale.Add($"{path} (source encoding '{file.SourceEncoding}' is not available)");
+                continue;
+            }
+
+            if (file.Action == PlannedAction.Convert &&
+                sourceEncoding!.CodePage != file.SourceCodePage)
+            {
+                stale.Add($"{path} (source codec identity does not match the plan)");
                 continue;
             }
 

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -132,6 +132,12 @@ internal sealed class ConversionReportEntry
 
     /// <summary>Stable machine-readable reason for a non-success outcome.</summary>
     internal string? ReasonCode { get; set; }
+
+    /// <summary>The backup created by this run, even if conversion later failed.</summary>
+    internal string? BackupPath { get; set; }
+
+    /// <summary>The recovery sidecar created by this run, when conversion completed.</summary>
+    internal string? RecoveryMetadataPath { get; set; }
 }
 
 /// <summary>Stable reason codes written to reports and journals.</summary>
@@ -145,6 +151,7 @@ internal static class ConversionReasonCodes
     internal const string StrictValidationFailed = nameof(StrictValidationFailed);
     internal const string SourceSnapshotFailed = nameof(SourceSnapshotFailed);
     internal const string BackupFailed = nameof(BackupFailed);
+    internal const string MultipleLeadingByteOrderMarks = nameof(MultipleLeadingByteOrderMarks);
     internal const string ScanFailed = nameof(ScanFailed);
 }
 

--- a/sources/EncodingChecker/EncodingConverter.FileReplacement.cs
+++ b/sources/EncodingChecker/EncodingConverter.FileReplacement.cs
@@ -37,6 +37,23 @@ internal static partial class EncodingConverter
     }
 
     /// <summary>
+    /// Tests whether the next bytes are another encoding preamble without consuming them.
+    /// </summary>
+    private static bool HasPreambleAtCurrentPosition(FileStream stream, Encoding encoding)
+    {
+        long position = stream.Position;
+
+        try
+        {
+            return ConsumePreambleIfPresent(stream, encoding) > 0;
+        }
+        finally
+        {
+            stream.Position = position;
+        }
+    }
+
+    /// <summary>
     /// Opens a file for shared reads while blocking writes and deletion.
     /// </summary>
     private static FileStream OpenReadShared(string path, int bufferSize)

--- a/sources/EncodingChecker/EncodingConverter.cs
+++ b/sources/EncodingChecker/EncodingConverter.cs
@@ -24,6 +24,7 @@ internal enum ConversionErrorCode
     VerificationFailed,
     UnicodeMismatch,
     BomMismatch,
+    MultipleLeadingByteOrderMarks,
     TemporaryFileError,
     ReplacementError,
     RecoveryRecordError,
@@ -288,7 +289,7 @@ internal static partial class EncodingConverter
                     "Failed to create the temporary output file",
                     () => CreateTempStream(path, effectiveBufferSize));
 
-                // Remove a compatible source BOM from the data stream.
+                // Consume one source BOM as metadata; an additional one is ambiguous text.
                 int sourcePreambleLength = RunIoStage(
                     ConversionErrorCode.SourceReadError,
                     "Failed to read the source file's leading bytes",
@@ -296,6 +297,21 @@ internal static partial class EncodingConverter
 
                 sourceBytesProcessed += sourcePreambleLength;
                 sourceHadBom = sourcePreambleLength > 0;
+
+                // A second marker would be decoded as U+FEFF text.  Do not discard it
+                // automatically: it could be intentional content, and a no-BOM target
+                // cannot represent that distinction reliably at the start of a file.
+                if (sourceHadBom && HasPreambleAtCurrentPosition(sourceStream, sourceEncoding))
+                {
+                    return Failure(
+                        ConversionErrorCode.MultipleLeadingByteOrderMarks,
+                        $"The source begins with multiple {sourceEncoding.WebName} " +
+                        "byte-order marks. No conversion was performed because an " +
+                        "additional marker may be intentional text. Remove the duplicate " +
+                        "marker manually, then try again.",
+                        sourceEncoding,
+                        targetEncoding);
+                }
 
                 if (options.WriteBom)
                 {

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -415,10 +415,6 @@ public partial class MainForm : Form
         actionStatus.Text = statusMessage;
     }
 
-    // Matches encodings reported by UtfUnknown.Core.CodepageName.
-    // UTF-7 is intentionally excluded because .NET disables it by default (SYSLIB0001)
-    // and Encoding.GetEncoding throws NotSupportedException.
-
     private void ShowWarning(
         string message,
         params object[] args)

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -110,7 +110,7 @@ internal static partial class Program
     }
 
     private const string UsageText = """
-        EncodingChecker v3.9.0
+        EncodingChecker v3.9.1
 
         Common commands:
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.0.0")]
-[assembly: AssemblyFileVersion("3.9.0.0")]
+[assembly: AssemblyVersion("3.9.1.0")]
+[assembly: AssemblyFileVersion("3.9.1.0")]

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -179,7 +179,12 @@ internal static class ScanEngine
                         nameof(options));
                 }
 
-                return Encoding.GetEncoding(options.TargetCharset);
+                if (TextEncoding.TryResolve(options.TargetCharset, out Encoding? target))
+                    return target;
+
+                throw new ArgumentException(
+                    $"Target encoding '{options.TargetCharset}' is not available.",
+                    nameof(options));
 
             case ScanAction.Validate:
                 if (options.ValidCharsets is null ||
@@ -225,7 +230,14 @@ internal static class ScanEngine
         ArgumentNullException.ThrowIfNull(onEntry);
 
         // Resolve the target once, matching ScanDirectory.
-        Encoding targetEncoding = Encoding.GetEncoding(targetCharset);
+        if (!TextEncoding.TryResolve(targetCharset, out Encoding? resolvedTarget))
+        {
+            throw new ArgumentException(
+                $"Target encoding '{targetCharset}' is not available.",
+                nameof(targetCharset));
+        }
+
+        Encoding targetEncoding = resolvedTarget!;
 
         RunParallel(
             entries,
@@ -262,13 +274,7 @@ internal static class ScanEngine
                 Encoding sourceEncoding;
                 Encoding? automaticallyDetected = null;
 
-                try
-                {
-                    sourceEncoding = Encoding.GetEncoding(sourceCharset);
-                    if (!string.IsNullOrWhiteSpace(entry.DetectedEncodingLabel))
-                        automaticallyDetected = Encoding.GetEncoding(entry.DetectedEncodingLabel);
-                }
-                catch (ArgumentException)
+                if (!TextEncoding.TryResolve(sourceCharset, out Encoding? resolvedSource))
                 {
                     entry.Action = PlannedAction.Refuse;
                     entry.SourceInterpretation = SourceInterpretation.NotApplicable;
@@ -277,6 +283,11 @@ internal static class ScanEngine
                     entry.Diagnostic = $"The source encoding '{sourceCharset}' is not available.";
                     return entry;
                 }
+
+                sourceEncoding = resolvedSource!;
+
+                if (!string.IsNullOrWhiteSpace(entry.DetectedEncodingLabel))
+                    TextEncoding.TryResolve(entry.DetectedEncodingLabel, out automaticallyDetected);
 
                 ApplyConversion(
                     entry,
@@ -432,14 +443,7 @@ internal static class ScanEngine
         }
         else if (sourceWasSpecified)
         {
-            try
-            {
-                detected = Encoding.GetEncoding(options.SourceCharset!);
-            }
-            catch (ArgumentException)
-            {
-                detected = null;
-            }
+            TextEncoding.TryResolve(options.SourceCharset, out detected);
 
             hasBom = detected != null && HasPreamble(path, detected);
         }
@@ -586,7 +590,11 @@ internal static class ScanEngine
                 explicitSourceLabel,
                 out string sourceCharset,
                 out _);
-            sourceEncoding = Encoding.GetEncoding(sourceCharset);
+            if (!TextEncoding.TryResolve(sourceCharset, out sourceEncoding))
+            {
+                throw new NotSupportedException(
+                    $"The source encoding '{sourceCharset}' is not available.");
+            }
         }
 
         bool hasBom = sourceEncoding != null && HasPreamble(stream, sourceEncoding);
@@ -747,6 +755,17 @@ internal static class ScanEngine
             return;
         }
 
+        if (HasMultipleLeadingPreambles(path, sourceEncoding))
+        {
+            entry.Action = PlannedAction.Refuse;
+            entry.Result = ConversionRowResult.Refused;
+            entry.ReasonCode = ConversionReasonCodes.MultipleLeadingByteOrderMarks;
+            entry.Diagnostic =
+                "The source starts with more than one byte-order mark. "
+                + "Remove the extra mark before converting; no files were changed.";
+            return;
+        }
+
         if (whatIf)
         {
             entry.Result = ConversionRowResult.Converted; // "would be converted"
@@ -758,6 +777,7 @@ internal static class ScanEngine
             try
             {
                 CreateBackup(path);
+                entry.BackupPath = path + ".bak";
             }
             catch (Exception ex) when (
                 ex is IOException or UnauthorizedAccessException)
@@ -775,7 +795,15 @@ internal static class ScanEngine
 
             // Without a backup there is nothing to restore from.
             RecordConversion = backup
-                ? record => WriteConversionMetadata(path, record, entry)
+                ? record =>
+                {
+                    string? error = WriteConversionMetadata(path, record, entry);
+
+                    if (error is null)
+                        entry.RecoveryMetadataPath = ConversionMetadataStore.MetadataPathFor(path);
+
+                    return error;
+                }
                 : null,
 
             // Present only when an approved plan pinned the original bytes.
@@ -822,10 +850,7 @@ internal static class ScanEngine
     }
 
     /// <summary>
-    /// Writes "<paramref name="path"/>.bak" through a temporary file before replacement.
-    /// </summary>
-    /// <summary>
-    /// Writes the sidecar describing how to undo this conversion, next to the backup.
+    /// Writes recovery metadata only after output verification and before installation.
     /// </summary>
     /// <remarks>
     /// Called after output verification and before installation so metadata failure leaves
@@ -847,8 +872,7 @@ internal static class ScanEngine
             return $"the backup at '{backupPath}' could not be read: {ex.Message}";
         }
 
-        // A readable backup is not enough: prove it is the exact source this conversion
-        // used. Missing either hash is a refusal, not permission to skip the comparison.
+        // A backup is useful only if it is the exact source this conversion read.
         string? hashError = ConversionMetadataStore.ValidateRecoveryHashes(
             record.SourceSha256, backupHash, backupPath);
 
@@ -891,19 +915,42 @@ internal static class ScanEngine
     /// <summary>The code page for a charset label, or null when it cannot be resolved.</summary>
     private static int? ResolveCodePage(string? label)
     {
-        if (string.IsNullOrEmpty(label))
-            return null;
+        return TextEncoding.TryResolve(label, out Encoding? encoding)
+            ? encoding!.CodePage
+            : null;
+    }
+
+    /// <summary>Detects a repeated leading BOM before a backup is created.</summary>
+    private static bool HasMultipleLeadingPreambles(string path, Encoding encoding)
+    {
+        byte[] preamble = encoding.GetPreamble();
+
+        if (preamble.Length == 0)
+            return false;
+
+        byte[] prefix = new byte[preamble.Length * 2];
 
         try
         {
-            return Encoding.GetEncoding(label).CodePage;
+            using FileStream stream = new(
+                path, FileMode.Open, FileAccess.Read, FileShare.Read,
+                prefix.Length, FileOptions.SequentialScan);
+
+            int read = stream.Read(prefix, 0, prefix.Length);
+
+            return read == prefix.Length
+                   && prefix.AsSpan(0, preamble.Length).SequenceEqual(preamble)
+                   && prefix.AsSpan(preamble.Length, preamble.Length).SequenceEqual(preamble);
         }
-        catch (ArgumentException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            return null;
+            // This is an early diagnostic only; the normal conversion path reports the
+            // actual read or backup failure on the original entry.
+            return false;
         }
     }
 
+    /// <summary>Creates a durable backup before conversion can replace the source.</summary>
     private static void CreateBackup(string path)
     {
         string? directory = Path.GetDirectoryName(path);
@@ -1006,6 +1053,8 @@ internal static class ScanEngine
                         SourceEncoding = "(Error)",
                         TargetEncoding = "(Error)",
                         Result = ConversionRowResult.Error,
+                        Action = PlannedAction.Refuse,
+                        SourceInterpretation = SourceInterpretation.NotApplicable,
                         ReasonCode = ConversionReasonCodes.ScanFailed,
                         Diagnostic = ex.Message,
                     };

--- a/sources/EncodingChecker/TextEncoding.cs
+++ b/sources/EncodingChecker/TextEncoding.cs
@@ -230,6 +230,10 @@ internal static class TextEncoding
     /// <summary>
     /// Charset names EC knows how to ask the current runtime for.
     /// </summary>
+    /// <remarks>
+    /// UTF-7 is deliberately not listed: current .NET versions disable it by default.
+    /// Other unavailable names are filtered when <see cref="SupportedEncodings"/> is built.
+    /// </remarks>
     private static readonly string[] CharsetNames =
     [
         "ascii", "utf-8", "utf-16le", "utf-16be",
@@ -267,6 +271,27 @@ internal static class TextEncoding
         ResolveSupportedEncodings();
 
 
+    /// <summary>Resolves a codec without allowing an unsupported name to escape.</summary>
+    internal static bool TryResolve(string? name, out Encoding? encoding)
+    {
+        encoding = null;
+
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        try
+        {
+            encoding = Encoding.GetEncoding(name);
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is ArgumentException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+
     private static IReadOnlyList<Encoding> ResolveSupportedEncodings()
     {
         var encodings = new List<Encoding>();
@@ -274,17 +299,10 @@ internal static class TextEncoding
 
         foreach (string name in CharsetNames)
         {
-            try
+            if (TryResolve(name, out Encoding? encoding) &&
+                codePages.Add(encoding!.CodePage))
             {
-                Encoding encoding = Encoding.GetEncoding(name);
-
-                if (codePages.Add(encoding.CodePage))
-                    encodings.Add(encoding);
-            }
-            catch (Exception ex) when (
-                ex is ArgumentException or NotSupportedException)
-            {
-                // This runtime does not provide the named encoding.
+                encodings.Add(encoding);
             }
         }
 


### PR DESCRIPTION
## Summary

- validate every saved-plan row, path, hash, and codec before any write
- refuse repeated leading BOMs before backup creation
- make unreadable and unsupported inputs terminal, reportable outcomes
- record backups and recovery metadata truthfully in journal schema v4
- improve conversion review clarity and focused regression coverage
- bump the application and documentation to v3.9.1

## Verification

- Release build: 0 warnings, 0 errors
- Release tests: 459 passed
- shared detector parity: passed across EncodingChecker, LineEndingNormalizer, and CorpusTesters
- changed C# files: CRLF only
- git diff check: clean