### PR TITLE
Correct v3.9.2 conversion workflow documentation

### DIFF
--- a/docs/CONVERSION-WORKFLOW.md
+++ b/docs/CONVERSION-WORKFLOW.md
@@ -35,15 +35,20 @@ disable strict decoding, output verification, backup verification, or safe insta
 flowchart LR
     A[Scan files] --> B[Decide source interpretation]
     B --> C[Build review plan]
-    C --> D[User confirms]
-    D --> E[Strict source decode]
-    E --> F[Strict target encode]
-    F --> G[Verify identical text]
-    G --> H[Backup and metadata]
-    H --> I[Install verified output]
+    C --> D[Conversion is confirmed or applied]
+    D --> E[Create backup if enabled]
+    E --> F[Strict source decode]
+    F --> G[Strict target encode]
+    G --> H[Verify identical text]
+    H --> I[If backed up: verify backup and write Prepared metadata]
+    I --> J[Install verified output]
+    J --> K[If backed up: mark metadata Completed]
 ```
 
-Every step after confirmation must succeed. If decoding, encoding, verification, backup creation, or installation fails, EC leaves that source file unchanged.
+Every step after confirmation must succeed. If decoding, encoding, verification, backup
+creation, or installation fails, EC leaves that source file unchanged. Because the backup
+is created first, a later refusal or failure can leave a `.bak` file beside the unchanged
+source. Recovery metadata is written only after the converted output and backup both verify.
 
 ## Two ways to start a conversion
 
@@ -51,8 +56,9 @@ EC offers two workflows, but they do not use different conversion engines. Both 
 same source-encoding policy, strict codecs, output verification, backup checks, and safe
 file installation.
 
-**Most users should use direct conversion. Saved plan/apply is an optional advanced
-workflow for delayed approval or repeatable automation.**
+**Use direct conversion for ordinary interactive work. For batch jobs or automation,
+saved plan/apply is the safest workflow because it binds approval to the exact files and
+settings that were reviewed.**
 
 | Workflow | Best for | What happens |
 | --- | --- | --- |

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -127,6 +127,9 @@ internal static partial class Program
           Review that plan, then apply exactly it:
             EncodingChecker.exe -Apply plan.json
 
+          Convert a folder directly, keeping each original:
+            EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Backup
+
           Convert files whose original legacy encoding you know:
             EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -From windows-1252 -Backup
 


### PR DESCRIPTION
## Fixes

- show that an optional backup is created before strict source decoding
- show that backup verification and Prepared recovery metadata occur after output verification, while Completed is recorded after installation
- state that a later failure can leave a backup beside an unchanged source
- align the recommendation with command-line help: direct is simplest for interactive work; plan/apply is safest for batch jobs and automation
- add the missing direct-conversion example to `--help`

## Why the help example was missing

`CONVERSION-WORKFLOW.md` names direct conversion the everyday workflow, but of the four commands under **Common commands**, the only direct one supplied `-From`. The simplest and most frequent case — convert a folder to UTF-8, keeping the originals — appeared nowhere a reader would find it. It now sits between the plan/apply pair and the legacy example, so the list reads: preview, apply, convert directly, convert known legacy, inspect.

```
  Convert a folder directly, keeping each original:
    EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Backup
```

## Scope

Documentation and help text; no behaviour change. `sources/EncodingChecker/Program.cs` appears in the diff, but the edit is three lines inside the `UsageText` string literal.

Verified against the code rather than assumed: the corrected flowchart matches the real order — `CreateBackup` at `ScanEngine.cs:811`, `EncodingConverter.Convert` at `:873`, recovery metadata written after verification and before installation. Build clean, 485/485 tests pass, CRLF preserved.
