### PR TITLE
Prepare EncodingChecker v3.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ EncodingChecker.exe -BasePath "D:\Share" -Target utf-8 -MaxParallelism 2
 | `-MaxParallelism <N>` | Maximum simultaneous files; default is `min(CPU count, 4)`. |
 | `-FailOnChanges` | Return exit code `2` if files need conversion or fail validation. Useful in CI. |
 
-Patterns without a path separator match filenames at any depth, such as `*.txt`. Patterns containing `/` or `\` match paths relative to `-BasePath`, such as `src/*.cs`. Build and metadata folders including `.git`, `bin`, `obj`, and `node_modules` are skipped automatically. Hidden files, system files, and shortcuts to files elsewhere are left alone as well. If a scan comes across any of these, it tells you how many it passed over, so a clean result never hides files EC did not open.
+Patterns without a path separator match filenames at any depth, such as `*.txt`. Patterns containing `/` or `\` match paths relative to `-BasePath`, such as `src/*.cs`. Build and metadata folders including `.git`, `bin`, `obj`, and `node_modules` are skipped automatically. Matching hidden, system, and reparse-point files are left alone and counted. Hidden, system, and reparse-point folders are not entered and are counted separately because EC does not inspect their contents. The GUI shows these counts in its status; the CLI writes them to standard error. These coverage notices are informational and do not change the exit code.
 
 Run `EncodingChecker.exe -?` for the same reference from the executable. The help aliases are `-?`, `/?`, `-h`, `/h`, and `--help`. Exit codes: `0` completed, `1` invalid command, `2` `-FailOnChanges`, `3` processing/plan/report failure, `4` cancelled, `5` conversion safely refused.
 
@@ -112,7 +112,7 @@ For the complete safety model, conversion-plan guarantees, recovery metadata, kn
 
 ## Known limits
 
-File bytes alone cannot always identify the original legacy encoding uniquely. EC therefore leaves detected legacy text unchanged until you choose or confirm its source encoding. Keep each `.bak` file with its matching `.ecmeta.json` record: together they provide independently verifiable recovery information, although EC does not currently include a restore command.
+File bytes alone cannot always identify the original legacy encoding uniquely. EC therefore leaves detected legacy text unchanged until you choose or confirm its source encoding. If your explicit source differs from a BOM-less UTF-16/32 estimate, EC follows your choice but shows a warning. Keep each `.bak` file with its matching `.ecmeta.json` record: together they provide independently verifiable recovery information, although EC does not currently include a restore command. The record contains both original and expected-output hashes and says whether installation was only prepared or completed.
 
 ## Supported charsets
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.9.1
+# EncodingChecker v3.9.2
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 
@@ -100,7 +100,7 @@ EncodingChecker.exe -BasePath "D:\Share" -Target utf-8 -MaxParallelism 2
 | `-MaxParallelism <N>` | Maximum simultaneous files; default is `min(CPU count, 4)`. |
 | `-FailOnChanges` | Return exit code `2` if files need conversion or fail validation. Useful in CI. |
 
-Patterns without a path separator match filenames at any depth, such as `*.txt`. Patterns containing `/` or `\` match paths relative to `-BasePath`, such as `src/*.cs`. Build and metadata folders including `.git`, `bin`, `obj`, and `node_modules` are skipped automatically.
+Patterns without a path separator match filenames at any depth, such as `*.txt`. Patterns containing `/` or `\` match paths relative to `-BasePath`, such as `src/*.cs`. Build and metadata folders including `.git`, `bin`, `obj`, and `node_modules` are skipped automatically. Hidden files, system files, and shortcuts to files elsewhere are left alone as well. If a scan comes across any of these, it tells you how many it passed over, so a clean result never hides files EC did not open.
 
 Run `EncodingChecker.exe -?` for the same reference from the executable. The help aliases are `-?`, `/?`, `-h`, `/h`, and `--help`. Exit codes: `0` completed, `1` invalid command, `2` `-FailOnChanges`, `3` processing/plan/report failure, `4` cancelled, `5` conversion safely refused.
 

--- a/docs/CONVERSION-WORKFLOW.md
+++ b/docs/CONVERSION-WORKFLOW.md
@@ -14,13 +14,20 @@ The review tells you which files will convert, already match the target, need a 
 
 ## The important rule
 
-| File type | What EC does automatically |
-| --- | --- |
-| Unicode or ASCII | May convert it |
-| Legacy text | Leaves it unchanged until you choose the original encoding |
-| Unknown or unreadable data | Leaves it unchanged |
+For a file that needs conversion, EC applies this policy:
 
-Choosing a legacy encoding answers only “how should these bytes be read?” It does not disable strict decoding, output verification, backups, or atomic installation.
+| Source interpretation | EC's action |
+| --- | --- |
+| Unicode or ASCII detected automatically | Convert if needed |
+| Legacy codec selected explicitly by the user | Convert if needed, subject to every safety check; refuse if the choice conflicts with fully validated UTF-8 or BOM-confirmed UTF-16/32 |
+| Legacy codec detected automatically | Refuse conversion until you choose or confirm the source codec |
+| Unknown or unreadable source | Do not convert |
+
+A file that already matches the target encoding and BOM is reported as **Unchanged** and
+is not decoded or rewritten. No source choice is needed because no conversion occurs.
+
+Choosing a legacy encoding answers only “how should these bytes be read?” It does not
+disable strict decoding, output verification, backup verification, or safe installation.
 
 ## What EC does
 
@@ -38,7 +45,35 @@ flowchart LR
 
 Every step after confirmation must succeed. If decoding, encoding, verification, backup creation, or installation fails, EC leaves that source file unchanged.
 
-## Plans and the command line
+## Two ways to start a conversion
+
+EC offers two workflows, but they do not use different conversion engines. Both use the
+same source-encoding policy, strict codecs, output verification, backup checks, and safe
+file installation.
+
+**Most users should use direct conversion. Saved plan/apply is an optional advanced
+workflow for delayed approval or repeatable automation.**
+
+| Workflow | Best for | What happens |
+| --- | --- | --- |
+| Direct conversion | Normal GUI use and simple command-line jobs | EC scans, makes its safety decisions, and converts during one run. |
+| Saved plan and apply | Important batches, automation, or approval at a later time | EC saves exactly what was reviewed, then verifies that saved decision before writing. |
+
+### Direct conversion
+
+The GUI normally uses the direct workflow: **View → select → Convert → review → confirm**.
+The review plan exists in memory and is executed immediately after confirmation.
+
+The command-line equivalent is:
+
+```powershell
+EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Backup
+```
+
+Choose direct conversion when you are reviewing and converting the files in the same
+session. It is simpler because there is no plan file to save or manage.
+
+### Saved plan and apply
 
 For a cautious batch workflow, create a plan first:
 
@@ -52,9 +87,61 @@ After reviewing it, apply that exact plan:
 EncodingChecker.exe -Apply plan.json
 ```
 
-Detection and SHA-256 hashing use the same source snapshot when the plan is built. The plan contains those hashes and the complete conversion settings. If a scheduled file changes after review, EC rejects the whole plan instead of applying an approval to different bytes. `-Apply` cannot be combined with `-WhatIf`: the saved plan is already the preview, while applying it performs the reviewed writes.
+Detection and SHA-256 hashing use the same source snapshot when the plan is built. The plan
+contains those hashes and the complete conversion settings. If a scheduled file changes
+after review, EC rejects the whole plan instead of applying an approval to different bytes.
+`-Apply` cannot be combined with `-WhatIf`: the saved plan is already the preview, while
+applying it performs the reviewed writes.
 
-The GUI uses the same planned actions. Its **Export results** menu can save selected rows as text, all displayed results as a diagnostic CSV report, or the exact completed conversion journal as JSON.
+### What a saved plan uniquely provides
+
+A saved plan lets you separate review from execution. It records:
+
+- the folder and relative file paths;
+- each file's size and SHA-256;
+- the detected or explicitly selected source encoding;
+- the target encoding and BOM choice;
+- whether backups are enabled;
+- the EC plan schema and conversion-safety rules.
+
+When you run `-Apply`, EC uses those saved decisions instead of detecting the files again.
+Before writing anything, it verifies every planned file. If any file changed, disappeared,
+or no longer matches the approved plan, EC rejects the entire plan.
+
+This is useful when:
+
+- the plan is reviewed now but applied later;
+- one person prepares a batch and another approves it;
+- a script must perform exactly a previously reviewed operation;
+- you need a durable record of what was approved.
+
+### What a saved plan does not provide
+
+A plan does not improve encoding detection or make an incorrect source choice correct. It
+does not disable any safety check, provide a restore command, or make the whole batch one
+atomic transaction. Files are still verified and installed individually. A plan also cannot
+include hidden or otherwise excluded files that EC never scanned.
+
+Plans deliberately become invalid when their files change. Regenerate and review the plan
+rather than editing its hashes or trying to force an old approval onto new bytes.
+
+### Why EC keeps direct conversion
+
+For everyday work, requiring everyone to save and reapply a JSON plan would add extra steps
+without improving the per-file conversion checks. Direct conversion therefore remains the
+simple workflow, while plan/apply is available when delayed approval, automation, or exact
+reproducibility matters.
+
+In short:
+
+```text
+Direct: scan → review → convert now
+Plan:   scan → save approval → review later → verify unchanged files → convert
+```
+
+The GUI uses the same planned actions. Its **Export results** menu can save selected rows as
+text, all displayed results as a diagnostic CSV report, or the exact completed conversion
+journal as JSON.
 
 For a known legacy source, supply the encoding explicitly:
 

--- a/docs/RELEASE-NOTES-v3.9.2.md
+++ b/docs/RELEASE-NOTES-v3.9.2.md
@@ -1,34 +1,50 @@
 # EncodingChecker v3.9.2
 
-This patch closes two gaps where a run could report a result it had not established, and
-hardens two smaller paths found in the same review.
+This patch closes cases where a run or recovery record could describe more than EC had
+actually established. It also improves scan-coverage reporting without changing which
+files EC is willing to convert.
 
-## Fixes
+## Safety fixes
 
-- A `-Include` value that contains no usable pattern is now rejected instead of silently
-  meaning *every file*. `-Include ""`, `-Include ",,,"` and similar previously widened a
-  scan to the whole folder — the opposite of what the caller asked for, and dangerous when
-  the value came from an unset variable in a script. `-Exclude` is validated the same way.
-  Omitting either option still means "every file", unchanged.
-- Files skipped for being hidden, system, or reparse points are now counted and reported.
-  They were dropped inside the operating system's own enumeration, so they produced no row,
-  no count and no note: a folder containing one validated clean and exited `0`, and a
-  conversion reported `Selected: 1` for two files. What gets skipped is unchanged; the
-  count is what makes a clean result distinguishable from files EC never opened. It is
-  written to standard error so it survives `-Quiet` and stays out of the CSV report.
-- The repeated byte-order-mark probe now requires its full prefix, rather than treating a
-  short read as "no repeated mark".
-- Closing the main window a second time during a run that has not stopped now closes it,
-  after confirmation. Cancellation is cooperative, so a run blocked on unresponsive storage
-  previously left the window impossible to close.
+- Recovery sidecars now distinguish `Prepared` from `Completed` installation and record
+  the verified output file's SHA-256. If installation fails or EC stops after preparation,
+  the sidecar remains truthful: its original and expected-output hashes identify which
+  state the current file is in. Sidecar updates use a verified temporary file so a failed
+  update does not overwrite the last valid record.
+- A `-Include` value that contains no usable pattern is rejected instead of silently
+  meaning *every file*. `-Include ""`, `-Include ",,,"` and similar values previously
+  widened a scan to the whole folder. `-Exclude` is validated the same way. Omitting either
+  option keeps its previous meaning.
+- The repeated byte-order-mark probe now requires its complete prefix, rather than treating
+  a short stream read as proof that no repeated mark exists.
+- When an explicit source differs from a BOM-less UTF-16/32 estimate, EC still follows the
+  user's source choice but now records and displays a clear warning. A BOM-confirmed UTF
+  conflict remains a refusal.
+- Saved plans now preserve automatic-detection provenance, including BOM state. This changes
+  the plan schema to version 4; regenerate plans created by an earlier release before applying
+  them with v3.9.2.
 
-## Documentation
+## Scan coverage
 
-- The help text and README now state that hidden files, system files, and reparse points are
-  not examined. This was previously recorded only in the v3.9.0 release notes, not in the two
-  places a reader looks.
+- Matching files skipped for hidden, system, or reparse-point attributes are counted after
+  include, exclude, output, backup, sidecar, and temporary-file exclusions are applied.
+- Hidden, system, and reparse-point folders are counted separately and are not entered.
+  EC does not claim to know how many matching files are inside an unexamined folder.
+- The GUI includes these counts in its completion status. The CLI writes them to standard
+  error so they remain visible with `-Quiet` without entering CSV output.
+- Coverage notices are informational and do not change the exit code. Scripts that require
+  complete coverage should inspect standard error; no new CLI policy switch is introduced
+  in this patch.
+
+## Usability
+
+- Closing the main window a second time can end a run that has not responded to cooperative
+  cancellation, after confirmation. The warning now states accurately that completed files
+  remain converted and that a file being installed may need inspection afterward.
+- The command-line help and README explain which excluded items are counted and where those
+  counts appear.
 
 ## Unchanged
 
-Detection, the strict streaming converter, output verification, atomic installation, backup
-handling, and the v3.9 legacy-source policy are untouched. No conversion behaves differently.
+Detection, strict streaming conversion, exact text verification, backup verification,
+the v3.9 legacy-source rule, and normal exit-code meanings are unchanged.

--- a/docs/RELEASE-NOTES-v3.9.2.md
+++ b/docs/RELEASE-NOTES-v3.9.2.md
@@ -1,0 +1,34 @@
+# EncodingChecker v3.9.2
+
+This patch closes two gaps where a run could report a result it had not established, and
+hardens two smaller paths found in the same review.
+
+## Fixes
+
+- A `-Include` value that contains no usable pattern is now rejected instead of silently
+  meaning *every file*. `-Include ""`, `-Include ",,,"` and similar previously widened a
+  scan to the whole folder — the opposite of what the caller asked for, and dangerous when
+  the value came from an unset variable in a script. `-Exclude` is validated the same way.
+  Omitting either option still means "every file", unchanged.
+- Files skipped for being hidden, system, or reparse points are now counted and reported.
+  They were dropped inside the operating system's own enumeration, so they produced no row,
+  no count and no note: a folder containing one validated clean and exited `0`, and a
+  conversion reported `Selected: 1` for two files. What gets skipped is unchanged; the
+  count is what makes a clean result distinguishable from files EC never opened. It is
+  written to standard error so it survives `-Quiet` and stays out of the CSV report.
+- The repeated byte-order-mark probe now requires its full prefix, rather than treating a
+  short read as "no repeated mark".
+- Closing the main window a second time during a run that has not stopped now closes it,
+  after confirmation. Cancellation is cooperative, so a run blocked on unresponsive storage
+  previously left the window impossible to close.
+
+## Documentation
+
+- The help text and README now state that hidden files, system files, and reparse points are
+  not examined. This was previously recorded only in the v3.9.0 release notes, not in the two
+  places a reader looks.
+
+## Unchanged
+
+Detection, the strict streaming converter, output verification, atomic installation, backup
+handling, and the v3.9 legacy-source policy are untouched. No conversion behaves differently.

--- a/docs/SAFETY-AUDIT.md
+++ b/docs/SAFETY-AUDIT.md
@@ -20,14 +20,17 @@ The source is not rewritten in place. File attributes and timestamps are applied
 
 Encoding identification and text preservation are different questions. A sequence of legacy bytes often cannot prove which historical single-byte code page produced it.
 
-EC therefore has a simple policy:
+EC therefore has a simple policy. For a file that needs conversion:
 
-| Source interpretation | Automatic conversion |
+| Source interpretation | EC's action |
 | --- | --- |
-| Unicode or ASCII | Allowed |
-| Legacy codec supplied explicitly by the user | Allowed, subject to all safety checks; rejected if it conflicts with a fully validated Unicode reading |
-| Legacy codec detected automatically | Refused; choose the source codec first |
-| Unknown or unreadable source | Not converted |
+| Unicode or ASCII detected automatically | Convert if needed |
+| Legacy codec selected explicitly by the user | Convert if needed, subject to every safety check; refuse if the choice conflicts with fully validated UTF-8 or BOM-confirmed UTF-16/32 |
+| Legacy codec detected automatically | Refuse conversion until you choose or confirm the source codec |
+| Unknown or unreadable source | Do not convert |
+
+A file that already matches the target encoding and BOM is reported as **Unchanged** and
+is not decoded or rewritten. No source choice is needed because no conversion occurs.
 
 `-From` and the GUI source chooser replace detection only. They do not bypass strict decoding, output verification, backup verification, or atomic installation.
 
@@ -39,7 +42,7 @@ EC therefore has a simple policy:
 
 The GUI uses the same policy and plan model. It displays a review before writing, and a changed source while that review is open invalidates the run.
 
-With backups enabled, each conversion has a portable `<file>.ecmeta.json` sidecar. The sidecar records the source codec actually used, whether it was detected or explicitly selected, source and backup hashes, target/BOM policy, conversion timestamp, and version. The backup and sidecar provide independently verifiable recovery metadata; EC does not currently provide a restore command.
+With backups enabled, each conversion has a portable `<file>.ecmeta.json` sidecar. The sidecar records the source codec actually used, whether it was detected or explicitly selected, source and backup hashes, the expected converted-file hash, target/BOM policy, preparation state, timestamp, and version. It is written as `Prepared` before installation and changed to `Completed` only after installation succeeds. If a run stops between those steps, the current file's hash shows whether it is still the original or the verified output. The backup and sidecar provide independently verifiable recovery metadata; EC does not currently provide a restore command.
 
 `-Journal` provides the batch-level record: EC's detected source, the source codec actually selected, whether that selection was explicit, any canonical-code-page disagreement between the two, the policy decision, planned action, actual outcome, stable reason code, diagnostic, and before/after hashes for every file—including skipped and refused ones. The GUI exports the immutable journal returned by the completed run rather than reconstructing history from mutable controls.
 

--- a/sources/EncodingChecker.Tests/CliArgumentParserTests.cs
+++ b/sources/EncodingChecker.Tests/CliArgumentParserTests.cs
@@ -184,6 +184,84 @@ public sealed class CliArgumentParserTests
         return options;
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(",,,")]
+    [InlineData("   ")]
+    [InlineData(",")]
+    public void TryValidateOptions_IncludeGivenButUnusable_Fails(string pattern)
+    {
+        // A filter that parses to nothing must not mean "every file". This is the
+        // dangerous direction: -Include "$VAR" with VAR unset would otherwise widen
+        // a conversion to the whole tree instead of failing.
+        Program.CliOptions options =
+            ParsedOptions("-BasePath", @"C:\Source", "-Target", "utf-8", "-Include", pattern);
+
+        Assert.True(options.IncludeSpecified);
+        Assert.Empty(options.Include);
+
+        bool valid = Program.TryValidateOptions(options, out string? error);
+
+        Assert.False(valid);
+        Assert.Contains("no usable pattern", error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(",,,")]
+    public void TryValidateOptions_ExcludeGivenButUnusable_Fails(string pattern)
+    {
+        Program.CliOptions options =
+            ParsedOptions("-BasePath", @"C:\Source", "-Target", "utf-8", "-Exclude", pattern);
+
+        bool valid = Program.TryValidateOptions(options, out string? error);
+
+        Assert.False(valid);
+        Assert.Contains("no usable pattern", error);
+    }
+
+    [Fact]
+    public void TryValidateOptions_IncludeOmitted_StillMeansEveryFile()
+    {
+        // The fix must not turn "no filter" into an error; only a supplied-but-empty
+        // one. Validation also requires the base path to exist, so use a real folder
+        // and the assertion cannot pass for the wrong reason.
+        string root = Directory.CreateTempSubdirectory("ec-include-").FullName;
+
+        try
+        {
+            Program.CliOptions options =
+                ParsedOptions("-BasePath", root, "-Target", "utf-8");
+
+            Assert.False(options.IncludeSpecified);
+            Assert.Empty(options.Include);
+            Assert.True(Program.TryValidateOptions(options, out string? error), error);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryValidateOptions_IncludeWithOneUsablePattern_Passes()
+    {
+        string root = Directory.CreateTempSubdirectory("ec-include-").FullName;
+
+        try
+        {
+            Program.CliOptions options = ParsedOptions(
+                "-BasePath", root, "-Target", "utf-8", "-Include", ",,*.txt,,");
+
+            Assert.Equal(["*.txt"], options.Include);
+            Assert.True(Program.TryValidateOptions(options, out string? error), error);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     [Fact]
     public void TryValidateOptions_MissingBasePath_Fails()
     {

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -108,6 +108,51 @@ public sealed class ConversionConfirmationFormTests : IDisposable
     }
 
     [Fact]
+    public void ItShowsBomlessUnicodeDisagreementWithoutCallingItARefusal()
+    {
+        var plan = new ConversionPlan
+        {
+            CreatedUtc = DateTime.UtcNow.ToString("O"),
+            EcVersion = "test",
+            BaseDirectory = _root,
+            TargetEncoding = "utf-8",
+            TargetHasBom = false,
+            BackupEnabled = true,
+            ExplicitSourceEncoding = "windows-1252",
+            Files =
+            [
+                new PlannedFile
+                {
+                    RelativePath = "bomless.txt",
+                    Size = 20,
+                    Sha256 = new string('0', 64),
+                    Action = PlannedAction.Convert,
+                    SourceEncoding = "windows-1252",
+                    SourceCodePage = 1252,
+                    SourceHasBom = false,
+                    SourceWasSpecified = true,
+                    SourceInterpretation = SourceInterpretation.ExplicitSource,
+                    ReasonCode = ConversionReasonCodes
+                        .ExplicitSourceDiffersFromBomlessUnicodeEstimate,
+                    Reason =
+                        "EC estimated BOM-less utf-16BE, but you selected windows-1252.",
+                },
+            ],
+        };
+
+        UiTest.OnStaThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+            string text = AllText(form);
+
+            Assert.Contains("BOM-less Unicode estimate", text);
+            Assert.Contains("bomless.txt", text);
+            Assert.Contains("Convert 1 file(s)", text);
+            Assert.DoesNotContain("Needs a source encoding", text);
+        });
+    }
+
+    [Fact]
     public void ItBuildsWhenEverythingIsRefused()
     {
         // Nothing to convert. The button has to say so rather than offering an action

--- a/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 
@@ -67,7 +69,11 @@ public sealed class ConversionMetadataTests : IDisposable
         var metadata = JsonSerializer.Deserialize<ConversionMetadata>(
             File.ReadAllText(metadataPath))!;
 
-        Assert.Equal(2, metadata.MetadataVersion);
+        Assert.Equal(3, metadata.MetadataVersion);
+        Assert.Equal(ConversionInstallationState.Completed, metadata.InstallationState);
+        Assert.Equal(
+            ConversionMetadataStore.ComputeSha256(path),
+            metadata.ExpectedOutputSha256);
 
         // The recovery key is the codec actually used. This conversion used an
         // explicit source, so it deliberately has no detector provenance.
@@ -163,6 +169,102 @@ public sealed class ConversionMetadataTests : IDisposable
 
         Assert.Contains("does not match", ConversionMetadataStore.ValidateRecoveryHashes(
             hash, new string('b', 64), "example.txt.bak"));
+    }
+
+    [Fact]
+    public void FailedInstallationLeavesATruthfulPreparedRecord()
+    {
+        const string text = "café";
+        string path = Path.Combine(_root, "locked.txt");
+        byte[] original = Encoding.GetEncoding("windows-1252").GetBytes(text);
+        File.WriteAllBytes(path, original);
+
+        // Allow reads and backup creation but deny replacement. This reaches the real
+        // failure window after the sidecar is prepared and before output installation.
+        using FileStream locked = new(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        var entries = new ConcurrentBag<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["locked.txt"],
+                Action = ScanAction.Convert,
+                SourceCharset = "windows-1252",
+                TargetCharset = "utf-8",
+                TargetWriteBom = false,
+                Backup = true,
+            },
+            entries.Add,
+            CancellationToken.None);
+
+        ConversionReportEntry entry = Assert.Single(entries);
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.Equal(original, File.ReadAllBytes(path));
+
+        var metadata = JsonSerializer.Deserialize<ConversionMetadata>(
+            File.ReadAllText(ConversionMetadataStore.MetadataPathFor(path)))!;
+
+        Assert.Equal(ConversionInstallationState.Prepared, metadata.InstallationState);
+        Assert.Equal(metadata.OriginalSha256, ConversionMetadataStore.ComputeSha256(path));
+        Assert.Equal(
+            System.Convert.ToHexStringLower(
+                SHA256.HashData(new UTF8Encoding(false).GetBytes(text))),
+            metadata.ExpectedOutputSha256);
+        Assert.NotEqual(metadata.OriginalSha256, metadata.ExpectedOutputSha256);
+    }
+
+    [Fact]
+    public void FailedSidecarUpdatePreservesThePreviousValidRecord()
+    {
+        const string text = "café";
+        string path = Path.Combine(_root, "sidecar-locked.txt");
+        File.WriteAllBytes(path, Encoding.GetEncoding("windows-1252").GetBytes(text));
+
+        var entries = new ConcurrentBag<ConversionReportEntry>();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = ["sidecar-locked.txt"],
+                Action = ScanAction.Convert,
+                SourceCharset = "windows-1252",
+                TargetCharset = "utf-8",
+                TargetWriteBom = false,
+                Backup = true,
+            },
+            entries.Add,
+            CancellationToken.None);
+
+        Assert.Equal(ConversionRowResult.Converted, Assert.Single(entries).Result);
+
+        string metadataPath = ConversionMetadataStore.MetadataPathFor(path);
+        var completed = JsonSerializer.Deserialize<ConversionMetadata>(
+            File.ReadAllBytes(metadataPath))!;
+        ConversionMetadata prepared = completed with
+        {
+            InstallationState = ConversionInstallationState.Prepared,
+        };
+
+        Assert.Null(ConversionMetadataStore.Write(path, prepared));
+        byte[] validPreparedRecord = File.ReadAllBytes(metadataPath);
+
+        using FileStream locked = new(
+            metadataPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        string? error = ConversionMetadataStore.Write(path, completed);
+
+        Assert.NotNull(error);
+        Assert.Equal(validPreparedRecord, File.ReadAllBytes(metadataPath));
+        Assert.Equal(
+            ConversionInstallationState.Prepared,
+            JsonSerializer.Deserialize<ConversionMetadata>(validPreparedRecord)!
+                .InstallationState);
     }
 
 }

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -437,6 +437,11 @@ public sealed class ConversionPlanTests : IDisposable
         Assert.True(plan.Semantics.OutputVerification);
         Assert.True(plan.Semantics.AtomicInstall);
         Assert.True(plan.Semantics.LegacyRequiresExplicitSource);
+
+        PlannedFile file = Assert.Single(plan.Files);
+        Assert.Equal("shift_jis", file.DetectedEncoding);
+        Assert.Equal(932, file.DetectedCodePage);
+        Assert.False(file.DetectedHasBom);
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/ConversionSafetyInvariantTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionSafetyInvariantTests.cs
@@ -167,6 +167,68 @@ public sealed class ConversionSafetyInvariantTests : IDisposable
     }
 
     [Fact]
+    public void RecoveryRecordIsCompletedOnlyAfterOutputInstallation()
+    {
+        const string text = "café — 日本語";
+        string path = Path.Combine(_root, "record-complete.txt");
+        File.WriteAllBytes(path, Encoding.UTF8.GetBytes(text));
+
+        var prepared = false;
+        var completed = false;
+
+        ConversionResult result = EncodingConverter.Convert(
+            path,
+            path,
+            Encoding.UTF8,
+            new UnicodeEncoding(false, false),
+            new ConversionOptions
+            {
+                RecordConversion = record =>
+                {
+                    prepared = true;
+                    Assert.NotEmpty(record.OutputSha256);
+                    return null;
+                },
+                CompleteConversionRecord = () =>
+                {
+                    // Completion must run after replacement, not merely after preparation.
+                    Assert.Equal(text, Encoding.Unicode.GetString(File.ReadAllBytes(path)));
+                    completed = true;
+                    return null;
+                },
+            });
+
+        Assert.True(result.Success);
+        Assert.True(prepared);
+        Assert.True(completed);
+    }
+
+    [Fact]
+    public void RecoveryRecordCompletionFailureReportsInstalledOutputTruthfully()
+    {
+        const string text = "café — 日本語";
+        string path = Path.Combine(_root, "record-complete-fail.txt");
+        File.WriteAllBytes(path, Encoding.UTF8.GetBytes(text));
+
+        ConversionResult result = EncodingConverter.Convert(
+            path,
+            path,
+            Encoding.UTF8,
+            new UnicodeEncoding(false, false),
+            new ConversionOptions
+            {
+                RecordConversion = _ => null,
+                CompleteConversionRecord = () => "simulated completion failure",
+            });
+
+        Assert.False(result.Success);
+        Assert.Equal(ConversionErrorCode.RecoveryRecordError, result.ErrorCode);
+        Assert.True(result.ReplacementCommitted);
+        Assert.Equal(text, Encoding.Unicode.GetString(File.ReadAllBytes(path)));
+        Assert.Contains("installed and verified", result.ErrorMessage);
+    }
+
+    [Fact]
     public void WhatIf_NeverModifiesAnything()
     {
         // The dry run must be exactly that, including for a file that would

--- a/sources/EncodingChecker.Tests/ExplicitSourceEncodingTests.cs
+++ b/sources/EncodingChecker.Tests/ExplicitSourceEncodingTests.cs
@@ -146,6 +146,25 @@ public sealed class ExplicitSourceEncodingTests : IDisposable
     }
 
     [Fact]
+    public void ExplicitSource_DifferingFromBomlessUtf16Estimate_ConvertsWithWarning()
+    {
+        byte[] original = new UnicodeEncoding(bigEndian: true, byteOrderMark: false)
+            .GetBytes(string.Concat(Enumerable.Repeat("Hello, World! ", 40)));
+        Write("bomless-utf16.txt", original);
+
+        ConversionReportEntry entry = Assert.Single(Scan(from: "windows-1252"));
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.Equal("utf-16BE", entry.DetectedEncodingLabel);
+        Assert.False(entry.DetectedEncodingHasBom);
+        Assert.Equal(
+            ConversionReasonCodes.ExplicitSourceDiffersFromBomlessUnicodeEstimate,
+            entry.ReasonCode);
+        Assert.Contains("BOM-less utf-16BE", entry.Diagnostic);
+        Assert.Contains("you selected windows-1252", entry.Diagnostic);
+    }
+
+    [Fact]
     public void ExplicitShiftJisSource_StillConvertsShiftJisText()
     {
         const string text = "こんにちは世界。日本語のテキストです。";

--- a/sources/EncodingChecker.Tests/TraversalCoverageTests.cs
+++ b/sources/EncodingChecker.Tests/TraversalCoverageTests.cs
@@ -24,19 +24,44 @@ public sealed class TraversalCoverageTests
     }
 
     private static List<string> Enumerate(
-        string root, DirectoryTraversal.TraversalCounters counters)
+        string root,
+        DirectoryTraversal.TraversalCounters counters,
+        IReadOnlyList<string>? include = null,
+        IReadOnlyList<string>? exclude = null)
     {
-        List<Regex> matchAll =
-            DirectoryTraversal.CompilePatterns(["*"], defaultToMatchAll: true);
+        List<Regex> includePatterns =
+            DirectoryTraversal.CompilePatterns(include, defaultToMatchAll: true);
+        List<Regex> excludePatterns =
+            DirectoryTraversal.CompilePatterns(exclude, defaultToMatchAll: false);
 
         return DirectoryTraversal.EnumerateFiles(
             root,
             includeSubdirectories: true,
-            matchAll,
-            [],
+            includePatterns,
+            excludePatterns,
             excludedFullPaths: null,
             onWarning: null,
             counters: counters).ToList();
+    }
+
+    private static (int ExitCode, string Error) RunCli(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        try
+        {
+            Console.SetOut(output);
+            Console.SetError(error);
+            return (Program.RunConsoleMode(args), error.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
     }
 
     [Fact]
@@ -60,7 +85,8 @@ public sealed class TraversalCoverageTests
             Assert.Equal([visible], found);
 
             // What changed: the caller can now say so.
-            Assert.Equal(1, counters.ExcludedByAttribute);
+            Assert.Equal(1, counters.FilesExcludedByAttribute);
+            Assert.Equal(0, counters.DirectoriesExcludedByAttribute);
         }
         finally
         {
@@ -82,7 +108,7 @@ public sealed class TraversalCoverageTests
             var counters = new DirectoryTraversal.TraversalCounters();
 
             Assert.Empty(Enumerate(root, counters));
-            Assert.Equal(1, counters.ExcludedByAttribute);
+            Assert.Equal(1, counters.FilesExcludedByAttribute);
         }
         finally
         {
@@ -104,7 +130,7 @@ public sealed class TraversalCoverageTests
             var counters = new DirectoryTraversal.TraversalCounters();
 
             Assert.Equal(2, Enumerate(root, counters).Count);
-            Assert.Equal(0, counters.ExcludedByAttribute);
+            Assert.Equal(0, counters.FilesExcludedByAttribute);
         }
         finally
         {
@@ -134,7 +160,7 @@ public sealed class TraversalCoverageTests
             var counters = new DirectoryTraversal.TraversalCounters();
 
             Assert.Single(Enumerate(root, counters));
-            Assert.Equal(2, counters.ExcludedByAttribute);
+            Assert.Equal(2, counters.FilesExcludedByAttribute);
         }
         finally
         {
@@ -159,7 +185,7 @@ public sealed class TraversalCoverageTests
             var counters = new DirectoryTraversal.TraversalCounters();
 
             Assert.Single(Enumerate(root, counters));
-            Assert.Equal(0, counters.ExcludedByAttribute);
+            Assert.Equal(0, counters.FilesExcludedByAttribute);
         }
         finally
         {
@@ -190,6 +216,162 @@ public sealed class TraversalCoverageTests
                 []).ToList();
 
             Assert.Single(found);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HiddenFileOutsideIncludePattern_IsNotCounted()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string hidden = Path.Combine(root, "hidden.jpg");
+            File.WriteAllText(hidden, "hidden");
+            File.SetAttributes(hidden, FileAttributes.Hidden);
+            File.WriteAllText(Path.Combine(root, "kept.txt"), "kept");
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+            List<string> found = Enumerate(root, counters, include: ["*.txt"]);
+
+            Assert.Single(found);
+            Assert.Equal(0, counters.FilesExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HiddenFileExcludedByPattern_IsNotCounted()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string hidden = Path.Combine(root, "ignored.txt");
+            File.WriteAllText(hidden, "hidden");
+            File.SetAttributes(hidden, FileAttributes.Hidden);
+            File.WriteAllText(Path.Combine(root, "kept.txt"), "kept");
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+            List<string> found = Enumerate(root, counters, exclude: ["ignored.txt"]);
+
+            Assert.Single(found);
+            Assert.Equal(0, counters.FilesExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HiddenEcArtifact_IsNotCounted()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string artifact = Path.Combine(root, "a.txt.bak");
+            File.WriteAllText(artifact, "backup");
+            File.SetAttributes(artifact, FileAttributes.Hidden);
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+
+            Assert.Empty(Enumerate(root, counters));
+            Assert.Equal(0, counters.FilesExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HiddenDirectory_IsReportedWithoutEnteringIt()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string hiddenDirectory = Path.Combine(root, "hidden-folder");
+            Directory.CreateDirectory(hiddenDirectory);
+            File.WriteAllText(Path.Combine(hiddenDirectory, "not-counted.txt"), "hidden");
+            File.SetAttributes(hiddenDirectory, FileAttributes.Hidden);
+            File.WriteAllText(Path.Combine(root, "kept.txt"), "kept");
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+            List<string> found = Enumerate(root, counters);
+
+            Assert.Single(found);
+            Assert.Equal(0, counters.FilesExcludedByAttribute);
+            Assert.Equal(1, counters.DirectoriesExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GuiCoverageText_ReportsBothKindsOfIncompleteCoverage()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string hiddenFile = Path.Combine(root, "hidden.txt");
+            File.WriteAllText(hiddenFile, "hidden");
+            File.SetAttributes(hiddenFile, FileAttributes.Hidden);
+
+            string hiddenDirectory = Path.Combine(root, "hidden-folder");
+            Directory.CreateDirectory(hiddenDirectory);
+            File.SetAttributes(hiddenDirectory, FileAttributes.Hidden);
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+            _ = Enumerate(root, counters);
+
+            string text = MainForm.FormatCoverage(counters);
+
+            Assert.Contains("1 matching file(s) not examined", text);
+            Assert.Contains("1 folder(s) not entered", text);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CliReportsBothKindsOfIncompleteCoverageOnStandardError()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "kept.txt"), "kept");
+
+            string hiddenFile = Path.Combine(root, "hidden.txt");
+            File.WriteAllText(hiddenFile, "hidden");
+            File.SetAttributes(hiddenFile, FileAttributes.Hidden);
+
+            string hiddenDirectory = Path.Combine(root, "hidden-folder");
+            Directory.CreateDirectory(hiddenDirectory);
+            File.SetAttributes(hiddenDirectory, FileAttributes.Hidden);
+
+            (int exitCode, string error) = RunCli(
+                "-BasePath", root, "-Include", "*.txt", "-DetectOnly", "-Quiet");
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("1 matching file(s) not examined", error);
+            Assert.Contains("1 folder(s) not entered", error);
+            Assert.Contains("contents were not counted", error);
         }
         finally
         {

--- a/sources/EncodingChecker.Tests/TraversalCoverageTests.cs
+++ b/sources/EncodingChecker.Tests/TraversalCoverageTests.cs
@@ -1,0 +1,199 @@
+using System.Text.RegularExpressions;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Files excluded by attribute must be counted, not silently dropped.
+/// </summary>
+/// <remarks>
+/// A hidden file used to leave no trace at all: no row, no count, no note. A folder
+/// containing one validated clean and exited 0, so a CI check reported success over a
+/// file it never opened. The exclusion itself is deliberate and unchanged; what the
+/// count restores is the difference between "this folder is clean" and "this folder
+/// holds files I did not look at".
+/// </remarks>
+public sealed class TraversalCoverageTests
+{
+    private static string NewFolder()
+    {
+        string root = Path.Combine(
+            Path.GetTempPath(), "ec-coverage-" + Guid.NewGuid().ToString("N"));
+
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static List<string> Enumerate(
+        string root, DirectoryTraversal.TraversalCounters counters)
+    {
+        List<Regex> matchAll =
+            DirectoryTraversal.CompilePatterns(["*"], defaultToMatchAll: true);
+
+        return DirectoryTraversal.EnumerateFiles(
+            root,
+            includeSubdirectories: true,
+            matchAll,
+            [],
+            excludedFullPaths: null,
+            onWarning: null,
+            counters: counters).ToList();
+    }
+
+    [Fact]
+    public void HiddenFile_IsExcludedFromResults_ButCounted()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string visible = Path.Combine(root, "visible.txt");
+            string hidden = Path.Combine(root, "hidden.txt");
+
+            File.WriteAllText(visible, "visible");
+            File.WriteAllText(hidden, "hidden");
+            File.SetAttributes(hidden, FileAttributes.Hidden);
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+            List<string> found = Enumerate(root, counters);
+
+            // Behaviour is unchanged: the hidden file is still not scanned.
+            Assert.Equal([visible], found);
+
+            // What changed: the caller can now say so.
+            Assert.Equal(1, counters.ExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SystemFile_IsCounted()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string systemFile = Path.Combine(root, "system.txt");
+            File.WriteAllText(systemFile, "system");
+            File.SetAttributes(systemFile, FileAttributes.System);
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+
+            Assert.Empty(Enumerate(root, counters));
+            Assert.Equal(1, counters.ExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FolderWithNothingExcluded_CountsZero()
+    {
+        // A count that is never zero would be as useless as no count at all.
+        string root = NewFolder();
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "a.txt"), "a");
+            File.WriteAllText(Path.Combine(root, "b.txt"), "b");
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+
+            Assert.Equal(2, Enumerate(root, counters).Count);
+            Assert.Equal(0, counters.ExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HiddenFilesInSubdirectories_AreCountedToo()
+    {
+        string root = NewFolder();
+
+        try
+        {
+            string sub = Path.Combine(root, "sub");
+            Directory.CreateDirectory(sub);
+
+            foreach (string name in new[] { "one.txt", "two.txt" })
+            {
+                string path = Path.Combine(sub, name);
+                File.WriteAllText(path, name);
+                File.SetAttributes(path, FileAttributes.Hidden);
+            }
+
+            File.WriteAllText(Path.Combine(root, "kept.txt"), "kept");
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+
+            Assert.Single(Enumerate(root, counters));
+            Assert.Equal(2, counters.ExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ExcludedArtifacts_AreNotCountedAsUnexamined()
+    {
+        // EC's own .bak and .ecmeta.json files are excluded by name, not by attribute.
+        // Counting them would inflate the number and train the reader to ignore it.
+        string root = NewFolder();
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "a.txt"), "a");
+            File.WriteAllText(Path.Combine(root, "a.txt.bak"), "backup");
+            File.WriteAllText(
+                Path.Combine(root, "a.txt" + ConversionMetadataStore.Suffix), "{}");
+
+            var counters = new DirectoryTraversal.TraversalCounters();
+
+            Assert.Single(Enumerate(root, counters));
+            Assert.Equal(0, counters.ExcludedByAttribute);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CountersAreOptional()
+    {
+        // The scan must behave identically when the caller does not ask for coverage.
+        string root = NewFolder();
+
+        try
+        {
+            string hidden = Path.Combine(root, "hidden.txt");
+            File.WriteAllText(hidden, "hidden");
+            File.SetAttributes(hidden, FileAttributes.Hidden);
+            File.WriteAllText(Path.Combine(root, "kept.txt"), "kept");
+
+            List<Regex> matchAll =
+                DirectoryTraversal.CompilePatterns(["*"], defaultToMatchAll: true);
+
+            List<string> found = DirectoryTraversal.EnumerateFiles(
+                root,
+                includeSubdirectories: true,
+                matchAll,
+                []).ToList();
+
+            Assert.Single(found);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -80,6 +80,13 @@ internal sealed class ConversionConfirmationForm : Form
         ConversionPlanSummary summary = _plan.Summary;
         int convert = summary.ReadyToConvert;
         List<PlannedFile> refused = Refused;
+        List<PlannedFile> advisories =
+        [
+            .. _plan.Files.Where(f =>
+                f.Action == PlannedAction.Convert &&
+                f.ReasonCode == ConversionReasonCodes
+                    .ExplicitSourceDiffersFromBomlessUnicodeEstimate)
+        ];
 
         body.Controls.Add(Heading(
             "Review this conversion plan before changing files."));
@@ -108,6 +115,28 @@ internal sealed class ConversionConfirmationForm : Form
             ("Cannot be processed safely", summary.OtherRefusals,
              "Left unchanged because a safety check did not pass."),
         ]));
+
+        if (advisories.Count > 0)
+        {
+            string examples = string.Join(
+                Environment.NewLine,
+                advisories.Take(5).Select(f => $"• {f.RelativePath}: {f.Reason}"));
+
+            if (advisories.Count > 5)
+                examples += Environment.NewLine + $"• and {advisories.Count - 5} more";
+
+            body.Controls.Add(new Label
+            {
+                AutoSize = true,
+                MaximumSize = new Size(660, 0),
+                Padding = new Padding(0, 8, 0, 8),
+                ForeColor = Color.FromArgb(150, 80, 0),
+                Text =
+                    $"{advisories.Count} file(s) have a BOM-less Unicode estimate that "
+                    + "differs from your source choice. EC will use your choice, but review "
+                    + "these files carefully:" + Environment.NewLine + examples,
+            });
+        }
 
         body.Controls.Add(Rule());
 

--- a/sources/EncodingChecker/ConversionMetadata.cs
+++ b/sources/EncodingChecker/ConversionMetadata.cs
@@ -28,10 +28,21 @@ internal enum SourceEncodingMode
     Explicit,
 }
 
+/// <summary>Whether verified output is prepared or installed.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+internal enum ConversionInstallationState
+{
+    /// <summary>The output passed verification but installation is not yet recorded.</summary>
+    Prepared,
+
+    /// <summary>The verified output was installed.</summary>
+    Completed,
+}
+
 internal sealed record ConversionMetadata
 {
     /// <summary>The schema version written and understood by this build.</summary>
-    internal const int CurrentMetadataVersion = 2;
+    internal const int CurrentMetadataVersion = 3;
 
     /// <summary>Schema version for future readers.</summary>
     [JsonPropertyOrder(0)]
@@ -47,19 +58,27 @@ internal sealed record ConversionMetadata
     public required string EcVersion { get; init; }
 
     [JsonPropertyOrder(4)]
-    public required string OriginalPath { get; init; }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public required ConversionInstallationState InstallationState { get; init; }
 
     [JsonPropertyOrder(5)]
-    public required long OriginalSize { get; init; }
+    public required string OriginalPath { get; init; }
 
     [JsonPropertyOrder(6)]
-    public required string OriginalSha256 { get; init; }
+    public required long OriginalSize { get; init; }
 
     [JsonPropertyOrder(7)]
-    public required string BackupPath { get; init; }
+    public required string OriginalSha256 { get; init; }
 
     [JsonPropertyOrder(8)]
+    public required string BackupPath { get; init; }
+
+    [JsonPropertyOrder(9)]
     public required string BackupSha256 { get; init; }
+
+    /// <summary>SHA-256 of the exact verified bytes prepared for installation.</summary>
+    [JsonPropertyOrder(10)]
+    public required string ExpectedOutputSha256 { get; init; }
 
     /// <summary>
     /// The codec that actually read the file. This is the authoritative recovery key.
@@ -67,19 +86,19 @@ internal sealed record ConversionMetadata
     /// <remarks>
     /// The numeric identifier is authoritative because encoding names can have aliases.
     /// </remarks>
-    [JsonPropertyOrder(9)]
+    [JsonPropertyOrder(11)]
     public required int SourceEncodingId { get; init; }
 
     /// <summary>The source codec's human-readable name.</summary>
-    [JsonPropertyOrder(10)]
+    [JsonPropertyOrder(12)]
     public required string SourceEncodingName { get; init; }
 
     /// <summary>Whether the source codec was detected or explicitly supplied.</summary>
-    [JsonPropertyOrder(11)]
+    [JsonPropertyOrder(13)]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public required SourceEncodingMode SourceEncodingMode { get; init; }
 
-    [JsonPropertyOrder(12)]
+    [JsonPropertyOrder(14)]
     public required bool SourceHasBom { get; init; }
 
     /// <summary>
@@ -91,30 +110,30 @@ internal sealed record ConversionMetadata
     /// case the sidecar preserves both the detector's earlier conclusion and the
     /// codec the conversion actually used.
     /// </remarks>
-    [JsonPropertyOrder(13)]
+    [JsonPropertyOrder(15)]
     public int? DetectedEncodingId { get; init; }
 
     /// <summary>The detected codec's name, or <see langword="null"/> when none exists.</summary>
-    [JsonPropertyOrder(14)]
+    [JsonPropertyOrder(16)]
     public string? DetectedEncodingName { get; init; }
 
     /// <summary>The codec the file was converted to.</summary>
-    [JsonPropertyOrder(15)]
+    [JsonPropertyOrder(17)]
     public required int TargetEncodingId { get; init; }
 
-    [JsonPropertyOrder(16)]
+    [JsonPropertyOrder(18)]
     public required string TargetEncodingName { get; init; }
 
-    [JsonPropertyOrder(17)]
+    [JsonPropertyOrder(19)]
     public required bool TargetHasBom { get; init; }
 
-    [JsonPropertyOrder(18)]
+    [JsonPropertyOrder(20)]
     public required string SourceTextSha256 { get; init; }
 
-    [JsonPropertyOrder(19)]
+    [JsonPropertyOrder(21)]
     public required string OutputTextSha256 { get; init; }
 
-    [JsonPropertyOrder(20)]
+    [JsonPropertyOrder(22)]
     public required long UnicodeScalars { get; init; }
 }
 
@@ -174,29 +193,50 @@ internal static class ConversionMetadataStore
     internal static string? Write(string filePath, ConversionMetadata metadata)
     {
         string path = MetadataPathFor(filePath);
+        string tempPath =
+            $"{path}.{Guid.NewGuid():N}.{EncodingConverter.TempFileSuffix}";
 
         try
         {
             File.WriteAllText(
-                path, JsonSerializer.Serialize(metadata, Options), new UTF8Encoding(false));
+                tempPath,
+                JsonSerializer.Serialize(metadata, Options),
+                new UTF8Encoding(false));
 
             ConversionMetadata? readBack =
-                JsonSerializer.Deserialize<ConversionMetadata>(File.ReadAllText(path));
+                JsonSerializer.Deserialize<ConversionMetadata>(File.ReadAllText(tempPath));
 
             if (readBack is null)
-                return $"'{path}' was written but could not be read back.";
+                return $"The temporary recovery record for '{path}' could not be read back.";
 
             if (!MatchesForRecovery(readBack, metadata))
             {
-                return $"'{path}' was written but does not describe the expected file.";
+                return $"The temporary recovery record for '{path}' does not describe "
+                       + "the expected file.";
             }
+
+            // Keep the previous truthful record intact unless the complete replacement succeeds.
+            EncodingConverter.AtomicReplaceForBackup(tempPath, path);
 
             return null;
         }
         catch (Exception ex) when (
-            ex is IOException or UnauthorizedAccessException or JsonException)
+            ex is IOException or UnauthorizedAccessException or JsonException or
+                ArgumentException or NotSupportedException)
         {
             return $"{ex.Message}";
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Cleanup failure cannot make the existing sidecar less truthful.
+            }
         }
     }
 
@@ -209,11 +249,13 @@ internal static class ConversionMetadataStore
         ConversionMetadata expected) =>
         actual.MetadataVersion == ConversionMetadata.CurrentMetadataVersion &&
         actual.ConversionId == expected.ConversionId &&
+        actual.InstallationState == expected.InstallationState &&
         actual.OriginalPath == expected.OriginalPath &&
         actual.OriginalSize == expected.OriginalSize &&
         actual.OriginalSha256 == expected.OriginalSha256 &&
         actual.BackupPath == expected.BackupPath &&
         actual.BackupSha256 == expected.BackupSha256 &&
+        actual.ExpectedOutputSha256 == expected.ExpectedOutputSha256 &&
         actual.SourceEncodingId == expected.SourceEncodingId &&
         actual.SourceEncodingName == expected.SourceEncodingName &&
         actual.SourceEncodingMode == expected.SourceEncodingMode &&

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -92,6 +92,15 @@ internal sealed record PlannedFile
 
     public required bool SourceWasSpecified { get; init; }
 
+    /// <summary>What automatic detection found before an explicit source was applied.</summary>
+    public string? DetectedEncoding { get; init; }
+
+    /// <summary>The detected encoding's canonical code page, when available.</summary>
+    public int? DetectedCodePage { get; init; }
+
+    /// <summary>Whether automatic detection found the encoding's BOM.</summary>
+    public bool DetectedHasBom { get; init; }
+
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public required SourceInterpretation SourceInterpretation { get; init; }
 
@@ -120,7 +129,7 @@ internal sealed record PlannedFile
 internal sealed record ConversionPlan
 {
     /// <summary>The plan file schema version.</summary>
-    internal const int CurrentPlanVersion = 3;
+    internal const int CurrentPlanVersion = 4;
 
     public int PlanVersion { get; init; } = CurrentPlanVersion;
 
@@ -204,6 +213,11 @@ internal sealed record ConversionPlan
             if (TextEncoding.TryResolve(sourceCharset, out Encoding? encoding))
                 codePage = encoding!.CodePage;
 
+            int? detectedCodePage = null;
+
+            if (TextEncoding.TryResolve(entry.DetectedEncodingLabel, out Encoding? detected))
+                detectedCodePage = detected!.CodePage;
+
             files.Add(new PlannedFile
             {
                 RelativePath = Path.GetRelativePath(root, entry.FilePath),
@@ -214,6 +228,9 @@ internal sealed record ConversionPlan
                 SourceCodePage = codePage,
                 SourceHasBom = sourceHasBom,
                 SourceWasSpecified = entry.SourceEncodingWasSpecified,
+                DetectedEncoding = entry.DetectedEncodingLabel,
+                DetectedCodePage = detectedCodePage,
+                DetectedHasBom = entry.DetectedEncodingHasBom,
                 SourceInterpretation = entry.SourceInterpretation
                     ?? throw new InvalidOperationException(
                         $"'{entry.FilePath}' reached a conversion plan without being "
@@ -388,6 +405,22 @@ internal sealed record ConversionPlan
                 sourceEncoding!.CodePage != file.SourceCodePage)
             {
                 stale.Add($"{path} (source codec identity does not match the plan)");
+                continue;
+            }
+
+            if (file.DetectedEncoding is not null)
+            {
+                if (!TextEncoding.TryResolve(file.DetectedEncoding, out Encoding? detected) ||
+                    !file.DetectedCodePage.HasValue ||
+                    detected!.CodePage != file.DetectedCodePage.Value)
+                {
+                    stale.Add($"{path} (detected codec identity does not match the plan)");
+                    continue;
+                }
+            }
+            else if (file.DetectedCodePage.HasValue || file.DetectedHasBom)
+            {
+                stale.Add($"{path} (detected codec provenance is incomplete)");
                 continue;
             }
 

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -66,6 +66,9 @@ internal sealed class ConversionReportEntry
     /// </summary>
     internal bool HasReliableUnicodeDetection { get; set; }
 
+    /// <summary>Whether the automatically detected Unicode encoding had a BOM.</summary>
+    internal bool DetectedEncodingHasBom { get; set; }
+
     /// <summary>
     /// The SHA-256 this file must still have when installed, or <see langword="null"/>
     /// when no plan has committed to its contents. Internal state; not in CSV.
@@ -136,7 +139,9 @@ internal sealed class ConversionReportEntry
     /// <summary>The backup created by this run, even if conversion later failed.</summary>
     internal string? BackupPath { get; set; }
 
-    /// <summary>The recovery sidecar created by this run, when conversion completed.</summary>
+    /// <summary>
+    /// The recovery sidecar prepared by this run. Its state says whether installation completed.
+    /// </summary>
     internal string? RecoveryMetadataPath { get; set; }
 }
 
@@ -148,6 +153,8 @@ internal static class ConversionReasonCodes
     internal const string LegacySourceRequired = nameof(LegacySourceRequired);
     internal const string ExplicitSourceConflictsWithDetection =
         nameof(ExplicitSourceConflictsWithDetection);
+    internal const string ExplicitSourceDiffersFromBomlessUnicodeEstimate =
+        nameof(ExplicitSourceDiffersFromBomlessUnicodeEstimate);
     internal const string StrictValidationFailed = nameof(StrictValidationFailed);
     internal const string SourceSnapshotFailed = nameof(SourceSnapshotFailed);
     internal const string BackupFailed = nameof(BackupFailed);

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace EncodingChecker;
 
@@ -39,6 +40,38 @@ internal static class DirectoryTraversal
         IgnoreInaccessible = false,
     };
 
+    // Files are enumerated without an attribute filter so the excluded ones can be
+    // counted rather than vanishing. AttributesToSkip drops them inside the OS
+    // enumeration, which left a scan unable to distinguish "this folder is clean"
+    // from "this folder holds files I never looked at". The same attributes are
+    // still excluded below; they are now counted first.
+    private static readonly EnumerationOptions FileWalkOptions = new()
+    {
+        AttributesToSkip = FileAttributes.None,
+        IgnoreInaccessible = false,
+    };
+
+    private const FileAttributes ExcludedFileAttributes =
+        FileAttributes.Hidden | FileAttributes.System | FileAttributes.ReparsePoint;
+
+    /// <summary>
+    /// Counts files a scan never examined, so a report can say so.
+    /// </summary>
+    /// <remarks>
+    /// Incremented while <see cref="Parallel.ForEach"/> pulls from the traversal, so
+    /// the increments are interlocked rather than assumed to be serialized.
+    /// </remarks>
+    internal sealed class TraversalCounters
+    {
+        private int _excludedByAttribute;
+
+        /// <summary>Files skipped for being hidden, system, or reparse points.</summary>
+        internal int ExcludedByAttribute => Volatile.Read(ref _excludedByAttribute);
+
+        internal void CountExcludedByAttribute() =>
+            Interlocked.Increment(ref _excludedByAttribute);
+    }
+
     /// <summary>
     /// Files always excluded from scans, regardless of include patterns.
     /// </summary>
@@ -73,7 +106,8 @@ internal static class DirectoryTraversal
         List<Regex> includePatterns,
         List<Regex> excludePatterns,
         IReadOnlyCollection<string>? excludedFullPaths = null,
-        Action<string>? onWarning = null)
+        Action<string>? onWarning = null,
+        TraversalCounters? counters = null)
     {
         var pending = new Stack<string>();
         pending.Push(baseDirectory);
@@ -82,17 +116,18 @@ internal static class DirectoryTraversal
         {
             string dir = pending.Pop();
 
-            List<string> files;
+            List<FileInfo> files;
 
             try
             {
                 // Enumerate inside the try so directory access failures can be reported.
+                // FileInfo carries the attributes the enumeration already returned, so
+                // the exclusion test below costs no extra call per file.
                 files =
                 [
-                    .. Directory.EnumerateFiles(
-                        dir,
+                    .. new DirectoryInfo(dir).EnumerateFiles(
                         "*",
-                        DirectoryWalkOptions)
+                        FileWalkOptions)
                 ];
             }
             catch (Exception ex) when (
@@ -104,9 +139,19 @@ internal static class DirectoryTraversal
                 continue;
             }
 
-            foreach (string file in files)
+            foreach (FileInfo info in files)
             {
-                string fileName = Path.GetFileName(file);
+                string file = info.FullName;
+                string fileName = info.Name;
+
+                // Counted, not silently dropped: the caller reports how many files
+                // the scan never examined so a clean result cannot be mistaken for
+                // complete coverage.
+                if ((info.Attributes & ExcludedFileAttributes) != 0)
+                {
+                    counters?.CountExcludedByAttribute();
+                    continue;
+                }
 
                 if (IsAlwaysExcludedFile(fileName))
                     continue;

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -32,9 +32,8 @@ internal static class DirectoryTraversal
 
     private static readonly EnumerationOptions DirectoryWalkOptions = new()
     {
-        // Never traverse symlinks, junctions, or other reparse points.
-        AttributesToSkip = FileAttributes.Hidden | FileAttributes.System |
-            FileAttributes.ReparsePoint,
+        // Enumerate excluded directories so callers can report that they were not entered.
+        AttributesToSkip = FileAttributes.None,
 
         // Keep access failures visible so callers can report skipped directories.
         IgnoreInaccessible = false,
@@ -63,13 +62,21 @@ internal static class DirectoryTraversal
     /// </remarks>
     internal sealed class TraversalCounters
     {
-        private int _excludedByAttribute;
+        private int _filesExcludedByAttribute;
+        private int _directoriesExcludedByAttribute;
 
-        /// <summary>Files skipped for being hidden, system, or reparse points.</summary>
-        internal int ExcludedByAttribute => Volatile.Read(ref _excludedByAttribute);
+        /// <summary>Matching files skipped for being hidden, system, or reparse points.</summary>
+        internal int FilesExcludedByAttribute => Volatile.Read(ref _filesExcludedByAttribute);
 
-        internal void CountExcludedByAttribute() =>
-            Interlocked.Increment(ref _excludedByAttribute);
+        /// <summary>Directories not entered because they are hidden, system, or reparse points.</summary>
+        internal int DirectoriesExcludedByAttribute =>
+            Volatile.Read(ref _directoriesExcludedByAttribute);
+
+        internal void CountFileExcludedByAttribute() =>
+            Interlocked.Increment(ref _filesExcludedByAttribute);
+
+        internal void CountDirectoryExcludedByAttribute() =>
+            Interlocked.Increment(ref _directoriesExcludedByAttribute);
     }
 
     /// <summary>
@@ -144,15 +151,6 @@ internal static class DirectoryTraversal
                 string file = info.FullName;
                 string fileName = info.Name;
 
-                // Counted, not silently dropped: the caller reports how many files
-                // the scan never examined so a clean result cannot be mistaken for
-                // complete coverage.
-                if ((info.Attributes & ExcludedFileAttributes) != 0)
-                {
-                    counters?.CountExcludedByAttribute();
-                    continue;
-                }
-
                 if (IsAlwaysExcludedFile(fileName))
                     continue;
 
@@ -169,24 +167,31 @@ internal static class DirectoryTraversal
                 string relativePath =
                     Path.GetRelativePath(baseDirectory, file).Replace('\\', '/');
 
-                if (MatchesAny(relativePath, includePatterns) &&
-                    !MatchesAny(relativePath, excludePatterns))
+                if (!MatchesAny(relativePath, includePatterns) ||
+                    MatchesAny(relativePath, excludePatterns))
+                    continue;
+
+                // Count only matching files. Files outside the requested scope and EC's
+                // own artifacts must not inflate the incomplete-coverage warning.
+                if ((info.Attributes & ExcludedFileAttributes) != 0)
                 {
-                    yield return file;
+                    counters?.CountFileExcludedByAttribute();
+                    continue;
                 }
+
+                yield return file;
             }
 
             if (!includeSubdirectories)
                 continue;
 
-            List<string> subdirectories;
+            List<DirectoryInfo> subdirectories;
 
             try
             {
                 subdirectories =
                 [
-                    .. Directory.EnumerateDirectories(
-                        dir,
+                    .. new DirectoryInfo(dir).EnumerateDirectories(
                         "*",
                         DirectoryWalkOptions)
                 ];
@@ -200,13 +205,21 @@ internal static class DirectoryTraversal
                 continue;
             }
 
-            foreach (string subdirectory in subdirectories)
+            foreach (DirectoryInfo subdirectory in subdirectories)
             {
-                if (!ExcludedDirectoryNames.Contains(
-                    Path.GetFileName(subdirectory)))
+                if (ExcludedDirectoryNames.Contains(
+                    subdirectory.Name))
+                    continue;
+
+                // Do not traverse excluded directories merely to count their contents.
+                // Reporting the directory itself is honest about the unknown scope.
+                if ((subdirectory.Attributes & ExcludedFileAttributes) != 0)
                 {
-                    pending.Push(subdirectory);
+                    counters?.CountDirectoryExcludedByAttribute();
+                    continue;
                 }
+
+                pending.Push(subdirectory.FullName);
             }
         }
     }

--- a/sources/EncodingChecker/EncodingConverter.cs
+++ b/sources/EncodingChecker/EncodingConverter.cs
@@ -72,6 +72,12 @@ internal sealed record ConversionOptions
     internal Func<ConversionRecord, string?>? RecordConversion { get; init; }
 
     /// <summary>
+    /// Marks a prepared conversion record complete after installation.
+    /// Returns <see langword="null"/> on success.
+    /// </summary>
+    internal Func<string?>? CompleteConversionRecord { get; init; }
+
+    /// <summary>
     /// The SHA-256 the source must still have at installation time, or
     /// <see langword="null"/> to skip the check.
     /// </summary>
@@ -101,6 +107,9 @@ internal sealed record ConversionRecord
     /// successful verification.
     /// </summary>
     internal required string OutputTextSha256 { get; init; }
+
+    /// <summary>SHA-256 of the verified output file's exact bytes.</summary>
+    internal required string OutputSha256 { get; init; }
 
     internal required string SourceEncoding { get; init; }
 
@@ -457,6 +466,11 @@ internal static partial class EncodingConverter
 
             if (options.RecordConversion is not null)
             {
+                string outputFileSha = RunIoStage(
+                    ConversionErrorCode.TargetReadError,
+                    "The verified output could not be hashed",
+                    () => ComputeFileSha256(tempPath!));
+
                 string? recordError = options.RecordConversion(new ConversionRecord
                 {
                     SourcePath = sourcePath,
@@ -464,6 +478,7 @@ internal static partial class EncodingConverter
                     SourceSha256 = sourceFileSha,
                     SourceTextSha256 = System.Convert.ToHexStringLower(sourceDigest.Hash),
                     OutputTextSha256 = System.Convert.ToHexStringLower(sourceDigest.Hash),
+                    OutputSha256 = outputFileSha,
                     SourceEncoding = sourceEncoding.WebName,
                     SourceCodePage = sourceEncoding.CodePage,
                     SourceHasBom = sourceHadBom,
@@ -560,6 +575,32 @@ internal static partial class EncodingConverter
             }
 
             tempPath = null;
+
+            if (options.CompleteConversionRecord is not null)
+            {
+                string? completionError = options.CompleteConversionRecord();
+
+                if (completionError is not null)
+                {
+                    return new ConversionResult
+                    {
+                        Success = false,
+                        ErrorCode = ConversionErrorCode.RecoveryRecordError,
+                        ErrorMessage =
+                            "The converted file was installed and verified, but its recovery "
+                            + $"record could not be marked complete: {completionError} The "
+                            + "prepared record still contains the hashes needed to inspect it.",
+                        SourceEncoding = sourceEncoding,
+                        TargetEncoding = targetEncoding,
+                        SourceBytes = sourceBytesProcessed,
+                        TargetBytes = targetBytesWritten,
+                        UnicodeScalarsVerified = verification.ScalarsCompared,
+                        VerificationPassed = true,
+                        BomVerificationPassed = true,
+                        ReplacementCommitted = true,
+                    };
+                }
+            }
 
             return new ConversionResult
             {

--- a/sources/EncodingChecker/MainForm.Execution.cs
+++ b/sources/EncodingChecker/MainForm.Execution.cs
@@ -75,6 +75,8 @@ public partial class MainForm
         _actionCancellation?.Dispose();
         _actionCancellation = new CancellationTokenSource();
 
+        var counters = new DirectoryTraversal.TraversalCounters();
+
         var args = new WorkerArgs
         {
             Action = action,
@@ -82,8 +84,11 @@ public partial class MainForm
             IncludeSubdirectories = chkIncludeSubdirectories.Checked,
             FileMasks = txtFileMasks.Text,
             ValidCharsets = validCharsets,
+            Counters = counters,
             CancellationToken = _actionCancellation.Token,
         };
+
+        _scanCounters = counters;
 
         _actionWorker.RunWorkerAsync(args);
     }
@@ -213,6 +218,7 @@ public partial class MainForm
                     ? ScanAction.Validate
                     : ScanAction.Detect,
             ValidCharsets = args.ValidCharsets,
+            Counters = args.Counters,
         };
 
         try
@@ -351,8 +357,36 @@ public partial class MainForm
                 ? "{0} files processed"
                 : "{0} files do not have the correct encoding";
 
+        string completedStatus = string.Format(statusMessage, lstResults.Items.Count);
+        string coverage = FormatCoverage(_scanCounters);
+
         UpdateControlsOnActionDone(
-            string.Format(statusMessage, lstResults.Items.Count));
+            coverage.Length == 0
+                ? completedStatus
+                : completedStatus + "; " + coverage);
+    }
+
+    /// <summary>Describes matching files and directories deliberately left unexamined.</summary>
+    internal static string FormatCoverage(DirectoryTraversal.TraversalCounters? counters)
+    {
+        if (counters is null)
+            return string.Empty;
+
+        var parts = new List<string>(2);
+
+        if (counters.FilesExcludedByAttribute > 0)
+        {
+            parts.Add(
+                $"{counters.FilesExcludedByAttribute} matching file(s) not examined");
+        }
+
+        if (counters.DirectoriesExcludedByAttribute > 0)
+        {
+            parts.Add(
+                $"{counters.DirectoriesExcludedByAttribute} folder(s) not entered");
+        }
+
+        return string.Join(", ", parts);
     }
 
     private void ConvertWorkerCompleted(RunWorkerCompletedEventArgs e)

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -21,6 +21,7 @@ public partial class MainForm : Form
         internal bool IncludeSubdirectories;
         internal required string FileMasks;
         internal required List<string> ValidCharsets;
+        internal required DirectoryTraversal.TraversalCounters Counters;
         internal CancellationToken CancellationToken;
     }
 
@@ -71,6 +72,9 @@ public partial class MainForm : Form
 
     // Shared with the completion handler so it can report how the run ended.
     private ConvertWorkerArgs? _convertArgs;
+
+    // The completed scan's coverage is shown with its result count.
+    private DirectoryTraversal.TraversalCounters? _scanCounters;
 
     // Indices into imgsResults (see SetKeyName calls in MainForm.Designer.cs).
     // Reuses the existing Failed and Warning icons; Warning marks preview rows.
@@ -431,8 +435,8 @@ public partial class MainForm : Form
         MessageBox.Show(
             this,
             "This run has not stopped yet. Closing now abandons it.\r\n\r\n"
-            + "Files already converted stay converted, and the file being written "
-            + "is left unchanged, but no report or journal will be saved.\r\n\r\n"
+            + "Files already completed stay converted. A file currently being installed "
+            + "may need to be checked afterward, and no report or journal will be saved.\r\n\r\n"
             + "Close anyway?",
             @"Close while running",
             MessageBoxButtons.YesNo,

--- a/sources/EncodingChecker/MainForm.cs
+++ b/sources/EncodingChecker/MainForm.cs
@@ -175,16 +175,25 @@ public partial class MainForm : Form
     {
         if (_actionWorker.IsBusy)
         {
-            // Let the worker finish its cancellation path before closing.
-            e.Cancel = true;
-
             if (!_closeRequested)
             {
+                // Let the worker finish its cancellation path before closing.
+                e.Cancel = true;
                 _closeRequested = true;
                 _actionCancellation?.Cancel();
+                return;
             }
 
-            return;
+            // Cancellation is cooperative, so a run blocked on unresponsive storage
+            // would otherwise leave the window impossible to close. A second request
+            // closes anyway: each file is installed atomically only after its output
+            // is verified, so abandoning a run leaves finished files converted and the
+            // one in flight untouched.
+            if (!ConfirmCloseDuringRun())
+            {
+                e.Cancel = true;
+                return;
+            }
         }
 
         SaveSettings();
@@ -414,6 +423,21 @@ public partial class MainForm : Form
 
         actionStatus.Text = statusMessage;
     }
+
+    /// <summary>
+    /// Asks whether to close while a run that ignored cancellation is still active.
+    /// </summary>
+    private bool ConfirmCloseDuringRun() =>
+        MessageBox.Show(
+            this,
+            "This run has not stopped yet. Closing now abandons it.\r\n\r\n"
+            + "Files already converted stay converted, and the file being written "
+            + "is left unchanged, but no report or journal will be saved.\r\n\r\n"
+            + "Close anyway?",
+            @"Close while running",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Warning,
+            MessageBoxDefaultButton.Button2) == DialogResult.Yes;
 
     private void ShowWarning(
         string message,

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -67,6 +67,8 @@ internal static partial class Program
                     Action = f.Action,
                     SourceInterpretation = f.SourceInterpretation,
                     SourceEncodingWasSpecified = f.SourceWasSpecified,
+                    DetectedEncodingLabel = f.DetectedEncoding,
+                    DetectedEncodingHasBom = f.DetectedHasBom,
                     ReasonCode = f.ReasonCode,
                     Diagnostic = f.Reason,
 
@@ -306,11 +308,18 @@ internal static partial class Program
         // Coverage, not a result: a caller reading only the rows cannot tell a clean
         // folder from one holding files the scan never opened. Written to stderr so it
         // survives -Quiet and stays out of the machine-readable report on stdout.
-        if (traversalCounters.ExcludedByAttribute > 0)
+        if (traversalCounters.FilesExcludedByAttribute > 0)
         {
             Console.Error.WriteLine(
-                $"{traversalCounters.ExcludedByAttribute} file(s) not examined "
+                $"{traversalCounters.FilesExcludedByAttribute} matching file(s) not examined "
                 + "(hidden, system, or reparse point).");
+        }
+
+        if (traversalCounters.DirectoriesExcludedByAttribute > 0)
+        {
+            Console.Error.WriteLine(
+                $"{traversalCounters.DirectoriesExcludedByAttribute} folder(s) not entered "
+                + "(hidden, system, or reparse point); their contents were not counted.");
         }
 
         if (options.Verbose)

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -220,8 +220,13 @@ internal static partial class Program
                 out targetWriteBom);
         }
 
+        // Counts files the scan never examined so the run can say so rather than
+        // letting a clean result stand in for complete coverage.
+        var traversalCounters = new DirectoryTraversal.TraversalCounters();
+
         var scanOptions = new ScanDirectoryOptions
         {
+            Counters = traversalCounters,
             SourceCharset = options.From,
             BaseDirectory = options.BasePath!,
             IncludeSubdirectories = true,
@@ -296,6 +301,16 @@ internal static partial class Program
         else
         {
             ConversionReport.WriteCsv(entries, Console.Out);
+        }
+
+        // Coverage, not a result: a caller reading only the rows cannot tell a clean
+        // folder from one holding files the scan never opened. Written to stderr so it
+        // survives -Quiet and stays out of the machine-readable report on stdout.
+        if (traversalCounters.ExcludedByAttribute > 0)
+        {
+            Console.Error.WriteLine(
+                $"{traversalCounters.ExcludedByAttribute} file(s) not examined "
+                + "(hidden, system, or reparse point).");
         }
 
         if (options.Verbose)

--- a/sources/EncodingChecker/Program.CliParsing.cs
+++ b/sources/EncodingChecker/Program.CliParsing.cs
@@ -45,6 +45,7 @@ internal static partial class Program
                     }
 
                     // Repeated options accumulate patterns.
+                    options.IncludeSpecified = true;
                     options.Include.AddRange(SplitCommaList(include));
                     break;
 
@@ -59,6 +60,7 @@ internal static partial class Program
                     }
 
                     // Repeated options accumulate patterns.
+                    options.ExcludeSpecified = true;
                     options.Exclude.AddRange(SplitCommaList(exclude));
                     break;
 
@@ -230,6 +232,24 @@ internal static partial class Program
         CliOptions options,
         [NotNullWhen(false)] out string? error)
     {
+        // A filter that fails to parse must not widen the scan. -Include "" and
+        // -Include ",,," both leave no usable pattern, which would otherwise mean
+        // every file - the opposite of what the caller asked for, and dangerous
+        // when the value came from an unset variable in a script.
+        if (options.IncludeSpecified && options.Include.Count == 0)
+        {
+            error = "-Include was given but contains no usable pattern. Omit "
+                    + "-Include to process every file.";
+            return false;
+        }
+
+        if (options.ExcludeSpecified && options.Exclude.Count == 0)
+        {
+            error = "-Exclude was given but contains no usable pattern. Omit "
+                    + "-Exclude to process every file.";
+            return false;
+        }
+
         if (!string.IsNullOrWhiteSpace(options.PlanPath) &&
             !string.IsNullOrWhiteSpace(options.ApplyPath))
         {

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -198,10 +198,10 @@ internal static partial class Program
             EncodingChecker.exe -BasePath "D:\Share" -Target utf-8 -MaxParallelism 2
 
         Directories named .git, .svn, .hg, .vs, .idea, bin, obj, node_modules,
-        packages, dist, build, and target are always skipped. Hidden files,
-        system files, and reparse points are not examined; when any are found
-        their count is reported on stderr so a clean result is not mistaken for
-        complete coverage.
+        packages, dist, build, and target are always skipped. Matching hidden,
+        system, and reparse-point files are not examined. Hidden, system, and
+        reparse-point folders are not entered. Both counts are reported on stderr
+        and are informational; they do not change the exit code.
 
         Help: -?, /?, -h, /h, or --help.
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -93,6 +93,13 @@ internal static partial class Program
         internal string? BasePath;
         internal List<string> Include = [];
         internal List<string> Exclude = [];
+
+        // A pattern list that parses to nothing is not the same as no list at all:
+        // an empty -Include would silently widen the scan to every file. Record
+        // that the option was supplied so validation can reject the degenerate form.
+        internal bool IncludeSpecified;
+        internal bool ExcludeSpecified;
+
         internal string? Target;
         internal string? From;
         internal string? PlanPath;
@@ -110,7 +117,7 @@ internal static partial class Program
     }
 
     private const string UsageText = """
-        EncodingChecker v3.9.1
+        EncodingChecker v3.9.2
 
         Common commands:
 
@@ -191,7 +198,10 @@ internal static partial class Program
             EncodingChecker.exe -BasePath "D:\Share" -Target utf-8 -MaxParallelism 2
 
         Directories named .git, .svn, .hg, .vs, .idea, bin, obj, node_modules,
-        packages, dist, build, and target are always skipped.
+        packages, dist, build, and target are always skipped. Hidden files,
+        system files, and reparse points are not examined; when any are found
+        their count is reported on stderr so a clean result is not mistaken for
+        complete coverage.
 
         Help: -?, /?, -h, /h, or --help.
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.1.0")]
-[assembly: AssemblyFileVersion("3.9.1.0")]
+[assembly: AssemblyVersion("3.9.2.0")]
+[assembly: AssemblyFileVersion("3.9.2.0")]

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -50,6 +50,12 @@ internal sealed class ScanDirectoryOptions
     /// <summary>Full paths to exclude regardless of pattern matches.</summary>
     internal IReadOnlyCollection<string>? ExcludedFullPaths { get; init; }
 
+    /// <summary>
+    /// Receives counts of files the scan never examined. Supply one to report
+    /// coverage; the scan behaves identically either way.
+    /// </summary>
+    internal DirectoryTraversal.TraversalCounters? Counters { get; init; }
+
     internal ScanAction Action { get; init; }
 
     /// <summary>Accepted charset labels for validation.</summary>
@@ -128,7 +134,8 @@ internal static class ScanEngine
             includePatterns,
             excludePatterns,
             options.ExcludedFullPaths,
-            onWarning);
+            onWarning,
+            options.Counters);
 
         RunParallel(
             files,
@@ -936,7 +943,8 @@ internal static class ScanEngine
                 path, FileMode.Open, FileAccess.Read, FileShare.Read,
                 prefix.Length, FileOptions.SequentialScan);
 
-            int read = stream.Read(prefix, 0, prefix.Length);
+            int read = stream.ReadAtLeast(
+                prefix, prefix.Length, throwOnEndOfStream: false);
 
             return read == prefix.Length
                    && prefix.AsSpan(0, preamble.Length).SequenceEqual(preamble)

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -347,6 +347,7 @@ internal static class ScanEngine
                         ? FormatCharsetLabel(entry.SourceEncoding, snapshot.HasBom)
                         : null;
                     entry.DetectedEncodingLabel = snapshot.DetectedEncoding?.WebName;
+                    entry.DetectedEncodingHasBom = snapshot.DetectedEncodingHasBom;
                     entry.HasReliableUnicodeDetection = snapshot.HasReliableUnicodeDetection;
                     entry.ExpectedSourceSha256 = snapshot.Sha256;
                     entry.ExpectedSourceSize = snapshot.Size;
@@ -431,6 +432,7 @@ internal static class ScanEngine
         Encoding? detected;
         Encoding? automaticallyDetected = null;
         bool hasReliableUnicodeDetection = false;
+        bool snapshotDetectedHasBom = false;
         bool hasBom;
         string? sourceSha256 = null;
         long? sourceSize = null;
@@ -444,6 +446,7 @@ internal static class ScanEngine
             detected = snapshot.SourceEncoding;
             automaticallyDetected = snapshot.DetectedEncoding;
             hasReliableUnicodeDetection = snapshot.HasReliableUnicodeDetection;
+            snapshotDetectedHasBom = snapshot.DetectedEncodingHasBom;
             hasBom = snapshot.HasBom;
             sourceSha256 = snapshot.Sha256;
             sourceSize = snapshot.Size;
@@ -482,6 +485,8 @@ internal static class ScanEngine
             ExpectedSourceSize = sourceSize,
             HasReliableUnicodeDetection = options.Action == ScanAction.Convert &&
                 hasReliableUnicodeDetection,
+            DetectedEncodingHasBom = options.Action == ScanAction.Convert &&
+                snapshotDetectedHasBom,
         };
 
         if (options.Action == ScanAction.Convert)
@@ -567,6 +572,7 @@ internal static class ScanEngine
         Encoding? DetectedEncoding,
         Encoding? SourceEncoding,
         bool HasReliableUnicodeDetection,
+        bool DetectedEncodingHasBom,
         bool HasBom,
         string Sha256,
         long Size);
@@ -614,7 +620,7 @@ internal static class ScanEngine
 
         return new SourceSnapshot(
             detectedEncoding, sourceEncoding, hasReliableUnicodeDetection,
-            hasBom, hash, stream.Length);
+            detectedHasBom, hasBom, hash, stream.Length);
     }
 
     private static bool IsReliablyDetectedUnicode(
@@ -755,6 +761,25 @@ internal static class ScanEngine
             _ => null,
         };
 
+        // A retry must not carry a diagnostic from an earlier failed attempt.
+        // The optional BOM-less Unicode advisory below is added back for this pass.
+        entry.Diagnostic = null;
+
+        if (action == PlannedAction.Convert &&
+            entry.SourceEncodingWasSpecified &&
+            automaticallyDetected is not null &&
+            IsUtf16OrUtf32(automaticallyDetected) &&
+            !entry.DetectedEncodingHasBom &&
+            automaticallyDetected.CodePage != sourceEncoding.CodePage)
+        {
+            entry.ReasonCode =
+                ConversionReasonCodes.ExplicitSourceDiffersFromBomlessUnicodeEstimate;
+            entry.Diagnostic =
+                $"EC estimated BOM-less {automaticallyDetected.WebName}, but you selected "
+                + $"{sourceEncoding.WebName}. BOM-less Unicode can be ambiguous, so EC used "
+                + "your explicit selection and kept all strict conversion checks enabled.";
+        }
+
         if (action != PlannedAction.Convert)
         {
             entry.Result = ConversionPolicy.ToRowResult(action);
@@ -796,6 +821,8 @@ internal static class ScanEngine
             }
         }
 
+        ConversionMetadata? recoveryMetadata = null;
+
         var conversionOptions = new ConversionOptions
         {
             WriteBom = targetWriteBom,
@@ -804,10 +831,34 @@ internal static class ScanEngine
             RecordConversion = backup
                 ? record =>
                 {
-                    string? error = WriteConversionMetadata(path, record, entry);
+                    string? error = PrepareConversionMetadata(
+                        path, record, entry, out ConversionMetadata? prepared);
 
                     if (error is null)
+                    {
+                        recoveryMetadata = prepared;
                         entry.RecoveryMetadataPath = ConversionMetadataStore.MetadataPathFor(path);
+                    }
+
+                    return error;
+                }
+                : null,
+
+            CompleteConversionRecord = backup
+                ? () =>
+                {
+                    if (recoveryMetadata is null)
+                        return "the prepared recovery record is unavailable.";
+
+                    ConversionMetadata completed = recoveryMetadata with
+                    {
+                        InstallationState = ConversionInstallationState.Completed,
+                    };
+
+                    string? error = ConversionMetadataStore.Write(path, completed);
+
+                    if (error is null)
+                        recoveryMetadata = completed;
 
                     return error;
                 }
@@ -849,12 +900,15 @@ internal static class ScanEngine
                 ? ConversionRowResult.Converted
                 : ConversionRowResult.Error;
 
-        entry.Diagnostic =
-            result.Success
-                ? null
-                : $"{result.ErrorCode}: {result.ErrorMessage}";
-        entry.ReasonCode = result.Success ? null : result.ErrorCode.ToString();
+        if (!result.Success)
+        {
+            entry.Diagnostic = $"{result.ErrorCode}: {result.ErrorMessage}";
+            entry.ReasonCode = result.ErrorCode.ToString();
+        }
     }
+
+    private static bool IsUtf16OrUtf32(Encoding encoding) =>
+        encoding.CodePage is 1200 or 1201 or 12000 or 12001;
 
     /// <summary>
     /// Writes recovery metadata only after output verification and before installation.
@@ -863,9 +917,13 @@ internal static class ScanEngine
     /// Called after output verification and before installation so metadata failure leaves
     /// the original file intact.
     /// </remarks>
-    private static string? WriteConversionMetadata(
-        string path, ConversionRecord record, ConversionReportEntry entry)
+    private static string? PrepareConversionMetadata(
+        string path,
+        ConversionRecord record,
+        ConversionReportEntry entry,
+        out ConversionMetadata? metadata)
     {
+        metadata = null;
         string backupPath = path + ".bak";
 
         string backupHash;
@@ -886,18 +944,20 @@ internal static class ScanEngine
         if (hashError is not null)
             return hashError;
 
-        return ConversionMetadataStore.Write(path, new ConversionMetadata
+        var prepared = new ConversionMetadata
         {
             ConversionId = Guid.NewGuid().ToString("D"),
             ConversionTimestampUtc =
                 DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture),
             EcVersion = typeof(ScanEngine).Assembly.GetName().Version?.ToString()
                         ?? "unknown",
+            InstallationState = ConversionInstallationState.Prepared,
             OriginalPath = path,
             OriginalSize = record.SourceBytes,
             OriginalSha256 = record.SourceSha256,
             BackupPath = backupPath,
             BackupSha256 = backupHash,
+            ExpectedOutputSha256 = record.OutputSha256,
             // The recovery key is the codec that actually read the source.
             SourceEncodingId = record.SourceCodePage,
             SourceEncodingName = record.SourceEncoding,
@@ -916,7 +976,14 @@ internal static class ScanEngine
             SourceTextSha256 = record.SourceTextSha256,
             OutputTextSha256 = record.OutputTextSha256,
             UnicodeScalars = record.UnicodeScalars,
-        });
+        };
+
+        string? error = ConversionMetadataStore.Write(path, prepared);
+
+        if (error is null)
+            metadata = prepared;
+
+        return error;
     }
 
     /// <summary>The code page for a charset label, or null when it cannot be resolved.</summary>


### PR DESCRIPTION
## Summary

- reject supplied but empty include/exclude filters and report matching hidden/system/reparse items that were not examined
- distinguish prepared and completed recovery sidecars, bind them to the verified output hash, and preserve the last truthful record on update failure
- preserve automatic-detection provenance in saved plans and warn when an explicit source differs from a BOM-less UTF-16/32 estimate
- clarify forced-close wording and explain direct conversion versus saved plan/apply
- update README, safety documentation, and v3.9.2 release notes

## Verification

- Release test suite: 485 passed, 0 failed
- git diff --check: clean
- all changed text files use CRLF

## Release gates

The manual GUI smoke test and four-corpus regression audit are intentionally skipped for v3.9.2 at the maintainer's request. GitHub CI and shared-detector parity remain required before merge.