### PR TITLE
Refuse BOM-less UTF-16 whose byte order cannot be proven (v3.10.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,47 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      - name: Verify release version
+        shell: pwsh
+        run: |
+          $tagVersion = "${{ github.ref_name }}" -replace '^v', ''
+          $assemblyInfo = Get-Content "sources\EncodingChecker\Properties\AssemblyInfo.cs" -Raw
+
+          foreach ($attribute in @("AssemblyVersion", "AssemblyFileVersion")) {
+            $pattern = '(?m)^\s*\[assembly:\s*' + [regex]::Escape($attribute) + '\("(?<version>[^"]+)"\)\]'
+            $match = [regex]::Match($assemblyInfo, $pattern)
+
+            if (-not $match.Success) {
+              throw "Could not find [$attribute] in AssemblyInfo.cs."
+            }
+
+            $assemblyVersion = [Version]$match.Groups['version'].Value
+            $displayVersion = "$($assemblyVersion.Major).$($assemblyVersion.Minor).$([Math]::Max($assemblyVersion.Build, 0))"
+
+            if ($displayVersion -ne $tagVersion) {
+              throw "$attribute '$($assemblyVersion.ToString())' does not match release tag '${{ github.ref_name }}'."
+            }
+          }
+
       - name: Build
         run: dotnet build sources\EncodingChecker.sln --configuration Release
 
       - name: Test
         run: dotnet test sources\EncodingChecker.sln --configuration Release --no-build
+
+      - name: Verify built display version
+        shell: pwsh
+        run: |
+          $expected = "${{ github.ref_name }}" -replace '^v', ''
+          $actual = (& dotnet "sources\EncodingChecker\bin\Release\net10.0-windows\EncodingChecker.dll" --version).Trim()
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "EncodingChecker --version failed with exit code $LASTEXITCODE."
+          }
+
+          if ($actual -ne $expected) {
+            throw "Built EncodingChecker reports version '$actual', expected '$expected'."
+          }
 
       - name: Publish framework-dependent single-file executable
         run: dotnet publish sources\EncodingChecker\EncodingChecker.csproj -p:PublishProfile=FolderProfile
@@ -65,13 +101,15 @@ jobs:
       - name: Package
         shell: pwsh
         run: |
-          Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64\*" -DestinationPath "EncodingChecker.zip"
-          Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64-selfcontained\*" -DestinationPath "EncodingChecker-selfcontained.zip"
+          $version = "${{ github.ref_name }}" -replace '^v', ''
+          Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64\*" -DestinationPath "EncodingChecker-$version-framework-dependent.zip"
+          Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64-selfcontained\*" -DestinationPath "EncodingChecker-$version-win-x64-self-contained.zip"
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
-          gh release create "${{ github.ref_name }}" EncodingChecker.zip EncodingChecker-selfcontained.zip
+          gh release create "${{ github.ref_name }}"
+          EncodingChecker-*-framework-dependent.zip EncodingChecker-*-win-x64-self-contained.zip
           --title "${{ github.ref_name }}"
           --generate-notes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.9.2
+# EncodingChecker v3.10.0
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 
@@ -30,93 +30,58 @@ View → review → confirm → verified conversion
 
 [Read the conversion workflow](docs/CONVERSION-WORKFLOW.md)
 
-### Command line
+## Conversion rule
 
-For a folder you have not converted before, make a plan first:
+| File type | Automatic action |
+| --- | --- |
+| ASCII, Unicode with a BOM, or text whose encoding EC can prove from its bytes | Convert automatically |
+| Legacy text or BOM-less Unicode whose encoding cannot be proven safely | Do not convert; ask you to choose the original encoding |
+
+If you choose a source encoding, EC uses it only to read the original bytes. It
+does not bypass strict decoding, output verification, backup checks, or safe
+installation.
+
+## Command line
+
+For a small job you are reviewing and converting in the same session, direct
+conversion is easiest:
 
 ```powershell
-EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Plan plan.json
+EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Backup
 ```
 
-Review the summary and `plan.json`, then apply exactly that plan:
+For an important batch, automation, or review that happens later, plan/apply is
+the safest workflow:
 
 ```powershell
+EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Backup -Plan plan.json
 EncodingChecker.exe -Apply plan.json
 ```
 
-The plan is tied to the selected files and their hashes. If a scheduled source file changes after review, nothing is converted.
+The saved plan is tied to the selected files and their hashes. If a scheduled
+source file changes after review, nothing is converted.
 
-## The conversion rule
+For direct conversion, previews, CI validation, exit codes, and every switch,
+read [Command-line reference](docs/CLI.md).
 
-**Unicode and ASCII files can be converted automatically.**
+## Documentation
 
-**Legacy text needs an explicit source encoding.** Tell EC what it is with `-From` on the command line or the source-encoding chooser in the GUI:
+- [How conversion works](docs/CONVERSION-WORKFLOW.md)
+- [Command-line reference](docs/CLI.md)
+- [Safety and recovery](docs/SAFETY.md)
+- [Encoding detection](docs/DETECTION.md)
+- [Independent audit](docs/SAFETY-AUDIT.md)
+- [Release checklist](docs/RELEASE-CHECKLIST.md)
 
-```powershell
-EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -From windows-1252 -Backup
-```
-
-Choosing a source encoding does not bypass safety checks. EC also refuses a choice that conflicts with a fully validated UTF-8 or BOM-confirmed UTF-16/32 reading. The source must still decode strictly, the output must verify as the same text, and a backup failure stops the conversion.
-
-## Common commands
-
-```powershell
-# Inspect detected encodings only; do not modify files.
-EncodingChecker.exe -BasePath "C:\Files" -DetectOnly
-
-# Preview selected files once; do not modify files or create a plan.
-EncodingChecker.exe -BasePath "C:\Files" -Include "*.cs,*.txt" `
-  -Exclude "*.g.cs,*.designer.cs" -Target utf-8 -WhatIf
-
-# Validate in CI, save a CSV report, and fail when a file is outside the list.
-EncodingChecker.exe -BasePath "C:\Files" -Validate "utf-8,utf-8-bom" `
-  -Report validation.csv -FailOnChanges -Quiet
-
-# Convert known legacy text, preserve originals, and record the run.
-EncodingChecker.exe -BasePath "C:\Files" -Include "*.txt" -From windows-1252 `
-  -Target utf-8 -Backup -Journal conversion.json -Verbose
-
-# Limit work against a network or slow disk.
-EncodingChecker.exe -BasePath "D:\Share" -Target utf-8 -MaxParallelism 2
-```
-
-## Command-line reference
-
-| Option | Meaning |
-| --- | --- |
-| `-BasePath <directory>` | Folder to scan. Required except with `-Apply`. |
-| `-Target <encoding>` | Target encoding, such as `utf-8` or `utf-8-bom`. Required for conversion. |
-| `-From <encoding>` | Explicit original encoding for every selected file. Use for legacy conversion. |
-| `-Plan <path>` | Write a reviewable plan; do not modify files. |
-| `-Apply <path>` | Execute a saved plan. Its scope and settings are fixed. Only `-Journal`, `-Quiet`, and `-MaxParallelism` may be added; `-WhatIf` and conversion options are rejected. |
-| `-WhatIf` | One-time preview; do not write files. |
-| `-Backup` | Save every replaced original as `<file>.bak`. |
-| `-DetectOnly` | Report detected encodings; do not modify files. |
-| `-Validate <encodings>` | Strictly validate complete files against an allowed encoding list; do not modify files. |
-| `-Include` / `-Exclude` | Comma-separated wildcard patterns; either option may be repeated. |
-| `-Report <path>` | Also write the CSV report as UTF-8 with BOM (Excel-friendly). |
-| `-Journal <path>` | Write a JSON record of conversion decisions and results. |
-| `-Quiet` / `-Verbose` | Show only a summary, or include details and a result breakdown. |
-| `-MaxParallelism <N>` | Maximum simultaneous files; default is `min(CPU count, 4)`. |
-| `-FailOnChanges` | Return exit code `2` if files need conversion or fail validation. Useful in CI. |
-
-Patterns without a path separator match filenames at any depth, such as `*.txt`. Patterns containing `/` or `\` match paths relative to `-BasePath`, such as `src/*.cs`. Build and metadata folders including `.git`, `bin`, `obj`, and `node_modules` are skipped automatically. Matching hidden, system, and reparse-point files are left alone and counted. Hidden, system, and reparse-point folders are not entered and are counted separately because EC does not inspect their contents. The GUI shows these counts in its status; the CLI writes them to standard error. These coverage notices are informational and do not change the exit code.
-
-Run `EncodingChecker.exe -?` for the same reference from the executable. The help aliases are `-?`, `/?`, `-h`, `/h`, and `--help`. Exit codes: `0` completed, `1` invalid command, `2` `-FailOnChanges`, `3` processing/plan/report failure, `4` cancelled, `5` conversion safely refused.
-
-## Safety and transparency
-
-Every conversion uses strict decoding and encoding, verifies the output text before installation, and writes through a temporary file rather than in place. With `-Backup`, EC verifies the backup before it replaces the source. The GUI enables backups by default.
-
-For the complete safety model, conversion-plan guarantees, recovery metadata, known limits, and independent corpus audit, see [Safety and audit](docs/SAFETY-AUDIT.md). The audit harness and reproducible per-file evidence live in [CorpusTesters](https://github.com/amrali-eg/CorpusTesters).
-
-## Known limits
-
-File bytes alone cannot always identify the original legacy encoding uniquely. EC therefore leaves detected legacy text unchanged until you choose or confirm its source encoding. If your explicit source differs from a BOM-less UTF-16/32 estimate, EC follows your choice but shows a warning. Keep each `.bak` file with its matching `.ecmeta.json` record: together they provide independently verifiable recovery information, although EC does not currently include a restore command. The record contains both original and expected-output hashes and says whether installation was only prepared or completed.
+The independent audit harness and reproducible per-file evidence live in
+[CorpusTesters](https://github.com/amrali-eg/CorpusTesters).
 
 ## Supported charsets
 
-Over forty charsets, matching what [UtfUnknown](https://github.com/CharsetDetector/UTF-unknown) can report and .NET can encode/decode:
+Unicode detection is implemented by EC's own `UnicodeDetector`, including
+BOM-less UTF-8, UTF-16, and UTF-32 checks. [UtfUnknown](https://github.com/CharsetDetector/UTF-unknown)
+is used for legacy-charset detection. The supported legacy names are those that
+UtfUnknown can report and .NET can encode/decode:
 
 * ASCII
 * UTF-8 (with or without a BOM)
@@ -143,7 +108,7 @@ Over forty charsets, matching what [UtfUnknown](https://github.com/CharsetDetect
 
 The original [EncodingChecker](https://archive.codeplex.com/?p=encodingchecker) project was written by [Jeevan James](https://github.com/JeevanJames).
 
-For detection, EncodingChecker uses [UtfUnknown](https://github.com/CharsetDetector/UTF-unknown), a C# port of uchardet. See [THIRD-PARTY-NOTICES.txt](./THIRD-PARTY-NOTICES.txt) for license details.
+For legacy-encoding detection, EncodingChecker uses [UtfUnknown](https://github.com/CharsetDetector/UTF-unknown), a C# port of uchardet. EC's own `UnicodeDetector` handles Unicode detection. See [THIRD-PARTY-NOTICES.txt](./THIRD-PARTY-NOTICES.txt) for license details.
 
 ## License
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,139 @@
+# Command-line reference
+
+## Basic forms
+
+```text
+EncodingChecker.exe -BasePath <directory> -Target <encoding> [options]
+EncodingChecker.exe -Apply <plan.json> [options]
+```
+
+The GUI is usually simplest for one-time work. The command line is useful for
+repeatable work, CI, and reviewed batch conversions.
+
+For a small job you are reviewing and converting in one session, direct
+conversion is easiest. For an important batch, automation, or review that
+happens later, use `-Plan` followed by `-Apply`: it binds approval to the exact
+source files and refuses the entire plan if any scheduled file has changed.
+
+## File selection
+
+| Option | Meaning |
+|---|---|
+| `-BasePath <directory>` | Folder to scan. Required except with `-Apply`. |
+| `-Include <patterns>` | Comma-separated wildcard patterns; may be repeated. |
+| `-Exclude <patterns>` | Comma-separated wildcard patterns; may be repeated. |
+
+An explicitly supplied `-Include` or `-Exclude` must contain at least one
+non-empty pattern. Values such as `""`, `",,,"`, or whitespace are rejected.
+
+A pattern without `/` or `\` matches file names at any depth. A pattern with a
+separator matches the path relative to `-BasePath`. `/` and `\` are equivalent.
+`*` and `?` are supported wildcards.
+
+EC always excludes its own `.bak`, `.ecmeta.json`, temporary, plan, journal,
+and report files, along with common metadata and build folders such as `.git`,
+`bin`, `obj`, and `node_modules`. Hidden, system, and reparse-point files are
+left alone. Hidden, system, and reparse-point folders are not entered. EC reports
+these coverage counts, but they do not change the exit code.
+
+## Conversion
+
+| Option | Meaning |
+|---|---|
+| `-Target <encoding>` | Target encoding, for example `utf-8` or `utf-8-bom`. Required for conversion. |
+| `-From <encoding>` | Explicit original encoding for every selected file. Use when you know a legacy source encoding. |
+| `-Backup` | Save every replaced original as `<file>.bak`. |
+| `-WhatIf` | Show a one-time preview without writing files. |
+| `-Plan <path>` | Write a reviewable conversion plan; do not modify files. |
+| `-Apply <path>` | Execute a saved plan. Its scope and conversion settings are fixed. |
+
+EC converts ASCII, Unicode with a BOM, and text whose encoding it can prove
+from its bytes automatically. Legacy text and BOM-less Unicode whose encoding
+cannot be proven safely need `-From`. Choosing a source encoding replaces
+detection only; strict source decoding, strict target encoding, output
+verification, backup checks, and atomic installation still apply.
+
+For BOM-less UTF-16, EC converts automatically only when the bytes prove the
+byte order. If both UTF-16LE and UTF-16BE strictly decode the complete file,
+EC refuses the automatic conversion. Choose `-From utf-16le` or
+`-From utf-16be` if you know the original order.
+
+`-Apply` uses the decisions and hashes stored in the plan; it does not detect
+the files again. Only `-Journal`, `-Quiet`, and `-MaxParallelism` may accompany
+it. `-WhatIf`, `-Target`, `-From`, `-Backup`, and file-selection options are
+rejected with `-Apply`.
+
+## Read-only modes
+
+| Option | Meaning |
+|---|---|
+| `-DetectOnly` | Report detected encodings; do not modify files. |
+| `-Validate <charset1,...>` | Strictly validate complete files against an allowed encoding list; do not modify files. |
+| `-FailOnChanges` | Return exit code 2 when files need conversion or fail validation. Useful in CI. |
+
+`-DetectOnly` cannot be combined with `-Validate`, `-Target`, `-From`,
+`-WhatIf`, `-Backup`, `-Plan`, `-Apply`, or `-Journal`. `-Validate` cannot be
+combined with conversion options.
+
+## Output and performance
+
+| Option | Meaning |
+|---|---|
+| `-Report <path>` | Also write the CSV report as UTF-8 with a BOM for Excel. |
+| `-Journal <path>` | Write a JSON record of the conversion decision and final result for every file. Convert mode only. |
+| `-Quiet` | Print only the final summary on standard output. |
+| `-Verbose` | Include error details and a result breakdown. |
+| `-MaxParallelism <N>` | Maximum simultaneous files. Default: the smaller of CPU count and 4. |
+
+`-Quiet` and `-Verbose` cannot be combined.
+
+## Examples
+
+Preview files without writing anything:
+
+```powershell
+EncodingChecker.exe -BasePath "C:\Files" -Include "*.cs,*.txt" `
+  -Exclude "*.g.cs,*.designer.cs" -Target utf-8 -WhatIf
+```
+
+Prepare and later apply an approved batch:
+
+```powershell
+EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Backup -Plan plan.json
+EncodingChecker.exe -Apply plan.json -Journal conversion.json
+```
+
+Convert known Windows-1252 text while preserving originals:
+
+```powershell
+EncodingChecker.exe -BasePath "C:\Files" -Include "*.txt" `
+  -From windows-1252 -Target utf-8 -Backup -Journal conversion.json
+```
+
+Validate a folder in CI:
+
+```powershell
+EncodingChecker.exe -BasePath "C:\Files" -Validate "utf-8,utf-8-bom" `
+  -Report validation.csv -FailOnChanges -Quiet
+```
+
+## Version and exit codes
+
+```powershell
+EncodingChecker.exe --version
+```
+
+Prints the version and exits. It takes no other arguments and does not need
+`-BasePath`.
+
+| Code | Meaning |
+|---:|---|
+| 0 | Completed. |
+| 1 | Invalid command. |
+| 2 | `-FailOnChanges` found files requiring conversion or failing validation. |
+| 3 | Processing, plan, or report failure. |
+| 4 | Cancelled with Ctrl+C. |
+| 5 | One or more conversions were safely refused and left unchanged. |
+
+When more than one applies, processing failure (3) wins over safe refusal (5),
+which wins over `-FailOnChanges` (2).

--- a/docs/CONVERSION-WORKFLOW.md
+++ b/docs/CONVERSION-WORKFLOW.md
@@ -7,7 +7,7 @@ This page explains what happens after you ask EncodingChecker to convert files. 
 1. **View** the folder to see what EC found.
 2. Select the files you want to handle and choose **Convert**.
 3. Read the review before any file is changed.
-4. For legacy text, choose the source encoding if you know it.
+4. If EC asks, choose the original source encoding if you know it.
 5. Confirm the reviewed conversion.
 
 The review tells you which files will convert, already match the target, need a legacy source choice, or cannot be processed. Cancelling leaves every source file unchanged.
@@ -16,18 +16,26 @@ The review tells you which files will convert, already match the target, need a 
 
 For a file that needs conversion, EC applies this policy:
 
-| Source interpretation | EC's action |
+| File type | Automatic action |
 | --- | --- |
-| Unicode or ASCII detected automatically | Convert if needed |
-| Legacy codec selected explicitly by the user | Convert if needed, subject to every safety check; refuse if the choice conflicts with fully validated UTF-8 or BOM-confirmed UTF-16/32 |
-| Legacy codec detected automatically | Refuse conversion until you choose or confirm the source codec |
-| Unknown or unreadable source | Do not convert |
+| ASCII, Unicode with a BOM, or text whose encoding EC can prove from its bytes | Convert automatically |
+| Legacy text or BOM-less Unicode whose encoding cannot be proven safely | Do not convert; ask you to choose the original encoding |
 
 A file that already matches the target encoding and BOM is reported as **Unchanged** and
 is not decoded or rewritten. No source choice is needed because no conversion occurs.
 
-Choosing a legacy encoding answers only “how should these bytes be read?” It does not
+If you choose a source encoding, EC uses it only to read the original bytes. It does not
 disable strict decoding, output verification, backup verification, or safe installation.
+
+### BOM-less UTF-16
+
+Without a byte-order mark, UTF-16 bytes are usually valid as both UTF-16LE and UTF-16BE.
+For example, byte-swapped Latin text often lands in a valid CJK range. A detector may prefer
+one order, but that preference cannot prove what the original file meant. EC therefore
+strictly decodes the complete source under the opposite order before automatic conversion.
+If both orders work, the file is reported as `Refused` with reason code
+`AmbiguousBomlessUtf16`; no preview says it would convert, and no backup, sidecar, or output
+file is created. Choose the source encoding explicitly if you know it.
 
 ## What EC does
 
@@ -155,4 +163,5 @@ For a known legacy source, supply the encoding explicitly:
 EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -From windows-1252 -Backup
 ```
 
-For the detailed guarantees and known limits, read [Safety and audit](SAFETY-AUDIT.md).
+For detailed conversion guarantees and known limits, read [Safety and recovery](SAFETY.md).
+For independent corpus evidence and its limits, read [Safety audit](SAFETY-AUDIT.md).

--- a/docs/DETECTION.md
+++ b/docs/DETECTION.md
@@ -1,0 +1,54 @@
+# Encoding detection
+
+EC identifies a likely source encoding before it converts a file. Detection is
+helpful, but it cannot always recover the original historical codec from bytes
+alone. EC therefore separates **what it detected** from **what it is safe to
+convert automatically**.
+
+## Detection order
+
+1. Read at most 64 KiB from the start of the file.
+2. Reject sufficiently large, high-entropy samples as likely binary data.
+3. Check Unicode byte patterns for ASCII, UTF-8, UTF-16LE/BE, and UTF-32LE/BE,
+   with or without a BOM.
+4. If Unicode is not identified, ask UTF.Unknown for a legacy candidate.
+5. Strictly validate that candidate and check that the decoded sample looks like text.
+
+The shared detector remains aligned with LineEndingNormalizer and CorpusTesters.
+EC's full-file conversion checks are separate: a detector label is never proof
+that a destructive conversion should proceed.
+
+## What automatic detection permits
+
+- ASCII and UTF-8 may be converted automatically after strict validation.
+- UTF-16/UTF-32 with a BOM may be converted automatically because the marker
+  establishes byte order.
+- BOM-less UTF-16 is converted automatically only when the complete file is
+  invalid under the opposite byte order. Otherwise EC reports
+  `AmbiguousBomlessUtf16` and leaves it unchanged.
+- Detected legacy text requires an explicit source choice before EC rewrites it.
+- Unknown input is skipped and left unchanged.
+
+Use `-From <encoding>` or the GUI source selector when you know a legacy or
+BOM-less UTF-16 source. This selects how EC reads the bytes; it does not turn
+off strict decoding, output verification, backup verification, or safe install.
+
+## Supported text
+
+EC supports Unicode, ASCII, and the runtime-supported legacy charsets listed in
+the [README](../README.md#supported-charsets). The source list is built from
+`TextEncoding.SupportedEncodings`; unavailable .NET aliases are filtered before
+the GUI offers them.
+
+UTF-7 is intentionally unsupported. Current .NET versions disable its
+encoder/decoder by default, and EC does not use a heuristic to guess UTF-7.
+
+## What a detection label means
+
+For a file containing only ASCII bytes, many encodings can produce the same
+text. A label such as `utf-8` is a useful operational answer, not proof that the
+author originally used UTF-8 rather than ASCII or a legacy codec.
+
+The independent audit measures detector labels and conversion preservation as
+separate properties. See [Safety audit](SAFETY-AUDIT.md) for the evidence and
+its limits.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -3,13 +3,33 @@
 Automated coverage is the first gate and is enforced by CI. What follows is what CI
 cannot answer.
 
+## Source and version
+
+- [ ] Working tree is clean.
+- [ ] `AssemblyInfo.cs` contains the intended version; CLI help and `--version` display it; README and release notes name it.
+- [ ] Release tag is exactly `v<project version>`.
+- [ ] `SemanticsVersion` changes only when conversion or classification behaviour changes.
+
 ## Automated
 
+- [ ] Release build succeeds with no warnings.
 - [ ] `dotnet test sources/EncodingChecker.Tests/EncodingChecker.Tests.csproj -c Release` — all green.
 - [ ] The scheduled **Shared Unicode detector parity** workflow is green. It compares
       the shared detector source in EncodingChecker, LineEndingNormalizer, and
       CorpusTesters after normalizing namespace, a redundant `using System` import,
       and line-ending differences.
+- [ ] Ambiguous BOM-less UTF-16 is refused without changing bytes or creating a backup.
+- [ ] Structurally provable BOM-less UTF-16 still converts correctly.
+- [ ] Explicit source selection still receives strict decoding and output verification.
+- [ ] A stale reviewed plan leaves every selected source unchanged.
+- [ ] Backup and recovery-sidecar hashes match the source bytes used for conversion.
+- [ ] CSV reports and JSON journals contain a stable reason code and useful diagnostic.
+
+For a release changing detection or conversion policy:
+
+- [ ] Run the four-corpus audit from a clean committed build.
+- [ ] Record the exact commit, assembly hash, audit configuration, and limitations.
+- [ ] Run the independent-oracle sentinel set when the release checklist requires it.
 
 ## Manual: the GUI smoke test
 
@@ -36,15 +56,17 @@ Get-FileHash -Algorithm SHA256 <path> | Select-Object -ExpandProperty Hash
 
 ### Core GUI smoke test
 
-[`tools/gui-smoke-test.py`](tools/gui-smoke-test.py) creates disposable folders on the
+[`tools/gui-smoke-test.py`](../tools/gui-smoke-test.py) creates disposable folders on the
 Desktop and verifies the resulting bytes. For every phase, set the printed folder as
 **Directory to check** and choose **utf-8** in **Convert to**. Then run each short phase
 with the Release build:
 
 ```powershell
-python tools/gui-smoke-test.py setup A
+$smoke = (Resolve-Path tools/gui-smoke-test.py)
+python $smoke setup A
 # perform the displayed GUI steps
-python tools/gui-smoke-test.py verify A
+python $smoke mark A
+python $smoke verify A
 ```
 
 | Phase | What the GUI check proves |
@@ -52,6 +74,8 @@ python tools/gui-smoke-test.py verify A
 | A | **View** lists the prepared files; Unicode and ASCII are ready, legacy files need a source choice; **Cancel** changes no bytes and creates no recovery files. |
 | B | Unicode and ASCII convert without a source choice and preserve their exact text. |
 | C | A chosen legacy source encoding applies only to the ticked files; unselected legacy files stay unchanged. |
+| D | Ambiguous BOM-less UTF-16 is refused; cancelling leaves its bytes and folder unchanged. |
+| E | An explicit BOM-less UTF-16 source choice converts the file exactly and creates its backup and recovery record. |
 
 The script verifies hashes and decoded output; status messages alone never count as evidence.
 Its `tools/smoke-state-*.json` files are local generated state and must not be committed.
@@ -81,16 +105,18 @@ Tester:
 Phase A (review + cancel):                  PASS / FAIL
 Phase B (Unicode + ASCII conversion):       PASS / FAIL
 Phase C (scoped legacy source choice):      PASS / FAIL
+Phase D (ambiguous BOM-less UTF-16 refusal): PASS / FAIL
+Phase E (explicit BOM-less UTF-16 choice):   PASS / FAIL
 
 Cases where observed differed from expected:
 
 Result: PASS / FAIL
 ```
 
-## Documentation
+## Documentation and publish
 
 - [ ] README figures match the current audit run; no stale counts.
-- [ ] Version bumped in `Program.cs` usage text and the README heading.
-- [ ] `SemanticsVersion` bumped **only** if conversion or classification behaviour
-      changed — it invalidates existing plans, and bumping it for a release that changed
-      neither teaches people to work around the check.
+- [ ] README and release notes describe every changed refusal or safety rule.
+- [ ] Publish framework-dependent and self-contained artifacts.
+- [ ] Verify archive names and GitHub SHA-256 digests.
+- [ ] Link audit evidence and state its limits in the release notes.

--- a/docs/RELEASE-NOTES-v3.10.0.md
+++ b/docs/RELEASE-NOTES-v3.10.0.md
@@ -1,0 +1,28 @@
+# EncodingChecker v3.10.0
+
+## Safety change
+
+- **Ambiguous BOM-less UTF-16 is now refused automatically.** A BOM-less UTF-16 file can
+  be valid as both UTF-16LE and UTF-16BE. Detection may prefer one order, but that is not
+  enough evidence to rewrite the file. EC now strictly decodes the complete source with the
+  opposite byte order. If that also works, EC reports `Refused` with reason code
+  `AmbiguousBomlessUtf16` and does not create a backup, sidecar, temporary output, or
+  replacement file.
+
+- **Expect most ordinary BOM-less UTF-16 text to be refused.** Byte-swapped Latin text often
+  lands in a valid CJK range, so it commonly succeeds in both byte orders. Add the correct
+  BOM, or choose the known source order explicitly with `-From utf-16le` or `-From utf-16be`,
+  or with the GUI's source-encoding chooser. An explicit source selection still uses strict
+  decoding, strict output encoding, exact text verification, backup verification, and atomic
+  installation.
+
+## Plan compatibility
+
+Conversion semantics are now version 5. Plans made by earlier releases are rejected and must
+be regenerated, because a formerly automatic BOM-less UTF-16 conversion can now be refused.
+
+## Documentation
+
+The README, conversion workflow, and safety audit now describe this rule using the same
+evidence standard as LineEndingNormalizer: automatic rewriting requires bytes that prove the
+UTF-16 byte order.

--- a/docs/SAFETY-AUDIT.md
+++ b/docs/SAFETY-AUDIT.md
@@ -1,58 +1,11 @@
-# EncodingChecker safety and audit
+# Independent safety audit
 
-This document is the technical companion to the main [README](../README.md). It explains what EC's conversion pipeline guarantees, what it does not guarantee, and how those claims are checked independently.
+This document records the independent corpus evidence for released EC builds.
+For the current conversion rules, backups, recovery metadata, and known limits,
+see [Safety and recovery](SAFETY.md). For the user workflow, see
+[How conversion works](CONVERSION-WORKFLOW.md).
 
-## Conversion safety boundary
-
-For each file that EC is allowed to convert, the engine:
-
-1. strictly decodes the source encoding;
-2. strictly encodes the requested target encoding into a temporary file;
-3. strictly decodes that temporary output and compares the exact Unicode scalar sequence with the source text;
-4. if backups are enabled, creates and verifies `<file>.bak` plus recovery metadata;
-5. installs the verified temporary file atomically where the platform supports it.
-
-Any decode, encode, verification, backup, or write failure leaves the source file unchanged. No normalization, case folding, whitespace rewriting, or replacement-character fallback is used to make a conversion appear successful.
-
-The source is not rewritten in place. File attributes and timestamps are applied to the temporary output before installation. EC skips its own backups and temporary files on subsequent scans.
-
-## Source-encoding policy
-
-Encoding identification and text preservation are different questions. A sequence of legacy bytes often cannot prove which historical single-byte code page produced it.
-
-EC therefore has a simple policy. For a file that needs conversion:
-
-| Source interpretation | EC's action |
-| --- | --- |
-| Unicode or ASCII detected automatically | Convert if needed |
-| Legacy codec selected explicitly by the user | Convert if needed, subject to every safety check; refuse if the choice conflicts with fully validated UTF-8 or BOM-confirmed UTF-16/32 |
-| Legacy codec detected automatically | Refuse conversion until you choose or confirm the source codec |
-| Unknown or unreadable source | Do not convert |
-
-A file that already matches the target encoding and BOM is reported as **Unchanged** and
-is not decoded or rewritten. No source choice is needed because no conversion occurs.
-
-`-From` and the GUI source chooser replace detection only. They do not bypass strict decoding, output verification, backup verification, or atomic installation.
-
-## Plans, confirmation, and recovery
-
-`-Plan` writes a conversion plan without changing files. Detection and hashing read the same source snapshot. The plan contains those source hashes, paths relative to its declared root, target and BOM policy, source-selection mode, backup setting, and conversion-semantics version.
-
-`-Apply` rejects changed, missing, relocated, or incompatible planned work as a whole; it does not silently apply the remaining files. EC also rechecks the source hash immediately before installation. That narrows, but cannot eliminate, a narrow concurrent-writer TOCTOU window between the final check and replacement.
-
-The GUI uses the same policy and plan model. It displays a review before writing, and a changed source while that review is open invalidates the run.
-
-With backups enabled, each conversion has a portable `<file>.ecmeta.json` sidecar. The sidecar records the source codec actually used, whether it was detected or explicitly selected, source and backup hashes, the expected converted-file hash, target/BOM policy, preparation state, timestamp, and version. It is written as `Prepared` before installation and changed to `Completed` only after installation succeeds. If a run stops between those steps, the current file's hash shows whether it is still the original or the verified output. The backup and sidecar provide independently verifiable recovery metadata; EC does not currently provide a restore command.
-
-`-Journal` provides the batch-level record: EC's detected source, the source codec actually selected, whether that selection was explicit, any canonical-code-page disagreement between the two, the policy decision, planned action, actual outcome, stable reason code, diagnostic, and before/after hashes for every file—including skipped and refused ones. The GUI exports the immutable journal returned by the completed run rather than reconstructing history from mutable controls.
-
-## Strict-codec defect fixed in v3.6.0
-
-The independent audit found that assigning `Decoder.Fallback` or `Encoder.Fallback` after calling `GetDecoder()` or `GetEncoder()` does not reliably make .NET `CodePagesEncodingProvider` codecs strict. Some malformed legacy input could be silently substituted while EC's old downstream content check still reported success.
-
-EC now constructs strict code-page encodings with exception fallbacks at `Encoding.GetEncoding(...)` construction time. Permanent regression tests cover the previously permissive decoder and encoder paths.
-
-## Independent audit
+## Method
 
 [CorpusTesters](https://github.com/amrali-eg/CorpusTesters) is a separate, reproducible audit harness. It runs EC against four public corpora:
 
@@ -65,7 +18,7 @@ It operates on working copies, never source corpora. For each file with authorit
 
 The audit distinguishes detection identity, text-equivalent labels, unsupported or unscored material, mapping/profile differences, and end-to-end text preservation. It does **not** treat one runtime's legacy mapping table as a universal authority: its sampled independent-implementation comparison is recorded separately, and mapping differences remain explicitly qualified.
 
-Current raw artifacts, methodology revisions, and results are published with CorpusTesters. Historical corpus figures must be read in their recorded taxonomy and build context; they are not a substitute for the current product policy above.
+Current raw artifacts, methodology revisions, and results are published with CorpusTesters. Historical corpus figures must be read in their recorded taxonomy and build context; they are not a substitute for the current product policy in [Safety and recovery](SAFETY.md).
 
 ### v3.9.0 audited build
 

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -1,0 +1,88 @@
+# Safety and recovery
+
+EC converts text encodings in place only after it can verify the conversion.
+It does not normalize text, alter case, change whitespace, or use replacement
+characters to make a conversion appear successful.
+
+## Conversion sequence
+
+For each file EC is allowed to convert:
+
+1. Scans the source and decides whether automatic conversion is permitted.
+2. For a reviewed plan, verifies that every approved source hash still matches.
+3. Rejects malformed input, unsafe source choices, repeated leading BOMs, and
+   ambiguous BOM-less UTF-16 before writing output.
+4. If backups are enabled, creates `<file>.bak` before conversion begins.
+5. Strictly decodes the source and strictly encodes the target into a sibling
+   temporary file.
+6. Strictly decodes that output and compares the exact Unicode scalar sequence
+   with the source text.
+7. If backups are enabled, verifies the backup hash and writes a `Prepared`
+   `.ecmeta.json` recovery record.
+8. Atomically installs the verified temporary output where the platform supports it.
+9. Marks the recovery record `Completed` after installation succeeds.
+
+If a required step fails, EC does not install converted output. Because the
+backup is created before decoding and encoding, a later conversion failure can
+leave a valid `.bak` beside an unchanged source; metadata is not written until
+both the output and backup have verified.
+
+## Source-encoding policy
+
+| File type | Automatic action |
+|---|---|
+| ASCII, Unicode with a BOM, or text whose encoding EC can prove from its bytes | Convert automatically. |
+| Legacy text or BOM-less Unicode whose encoding cannot be proven safely | Do not convert; ask you to choose the original encoding. |
+
+An unchanged file is reported as `Unchanged` and is not decoded or rewritten.
+
+A source encoding chosen by the user controls only how EC reads the original
+bytes. It does not bypass any safety check.
+
+### BOM-less UTF-16
+
+Without a byte-order mark, UTF-16 bytes are often valid as both UTF-16LE and
+UTF-16BE. Byte-swapped Latin text commonly lands in a valid CJK range. EC
+strictly decodes the complete source with the opposite byte order before it
+allows automatic conversion. If both work, it reports `Refused` with reason
+code `AmbiguousBomlessUtf16` and leaves the source unchanged.
+
+This is intentionally conservative: most ordinary BOM-less UTF-16 files are
+expected to be refused. It costs a second full read, which is deliberate because
+rewriting a file must not rest on a sample-based byte-order guess.
+
+Choose `-From utf-16le` or `-From utf-16be` if you know the source order. That
+chooses the source interpretation only; it does not bypass any other safeguard.
+
+## Plans, backups, and recovery metadata
+
+A saved plan records each selected file's relative path, size, SHA-256, source
+interpretation, target/BOM policy, backup choice, and EC safety semantics.
+`-Apply` verifies every planned file before writing anything. A changed, missing,
+or incompatible planned file invalidates the entire plan.
+
+With `-Backup`, EC creates a portable `<file>.ecmeta.json` sidecar. It records
+the codec actually used, whether it was detected or explicitly selected, source
+and backup hashes, expected output hash, BOM policy, version, timestamp, and
+whether installation was prepared or completed. The `.bak` and sidecar provide
+independently verifiable recovery information. EC does not currently provide a
+built-in restore command.
+
+`-Journal` creates the batch-level record: detection, chosen source, decision,
+reason code, final result, and before/after hashes for every file.
+
+## Concurrent changes and links
+
+EC does not follow linked/reparse-point files or directories. Plans verify
+source hashes before execution and EC checks again immediately before
+installation. This greatly reduces accidental overwrite risk, but cannot remove
+the narrow race where another process changes a file between the last check and
+replacement.
+
+## Known limits
+
+No detector can infer an author's intended legacy codec when several codecs
+accept the same bytes but produce different Unicode text. EC refuses automatic
+legacy conversion for that reason. Explicit choices remain the user's
+responsibility, but the conversion engine still verifies that it can preserve the
+text under that chosen interpretation.

--- a/sources/EncodingChecker.Tests/BomlessUtf16SafetyTests.cs
+++ b/sources/EncodingChecker.Tests/BomlessUtf16SafetyTests.cs
@@ -1,0 +1,140 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Covers the one Unicode case where a successful heuristic is still not enough to
+/// authorize an automatic rewrite: UTF-16 without a byte-order mark.
+/// </summary>
+public sealed class BomlessUtf16SafetyTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_bomless_utf16_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private ConversionReportEntry Convert(
+        string fileName,
+        byte[] bytes,
+        string? sourceEncoding = null,
+        bool whatIf = false,
+        bool backup = true)
+    {
+        string path = Path.Combine(_root, fileName);
+        File.WriteAllBytes(path, bytes);
+
+        var completed = new EntrySink();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions
+            {
+                BaseDirectory = _root,
+                IncludeSubdirectories = true,
+                IncludePatterns = [fileName],
+                Action = ScanAction.Convert,
+                SourceCharset = sourceEncoding,
+                TargetCharset = "utf-8",
+                TargetWriteBom = false,
+                WhatIf = whatIf,
+                Backup = backup,
+            },
+            completed.Add,
+            CancellationToken.None);
+
+        return Assert.Single(completed);
+    }
+
+    [Fact]
+    public void AutomaticBomlessUtf16BeMisreadAsLittleEndian_IsRefusedBeforePreviewBackupOrWrite()
+    {
+        // UTF-16BE reads these bytes as U+4100, U+0A00, U+4200. The same bytes read as
+        // UTF-16LE look like A, LF, B, so the shared detector reasonably prefers LE.
+        // Its preference still cannot establish what the original author intended.
+        string authoritativeText = string.Concat(
+            Enumerable.Repeat("\u4100\u0A00\u4200", 20));
+        var utf16Be = new UnicodeEncoding(
+            bigEndian: true,
+            byteOrderMark: false,
+            throwOnInvalidBytes: true);
+        byte[] original = utf16Be.GetBytes(authoritativeText);
+
+        ConversionReportEntry entry = Convert(
+            "ambiguous-utf16be.txt", original, whatIf: false, backup: true);
+
+        Assert.Equal(ConversionRowResult.Refused, entry.Result);
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, entry.ReasonCode);
+        Assert.Contains("valid as both UTF-16LE and UTF-16BE", entry.Diagnostic);
+        Assert.Equal(original, File.ReadAllBytes(entry.FilePath));
+        Assert.Equal(authoritativeText, utf16Be.GetString(File.ReadAllBytes(entry.FilePath)));
+        Assert.False(File.Exists(entry.FilePath + ".bak"));
+        Assert.False(File.Exists(ConversionMetadataStore.MetadataPathFor(entry.FilePath)));
+    }
+
+    [Fact]
+    public void AmbiguousBomlessUtf16Preview_IsRefusedInsteadOfReportedAsConvertible()
+    {
+        byte[] original = new UnicodeEncoding(
+            bigEndian: true,
+            byteOrderMark: false,
+            throwOnInvalidBytes: true)
+            .GetBytes(string.Concat(Enumerable.Repeat("\u4100\u0A00\u4200", 20)));
+
+        ConversionReportEntry entry = Convert(
+            "preview-ambiguous-utf16be.txt", original, whatIf: true, backup: true);
+
+        // A preview must describe the same safe refusal a real run would make. Before
+        // this rule, the preview incorrectly promised conversion based on the LE guess.
+        Assert.Equal(ConversionRowResult.Refused, entry.Result);
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, entry.ReasonCode);
+        Assert.Equal(original, File.ReadAllBytes(entry.FilePath));
+        Assert.False(File.Exists(entry.FilePath + ".bak"));
+        Assert.False(File.Exists(ConversionMetadataStore.MetadataPathFor(entry.FilePath)));
+    }
+
+    [Fact]
+    public void AutomaticBomlessUtf16WhoseOppositeOrderIsInvalid_StillConverts()
+    {
+        // U+00D8 becomes D8 00 in UTF-16LE. Interpreted as BE, D8 00 is an unpaired
+        // surrogate, so the bytes themselves prove that LE is the only valid order.
+        string text = string.Concat(Enumerable.Repeat("Øline\n", 20));
+        byte[] original = Encoding.Unicode.GetBytes(text);
+
+        ConversionReportEntry entry = Convert("provable-utf16le.txt", original, backup: false);
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.Equal(PlannedAction.Convert, entry.Action);
+        Assert.Equal(text, Encoding.UTF8.GetString(File.ReadAllBytes(entry.FilePath)));
+    }
+
+    [Fact]
+    public void ExplicitUtf16SourceResolvesAnAmbiguousFileButKeepsEveryOtherSafetyCheck()
+    {
+        string authoritativeText = string.Concat(
+            Enumerable.Repeat("\u4100\u0A00\u4200", 20));
+        var utf16Be = new UnicodeEncoding(
+            bigEndian: true,
+            byteOrderMark: false,
+            throwOnInvalidBytes: true);
+        byte[] original = utf16Be.GetBytes(authoritativeText);
+
+        ConversionReportEntry entry = Convert(
+            "explicit-utf16be.txt", original, sourceEncoding: "utf-16BE", backup: true);
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.True(entry.SourceEncodingWasSpecified);
+        Assert.Equal(authoritativeText, Encoding.UTF8.GetString(File.ReadAllBytes(entry.FilePath)));
+        Assert.Equal(original, File.ReadAllBytes(entry.FilePath + ".bak"));
+        Assert.True(File.Exists(ConversionMetadataStore.MetadataPathFor(entry.FilePath)));
+    }
+}

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -35,6 +35,9 @@ public sealed class ConversionConfirmationFormTests : IDisposable
         File.WriteAllBytes(
             Path.Combine(_root, name), Encoding.GetEncoding(charset).GetBytes(text));
 
+    private void WriteBytes(string name, byte[] bytes) =>
+        File.WriteAllBytes(Path.Combine(_root, name), bytes);
+
     /// <summary>A plan over whatever is currently in the directory.</summary>
     private ConversionPlan Plan(bool backup = true, string target = "utf-8")
     {
@@ -212,6 +215,40 @@ public sealed class ConversionConfirmationFormTests : IDisposable
     }
 
     [Fact]
+    public void ItOffersAnExplicitChoiceForAmbiguousBomlessUtf16()
+    {
+        // This is not legacy text: EC detects UTF-16LE, but the exact bytes also strictly
+        // decode as UTF-16BE. Automatic conversion must refuse, while the review must give
+        // the user the same explicit UTF-16/UTF-16BE choice that -From provides in CLI.
+        string text = string.Concat(Enumerable.Repeat("\u4100\u0A00\u4200", 20));
+        byte[] bytes = new UnicodeEncoding(
+            bigEndian: true,
+            byteOrderMark: false,
+            throwOnInvalidBytes: true).GetBytes(text);
+        WriteBytes("ambiguous-utf16be.txt", bytes);
+
+        ConversionPlan plan = Plan();
+        PlannedFile refused = Assert.Single(plan.Files);
+
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, refused.ReasonCode);
+        Assert.True(refused.NeedsSourceChoice);
+
+        UiTest.OnStaThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+            ComboBox chooser = Assert.Single(Descendants(form).OfType<ComboBox>());
+            ListView list = Assert.Single(Descendants(form).OfType<ListView>());
+
+            Assert.Contains("utf-16", chooser.Items.Cast<string>());
+            Assert.Contains("utf-16BE", chooser.Items.Cast<string>());
+            Assert.Contains(
+                "ambiguous-utf16be.txt",
+                list.Items.Cast<ListViewItem>().Select(item => item.Text));
+            Assert.Contains("cannot safely process", AllText(form));
+        });
+    }
+
+    [Fact]
     public void SourcePickerOffersOnlyRuntimeSupportedCanonicalEncodings()
     {
         Write("ambiguous.txt", "Le café était déjà prêt", "windows-1252");
@@ -265,7 +302,7 @@ public sealed class ConversionConfirmationFormTests : IDisposable
 
             Assert.Equal("Files requiring source encoding", list.AccessibleName);
             Assert.False(string.IsNullOrWhiteSpace(list.AccessibleDescription));
-            Assert.Equal("Source encoding for selected legacy files", source.AccessibleName);
+            Assert.Equal("Source encoding for selected files", source.AccessibleName);
             Assert.False(string.IsNullOrWhiteSpace(source.AccessibleDescription));
             Assert.Equal("Confirm selected source encoding", confirmSource.AccessibleName);
             Assert.False(string.IsNullOrWhiteSpace(confirmSource.AccessibleDescription));

--- a/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionOrchestrationTests.cs
@@ -124,8 +124,11 @@ public sealed class ConversionOrchestrationTests : IDisposable
         List<ConversionReportEntry> entries = View();
 
         // Replace the bytes after View but before conversion planning. The plan must use
-        // the new big-endian interpretation and its matching hash, not View's old label.
-        File.WriteAllBytes(path, new UnicodeEncoding(true, false).GetBytes(text));
+        // the new BOM-confirmed big-endian interpretation and its matching hash, not
+        // View's old label. The BOM is intentional: this test proves snapshot binding,
+        // while BOM-less byte-order ambiguity is covered by BomlessUtf16SafetyTests.
+        var utf16Be = new UnicodeEncoding(true, true);
+        File.WriteAllBytes(path, [.. utf16Be.GetPreamble(), .. utf16Be.GetBytes(text)]);
         string replacementHash = ConversionMetadataStore.ComputeSha256(path);
 
         ConversionPlan? shown = null;
@@ -138,6 +141,7 @@ public sealed class ConversionOrchestrationTests : IDisposable
         Assert.NotNull(shown);
         PlannedFile file = Assert.Single(shown.Files);
         Assert.Equal(1201, file.SourceCodePage);
+        Assert.True(file.SourceHasBom);
         Assert.Equal(replacementHash, file.Sha256);
         Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
         Assert.Equal(text, Encoding.UTF8.GetString(File.ReadAllBytes(path)));
@@ -184,6 +188,50 @@ public sealed class ConversionOrchestrationTests : IDisposable
 
         Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
         Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ExplicitUtf16Choice_ResolvesAnAmbiguousBomlessUtf16Refusal()
+    {
+        // The first plan must refuse because automatic detection cannot prove the byte
+        // order. Choosing UTF-16BE then rebuilds that same file as an explicit source;
+        // strict decoding and output verification still decide whether it can be written.
+        string text = string.Concat(Enumerable.Repeat("\u4100\u0A00\u4200", 20));
+        byte[] original = new UnicodeEncoding(
+            bigEndian: true,
+            byteOrderMark: false,
+            throwOnInvalidBytes: true).GetBytes(text);
+        string path = Path.Combine(_root, "ambiguous-utf16be.txt");
+        File.WriteAllBytes(path, original);
+
+        var plansShown = new List<ConversionPlan>();
+        var answered = false;
+
+        OrchestrationResult result = Convert(View(), plan =>
+        {
+            plansShown.Add(plan);
+
+            if (answered)
+                return ConfirmationResponse.Proceed;
+
+            answered = true;
+            return new ConfirmationResponse(
+                ConfirmationChoice.ChooseSourceEncoding, "utf-16be", [path]);
+        }, backup: true);
+
+        PlannedFile first = Assert.Single(plansShown[0].Files);
+        PlannedFile resolved = Assert.Single(plansShown[1].Files);
+
+        Assert.Equal(PlannedAction.Refuse, first.Action);
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, first.ReasonCode);
+        Assert.True(first.NeedsSourceChoice);
+        Assert.Equal(PlannedAction.Convert, resolved.Action);
+        Assert.Equal("utf-16be", resolved.SourceEncoding);
+        Assert.True(resolved.SourceWasSpecified);
+        Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
+        Assert.Equal(text, Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+        Assert.Equal(original, File.ReadAllBytes(path + ".bak"));
+        Assert.True(File.Exists(ConversionMetadataStore.MetadataPathFor(path)));
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -626,7 +626,7 @@ public sealed class ConversionPlanTests : IDisposable
             Line("Will convert:")
             + Line("Already in target encoding:")
             + Line("Encoding not identified:")
-            + Line("Needs legacy source choice:")
+            + Line("Needs source choice:")
             + Line("Refused, unreadable:"));
 
         Assert.Equal(plan.Files.Count, Line("Selected:"));

--- a/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
@@ -144,6 +144,7 @@ public sealed class ConversionPolicyTests : IDisposable
             "utf-16le", targetHasBom: false,
             sourceWasSpecified: false, isUnicodeOrAscii: false,
             explicitSourceConflictsWithReliableDetection: false,
+            automaticBomlessUtf16IsAmbiguous: false,
             out SourceInterpretation interpretation, out string? reason);
 
         Assert.Equal(PlannedAction.Refuse, action);
@@ -161,6 +162,7 @@ public sealed class ConversionPolicyTests : IDisposable
             "utf-16le", targetHasBom: false,
             sourceWasSpecified: false, isUnicodeOrAscii: true,
             explicitSourceConflictsWithReliableDetection: false,
+            automaticBomlessUtf16IsAmbiguous: false,
             out SourceInterpretation automatic, out _));
         Assert.Equal(SourceInterpretation.AutomaticUnicodeOrAscii, automatic);
 
@@ -171,6 +173,7 @@ public sealed class ConversionPolicyTests : IDisposable
             "utf-8", targetHasBom: false,
             sourceWasSpecified: true, isUnicodeOrAscii: false,
             explicitSourceConflictsWithReliableDetection: false,
+            automaticBomlessUtf16IsAmbiguous: false,
             out SourceInterpretation explicitSource, out _));
         Assert.Equal(SourceInterpretation.ExplicitSource, explicitSource);
     }
@@ -187,6 +190,7 @@ public sealed class ConversionPolicyTests : IDisposable
                 "utf-8", targetHasBom: false,
                 sourceWasSpecified: false, isUnicodeOrAscii: true,
                 explicitSourceConflictsWithReliableDetection: false,
+                automaticBomlessUtf16IsAmbiguous: false,
                 out SourceInterpretation interpretation, out _));
         Assert.Equal(SourceInterpretation.NotApplicable, interpretation);
     }
@@ -203,6 +207,7 @@ public sealed class ConversionPolicyTests : IDisposable
                 "utf-8", targetHasBom: false,
                 sourceWasSpecified: false, isUnicodeOrAscii: false,
                 explicitSourceConflictsWithReliableDetection: false,
+                automaticBomlessUtf16IsAmbiguous: false,
                 out SourceInterpretation interpretation, out _));
         Assert.Equal(SourceInterpretation.NotApplicable, interpretation);
 

--- a/sources/EncodingChecker.Tests/ExitCodeContractTests.cs
+++ b/sources/EncodingChecker.Tests/ExitCodeContractTests.cs
@@ -72,6 +72,28 @@ public sealed class ExitCodeContractTests : IDisposable
     }
 
     [Fact]
+    public void Version_PrintsTheAssemblyVersionAndExitsZero()
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            using var output = new StringWriter();
+            Console.SetOut(output);
+            Console.SetError(new StringWriter());
+
+            Assert.Equal(ExpectedClean, Program.RunConsoleMode(["--version"]));
+            Assert.Equal(Program.GetDisplayVersion() + Environment.NewLine, output.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
     public void CleanDetectOnlyRun_ExitsZero()
     {
         WriteAscii("a.txt", "hello");

--- a/sources/EncodingChecker/BomlessUnicodeSafety.cs
+++ b/sources/EncodingChecker/BomlessUnicodeSafety.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace EncodingChecker;
+
+/// <summary>
+/// Prevents automatic conversion when BOM-less UTF-16 byte order cannot be
+/// established from the bytes alone.
+/// </summary>
+internal static class BomlessUnicodeSafety
+{
+    internal const string AmbiguousReasonCode = "AmbiguousBomlessUtf16";
+
+    /// <summary>
+    /// Returns true when the detected BOM-less UTF-16 bytes also strictly
+    /// decode under the opposite byte order.
+    /// </summary>
+    /// <remarks>
+    /// Detection may prefer one order, but that preference is not enough to
+    /// justify rewriting a file when both orders accept the complete source.
+    /// </remarks>
+    internal static bool IsAmbiguous(
+        Stream source,
+        Encoding? detectedEncoding,
+        bool detectedHasBom)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (detectedHasBom || detectedEncoding?.CodePage is not (1200 or 1201))
+            return false;
+
+        int oppositeCodePage = detectedEncoding.CodePage == 1200 ? 1201 : 1200;
+        Encoding opposite = Encoding.GetEncoding(
+            oppositeCodePage,
+            EncoderFallback.ExceptionFallback,
+            DecoderFallback.ExceptionFallback);
+
+        return StrictFileValidation.TryValidateStream(source, opposite, out _);
+    }
+
+    /// <summary>Builds the actionable explanation shared by reports and the GUI.</summary>
+    internal static string DescribeRefusal(Encoding detectedEncoding)
+    {
+        ArgumentNullException.ThrowIfNull(detectedEncoding);
+
+        string detectedName = detectedEncoding.CodePage == 1200
+            ? "UTF-16LE"
+            : "UTF-16BE";
+        string oppositeName = detectedEncoding.CodePage == 1200
+            ? "UTF-16BE"
+            : "UTF-16LE";
+
+        return $"EC detected BOM-less {detectedName}, but the same bytes are valid as both "
+               + $"{detectedName} and {oppositeName}. EC cannot determine the byte order "
+               + "safely, so no conversion was performed. Add a byte-order mark or choose "
+               + $"the source encoding explicitly (for example, -From {detectedEncoding.WebName}).";
+    }
+}

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -14,8 +14,8 @@ namespace EncodingChecker;
 /// Displays the conversion plan already decided by policy. The same entries are
 /// converted; no second detection pass can produce a different answer.
 /// <para>
-/// Unicode and ASCII detections can be converted automatically. Detected legacy text
-/// requires an explicit source choice, which never bypasses conversion safety checks.
+/// Files that EC cannot identify safely need an explicit source choice, which never
+/// bypasses conversion safety checks.
 /// </para>
 /// </remarks>
 internal sealed class ConversionConfirmationForm : Form
@@ -145,7 +145,7 @@ internal sealed class ConversionConfirmationForm : Form
             ("Directory", _plan.BaseDirectory),
             ("Source encoding",
              string.IsNullOrEmpty(_plan.ExplicitSourceEncoding)
-                 ? "Unicode and ASCII are automatic; legacy text needs your choice"
+                 ? "EC converts automatically only when it can identify the source safely"
                  : $"{_plan.ExplicitSourceEncoding} (chosen by you; strict checks still apply)"),
             ("Backups", _plan.BackupEnabled
                 ? "enabled — original as <file>.bak; record as <file>.ecmeta.json"
@@ -178,7 +178,7 @@ internal sealed class ConversionConfirmationForm : Form
             ForeColor = Color.FromArgb(150, 40, 0),
             Text =
                 $@"{refused.Count} file(s) require their source encoding to be identified or confirmed. "
-                + @"Encoding Checker detected legacy text, but cannot safely process these files until you specify or confirm their original encoding."
+                + @"Encoding Checker cannot safely process these files until you specify or confirm their original encoding."
                 + Environment.NewLine + Environment.NewLine
                 + @"Select only files that use the same source encoding, then choose or confirm that encoding. "
                 + @"Leave files with a different or unknown encoding unchecked; you can review them later.",
@@ -230,7 +230,7 @@ internal sealed class ConversionConfirmationForm : Form
         });
 
         _sourceChoice.DropDownStyle = ComboBoxStyle.DropDownList;
-        _sourceChoice.AccessibleName = "Source encoding for selected legacy files";
+        _sourceChoice.AccessibleName = "Source encoding for selected files";
         _sourceChoice.AccessibleDescription = "Choose the original encoding for the ticked files.";
         _sourceChoice.Width = 235;
         _sourceChoice.Items.Add("Choose or confirm source encoding…");

--- a/sources/EncodingChecker/ConversionDecision.cs
+++ b/sources/EncodingChecker/ConversionDecision.cs
@@ -5,7 +5,7 @@ namespace EncodingChecker;
 /// </summary>
 /// <remarks>
 /// This replaces the former candidate/ambiguity model. EC automatically converts only
-/// Unicode and ASCII; legacy text needs the user's explicit source choice.
+/// sources EC can identify safely; other files need the user's explicit source choice.
 /// </remarks>
 internal enum SourceInterpretation
 {

--- a/sources/EncodingChecker/ConversionOrchestrator.cs
+++ b/sources/EncodingChecker/ConversionOrchestrator.cs
@@ -286,7 +286,8 @@ internal sealed class ConversionOrchestrator
         foreach (ConversionReportEntry entry in entries)
         {
             if (entry.Action != PlannedAction.Refuse ||
-                entry.SourceInterpretation != SourceInterpretation.LegacyNeedsSourceChoice)
+                !ConversionPolicy.RequiresExplicitSourceChoice(
+                    entry.SourceInterpretation, entry.ReasonCode))
                 continue;
 
             if (scope is not null && !scope.Contains(entry.FilePath))

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -37,11 +37,11 @@ internal sealed record ConversionSemantics
     /// <summary>
     /// Changes only when the meaning of an existing plan's decisions changes.
     /// </summary>
-    internal const int Current = 4;
+    internal const int Current = 5;
 
     /// <summary>The guarantees of <see cref="Current"/> shown to the reader.</summary>
     internal const string Describes =
-        "source-bound detection, strict codecs, verified output, atomic install, explicit source required for legacy text";
+        "source-bound detection, strict codecs, verified output, atomic install, explicit source required for legacy text, proven BOM-less UTF-16 byte order";
 
     /// <summary>Malformed input is rejected rather than replaced.</summary>
     public bool StrictDecoding { get; init; } = true;
@@ -112,7 +112,8 @@ internal sealed record PlannedFile
 
     /// <summary>Whether automatic conversion needs the user to name the source codec.</summary>
     public bool NeedsSourceChoice =>
-        SourceInterpretation == SourceInterpretation.LegacyNeedsSourceChoice;
+        Action == PlannedAction.Refuse &&
+        ConversionPolicy.RequiresExplicitSourceChoice(SourceInterpretation, ReasonCode);
 }
 
 /// <summary>
@@ -456,7 +457,7 @@ internal sealed record ConversionPlan
             $"Will convert:                 {summary.ReadyToConvert}",
             $"Already in target encoding:   {summary.AlreadyTarget}",
             $"Encoding not identified:      {summary.NotIdentified}",
-            $"Needs legacy source choice:   {summary.NeedsSourceChoice}",
+            $"Needs source choice:          {summary.NeedsSourceChoice}",
             $"Refused, unreadable:          {summary.OtherRefusals}",
             string.Empty,
             $"Directory:                    {BaseDirectory}",

--- a/sources/EncodingChecker/ConversionPolicy.cs
+++ b/sources/EncodingChecker/ConversionPolicy.cs
@@ -25,6 +25,9 @@ internal static class ConversionPolicy
     /// <param name="sourceWasSpecified">Whether the source encoding was explicitly specified by the user.</param>
     /// <param name="isUnicodeOrAscii">Whether the source encoding is Unicode or ASCII.</param>
     /// <param name="explicitSourceConflictsWithReliableDetection">Whether the explicitly specified source encoding conflicts with reliable detection.</param>
+    /// <param name="automaticBomlessUtf16IsAmbiguous">
+    /// Whether automatic BOM-less UTF-16 detection is valid under both byte orders.
+    /// </param>
     /// <returns>The planned action for the file.</returns>
     internal static PlannedAction Decide(
         string sourceCharset,
@@ -34,6 +37,7 @@ internal static class ConversionPolicy
         bool sourceWasSpecified,
         bool isUnicodeOrAscii,
         bool explicitSourceConflictsWithReliableDetection,
+        bool automaticBomlessUtf16IsAmbiguous,
         out SourceInterpretation sourceInterpretation,
         out string? reason)
     {
@@ -60,6 +64,14 @@ internal static class ConversionPolicy
             sourceInterpretation = SourceInterpretation.ExplicitSource;
             reason = "The selected source encoding conflicts with EC's reliable Unicode "
                      + "or ASCII detection and could change the text. No conversion was performed.";
+            return PlannedAction.Refuse;
+        }
+
+        if (!sourceWasSpecified && automaticBomlessUtf16IsAmbiguous)
+        {
+            sourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii;
+            reason = "BOM-less UTF-16 needs a byte order that the bytes do not prove. "
+                     + "Choose the original source encoding explicitly before converting.";
             return PlannedAction.Refuse;
         }
 
@@ -91,4 +103,17 @@ internal static class ConversionPolicy
         PlannedAction.Refuse => ConversionRowResult.Refused,
         _ => ConversionRowResult.Converted,
     };
+
+    /// <summary>
+    /// Whether a refusal can be resolved by the user identifying the original source
+    /// encoding. Kept here so the GUI, plans, and CLI describe the same policy.
+    /// </summary>
+    internal static bool RequiresExplicitSourceChoice(
+        SourceInterpretation? sourceInterpretation,
+        string? reasonCode) =>
+        sourceInterpretation == SourceInterpretation.LegacyNeedsSourceChoice ||
+        string.Equals(
+            reasonCode,
+            ConversionReasonCodes.AmbiguousBomlessUtf16,
+            StringComparison.Ordinal);
 }

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -70,6 +70,12 @@ internal sealed class ConversionReportEntry
     internal bool DetectedEncodingHasBom { get; set; }
 
     /// <summary>
+    /// Whether a detected BOM-less UTF-16 source also strictly decodes under the opposite
+    /// byte order. Internal planning state; not in CSV.
+    /// </summary>
+    internal bool HasAmbiguousBomlessUtf16 { get; set; }
+
+    /// <summary>
     /// The SHA-256 this file must still have when installed, or <see langword="null"/>
     /// when no plan has committed to its contents. Internal state; not in CSV.
     /// </summary>
@@ -155,6 +161,7 @@ internal static class ConversionReasonCodes
         nameof(ExplicitSourceConflictsWithDetection);
     internal const string ExplicitSourceDiffersFromBomlessUnicodeEstimate =
         nameof(ExplicitSourceDiffersFromBomlessUnicodeEstimate);
+    internal const string AmbiguousBomlessUtf16 = BomlessUnicodeSafety.AmbiguousReasonCode;
     internal const string StrictValidationFailed = nameof(StrictValidationFailed);
     internal const string SourceSnapshotFailed = nameof(SourceSnapshotFailed);
     internal const string BackupFailed = nameof(BackupFailed);

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -165,6 +165,12 @@ internal static partial class Program
     // Internal so tests can pin the published CLI exit-code contract.
     internal static int RunConsoleMode(string[] args)
     {
+        if (args is ["--version"])
+        {
+            Console.Out.WriteLine(GetDisplayVersion());
+            return 0;
+        }
+
         if (args is ["/?" or "-?" or "/h" or "-h" or "--help"])
         {
             Console.Out.WriteLine(UsageText);

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -116,18 +116,32 @@ internal static partial class Program
         internal bool Verbose;
     }
 
-    private const string UsageText = """
-        EncodingChecker v3.9.2
+    /// <summary>
+    /// Returns the release version embedded in the built assembly.
+    /// Keeping this here makes the banner and <c>--version</c> agree with the
+    /// executable that is actually running.
+    /// </summary>
+    internal static string GetDisplayVersion()
+    {
+        Version version =
+            typeof(Program).Assembly.GetName().Version ??
+            new Version(0, 0, 0);
+
+        return $"{version.Major}.{version.Minor}.{Math.Max(version.Build, 0)}";
+    }
+
+    private static readonly string UsageText = $"""
+        EncodingChecker v{GetDisplayVersion()}
 
         Common commands:
 
-          Preview a folder safely (recommended first use):
+          Create a reviewable plan for an important batch (safest workflow):
             EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Plan plan.json
 
           Review that plan, then apply exactly it:
             EncodingChecker.exe -Apply plan.json
 
-          Convert a folder directly, keeping each original:
+          Convert an ordinary folder directly, keeping each original:
             EncodingChecker.exe -BasePath "C:\Files" -Target utf-8 -Backup
 
           Convert files whose original legacy encoding you know:
@@ -138,9 +152,10 @@ internal static partial class Program
 
         Automatic conversion rule:
 
-          EC converts Unicode and ASCII automatically. For legacy text, specify its
-          original encoding with -From. This replaces detection only; strict decoding,
-          output verification, backups, and atomic installation still apply.
+          EC converts ASCII, Unicode with a BOM, and text it can prove from its bytes.
+          Legacy text and BOM-less Unicode that cannot be proven safely are left
+          unchanged until you specify the original encoding with -From. That choice
+          does not bypass strict decoding, output verification, backups, or installation.
 
         Basic conversion:
 
@@ -206,7 +221,7 @@ internal static partial class Program
         reparse-point folders are not entered. Both counts are reported on stderr
         and are informational; they do not change the exit code.
 
-        Help: -?, /?, -h, /h, or --help.
+        Help: -?, /?, -h, /h, or --help. Version: --version.
 
         Exit codes: 0 = completed; 1 = invalid command; 2 = -FailOnChanges;
         3 = processing, plan, or report failure; 4 = cancelled (Ctrl+C);

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.2.0")]
-[assembly: AssemblyFileVersion("3.9.2.0")]
+[assembly: AssemblyVersion("3.10.0.0")]
+[assembly: AssemblyFileVersion("3.10.0.0")]

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -349,6 +349,7 @@ internal static class ScanEngine
                     entry.DetectedEncodingLabel = snapshot.DetectedEncoding?.WebName;
                     entry.DetectedEncodingHasBom = snapshot.DetectedEncodingHasBom;
                     entry.HasReliableUnicodeDetection = snapshot.HasReliableUnicodeDetection;
+                    entry.HasAmbiguousBomlessUtf16 = snapshot.HasAmbiguousBomlessUtf16;
                     entry.ExpectedSourceSha256 = snapshot.Sha256;
                     entry.ExpectedSourceSize = snapshot.Size;
                     entry.Action = snapshot.SourceEncoding is null
@@ -433,6 +434,7 @@ internal static class ScanEngine
         Encoding? automaticallyDetected = null;
         bool hasReliableUnicodeDetection = false;
         bool snapshotDetectedHasBom = false;
+        bool snapshotHasAmbiguousBomlessUtf16 = false;
         bool hasBom;
         string? sourceSha256 = null;
         long? sourceSize = null;
@@ -447,6 +449,7 @@ internal static class ScanEngine
             automaticallyDetected = snapshot.DetectedEncoding;
             hasReliableUnicodeDetection = snapshot.HasReliableUnicodeDetection;
             snapshotDetectedHasBom = snapshot.DetectedEncodingHasBom;
+            snapshotHasAmbiguousBomlessUtf16 = snapshot.HasAmbiguousBomlessUtf16;
             hasBom = snapshot.HasBom;
             sourceSha256 = snapshot.Sha256;
             sourceSize = snapshot.Size;
@@ -487,6 +490,8 @@ internal static class ScanEngine
                 hasReliableUnicodeDetection,
             DetectedEncodingHasBom = options.Action == ScanAction.Convert &&
                 snapshotDetectedHasBom,
+            HasAmbiguousBomlessUtf16 = options.Action == ScanAction.Convert &&
+                snapshotHasAmbiguousBomlessUtf16,
         };
 
         if (options.Action == ScanAction.Convert)
@@ -573,6 +578,7 @@ internal static class ScanEngine
         Encoding? SourceEncoding,
         bool HasReliableUnicodeDetection,
         bool DetectedEncodingHasBom,
+        bool HasAmbiguousBomlessUtf16,
         bool HasBom,
         string Sha256,
         long Size);
@@ -614,13 +620,15 @@ internal static class ScanEngine
         bool detectedHasBom = detectedEncoding != null && HasPreamble(stream, detectedEncoding);
         bool hasReliableUnicodeDetection = IsReliablyDetectedUnicode(
             stream, detectedEncoding, detectedHasBom);
+        bool hasAmbiguousBomlessUtf16 = BomlessUnicodeSafety.IsAmbiguous(
+            stream, detectedEncoding, detectedHasBom);
 
         stream.Position = 0;
         string hash = Convert.ToHexStringLower(SHA256.HashData(stream));
 
         return new SourceSnapshot(
             detectedEncoding, sourceEncoding, hasReliableUnicodeDetection,
-            detectedHasBom, hasBom, hash, stream.Length);
+            detectedHasBom, hasAmbiguousBomlessUtf16, hasBom, hash, stream.Length);
     }
 
     private static bool IsReliablyDetectedUnicode(
@@ -641,6 +649,29 @@ internal static class ScanEngine
 
             _ => false,
         };
+    }
+
+    /// <summary>
+    /// Checks the whole current source before a direct conversion that did not receive
+    /// a source-bound planning snapshot.
+    /// </summary>
+    private static bool IsAmbiguousBomlessUtf16(
+        string path,
+        Encoding sourceEncoding,
+        bool sourceHasBom)
+    {
+        if (sourceHasBom || sourceEncoding.CodePage is not (1200 or 1201))
+            return false;
+
+        using FileStream stream = new(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            64 * 1024,
+            FileOptions.SequentialScan);
+
+        return BomlessUnicodeSafety.IsAmbiguous(stream, sourceEncoding, sourceHasBom);
     }
 
     /// <summary>
@@ -735,6 +766,15 @@ internal static class ScanEngine
         if (entry.Action is null)
             DetectionCounters.RecordClassification();
 
+        // Source snapshots normally carry this result into the reviewed plan. Recheck
+        // here as well for callers of ConvertFiles that supply entries directly.
+        bool automaticBomlessUtf16IsAmbiguous =
+            !entry.SourceEncodingWasSpecified &&
+            (entry.HasAmbiguousBomlessUtf16 || IsAmbiguousBomlessUtf16(
+                path, sourceEncoding, sourceHasBom));
+
+        entry.HasAmbiguousBomlessUtf16 = automaticBomlessUtf16IsAmbiguous;
+
         PlannedAction action = ConversionPolicy.Decide(
             sourceCharset,
             sourceHasBom,
@@ -745,6 +785,7 @@ internal static class ScanEngine
             entry.SourceEncodingWasSpecified && entry.HasReliableUnicodeDetection &&
             automaticallyDetected is not null &&
             automaticallyDetected.CodePage != sourceEncoding.CodePage,
+            automaticBomlessUtf16IsAmbiguous,
             out SourceInterpretation sourceInterpretation,
             out string? policyReason);
 
@@ -753,6 +794,8 @@ internal static class ScanEngine
         entry.ReasonCode = action switch
         {
             PlannedAction.Skip => ConversionReasonCodes.UnknownEncoding,
+            PlannedAction.Refuse when automaticBomlessUtf16IsAmbiguous =>
+                ConversionReasonCodes.AmbiguousBomlessUtf16,
             PlannedAction.Refuse => entry.SourceEncodingWasSpecified &&
                 entry.HasReliableUnicodeDetection && automaticallyDetected is not null &&
                 automaticallyDetected.CodePage != sourceEncoding.CodePage
@@ -783,7 +826,9 @@ internal static class ScanEngine
         if (action != PlannedAction.Convert)
         {
             entry.Result = ConversionPolicy.ToRowResult(action);
-            entry.Diagnostic = policyReason;
+            entry.Diagnostic = automaticBomlessUtf16IsAmbiguous
+                ? BomlessUnicodeSafety.DescribeRefusal(sourceEncoding)
+                : policyReason;
             return;
         }
 

--- a/tools/gui-smoke-test.py
+++ b/tools/gui-smoke-test.py
@@ -143,6 +143,23 @@ def snapshot(directory):
     }
 
 
+def required_setup_steps(spec):
+    """GUI preconditions a phase's assertions depend on, derived from the spec."""
+    steps = []
+
+    if spec.get("artifacts"):
+        steps.append(
+            "Ensure 'Create backup' is TICKED before converting; this phase "
+            "verifies the .bak and .ecmeta.json recovery files.")
+
+    if spec.get("no_artifacts"):
+        steps.append(
+            "Leave 'Create backup' TICKED; this phase proves nothing is written "
+            "even when backups are enabled.")
+
+    return steps
+
+
 def setup(phase):
     spec = PHASES[phase]
     directory = root(phase)
@@ -165,6 +182,15 @@ def setup(phase):
     print("\n  folder: " + directory)
     print("  files : " + ", ".join(spec["files"]))
     print("\n  in the GUI:")
+    # Derived from the spec rather than written into each phase's steps. A phase
+    # that asserts .bak and .ecmeta.json depends on the backup checkbox, which the
+    # GUI persists between sessions: phase E once failed on "missing recovery
+    # artifact" because an earlier run had left it unticked, which says nothing
+    # about the behaviour under test. Deriving it means a phase that starts
+    # asserting artifacts cannot forget to ask for them.
+    for step in required_setup_steps(spec):
+        print("    " + step)
+
     for step in spec["steps"]:
         print("    " + step)
     print("\n  PowerShell commands to copy and paste after the GUI steps:")

--- a/tools/gui-smoke-test.py
+++ b/tools/gui-smoke-test.py
@@ -22,6 +22,10 @@ JP = ("こんにちは世界。日本語のテキストです。", "shift_jis")
 RUSSIAN = ("Привет мир, это русский текст", "koi8-r")
 PLAIN = ("plain ascii, no high bytes at all", "ascii")
 
+# UTF-16BE text whose byte-swapped UTF-16LE reading is ordinary-looking A/LF/B.
+# Both byte orders strictly decode, so automatic conversion must be refused.
+AMBIGUOUS_UTF16_BE = ("\u4100\u0a00\u4200" * 4, "utf-16-be")
+
 # Deliberately carries 0x80.  In windows-1252 that is the euro sign; in iso-8859-1 it is
 # a C1 control.  It proves that the user's explicit choice, rather than a legacy guess,
 # controls the conversion.
@@ -80,6 +84,36 @@ PHASES = {
             },
         },
     },
+    "D": {
+        "title": "Ambiguous BOM-less UTF-16 is refused without writing",
+        "files": {"ambiguous-utf16be.txt": AMBIGUOUS_UTF16_BE},
+        "steps": [
+            "In the Release build, set 'Directory to check' to the folder shown above.",
+            "Choose utf-8 in 'Convert to', click View, tick the row, and click Convert.",
+            "The review must say that the BOM-less UTF-16 byte order cannot be proven safely.",
+            "Click Cancel. Do not choose a source encoding for this phase.",
+        ],
+        "unchanged": {
+            "ambiguous-utf16be.txt": "automatic BOM-less UTF-16 conversion was refused",
+        },
+        "no_artifacts": True,
+    },
+    "E": {
+        "title": "An explicit BOM-less UTF-16 source converts safely",
+        "files": {"ambiguous-utf16be.txt": AMBIGUOUS_UTF16_BE},
+        "steps": [
+            "In the Release build, set 'Directory to check' to the folder shown above.",
+            "Choose utf-8 in 'Convert to', click View, tick the row, and click Convert.",
+            "The review must refuse automatic conversion and offer a source-encoding chooser.",
+            "Choose utf-16BE and click 'Confirm for 1 file(s)'.",
+            "The refreshed review must show 1 file ready. Click 'Convert 1 file(s)'.",
+        ],
+        "converted": {"ambiguous-utf16be.txt": AMBIGUOUS_UTF16_BE[0]},
+        "artifacts": [
+            "ambiguous-utf16be.txt.bak",
+            "ambiguous-utf16be.txt.ecmeta.json",
+        ],
+    },
 }
 
 
@@ -89,6 +123,11 @@ def root(phase):
 
 def state_path(phase):
     return os.path.join(HERE, "smoke-state-" + phase + ".json")
+
+
+def powershell_quote(value):
+    """Returns a PowerShell single-quoted string for copy-and-paste instructions."""
+    return "'" + value.replace("'", "''") + "'"
 
 
 def sha256(path):
@@ -117,7 +156,10 @@ def setup(phase):
             handle.write(text.encode(encoding))
 
     with open(state_path(phase), "w", encoding="utf-8") as handle:
-        json.dump({"root": directory, "before": snapshot(directory)}, handle, indent=1)
+        json.dump(
+            {"root": directory, "before": snapshot(directory), "manual_complete": False},
+            handle,
+            indent=1)
 
     print("Phase " + phase + " - " + spec["title"])
     print("\n  folder: " + directory)
@@ -125,7 +167,31 @@ def setup(phase):
     print("\n  in the GUI:")
     for step in spec["steps"]:
         print("    " + step)
-    print("\n  then: python gui-smoke-test.py verify " + phase)
+    print("\n  PowerShell commands to copy and paste after the GUI steps:")
+    print("    $smoke = " + powershell_quote(os.path.abspath(__file__)))
+    print("    python $smoke mark " + phase)
+    print("    python $smoke verify " + phase)
+
+    next_phase = chr(ord(phase) + 1)
+    if next_phase in PHASES:
+        print("    python $smoke setup " + next_phase)
+
+    return 0
+
+
+def mark(phase):
+    """Records that the tester completed the displayed GUI steps for this phase."""
+    path = state_path(phase)
+
+    with open(path, encoding="utf-8") as handle:
+        state = json.load(handle)
+
+    state["manual_complete"] = True
+
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=1)
+
+    print("Phase " + phase + " marked ready for verification.")
     return 0
 
 
@@ -190,11 +256,25 @@ def check_text(spec, directory, ok, fail):
                 ok("%-18s %s" % (name, rule["why"]))
 
 
+def check_artifacts(spec, directory, ok, fail):
+    for name in spec.get("artifacts", []):
+        if not os.path.isfile(os.path.join(directory, name)):
+            fail(name + ": missing recovery artifact")
+        else:
+            ok("%-18s present" % name)
+
+
 def verify(phase):
     spec = PHASES[phase]
 
     with open(state_path(phase), encoding="utf-8") as handle:
         state = json.load(handle)
+
+    if not state.get("manual_complete"):
+        print("PHASE " + phase + ": NOT VERIFIED")
+        print("  Complete the displayed GUI steps first, then run:")
+        print("    python " + powershell_quote(os.path.abspath(__file__)) + " mark " + phase)
+        return 2
 
     directory = state["root"]
     before = state["before"]
@@ -210,6 +290,7 @@ def verify(phase):
     check_unchanged(spec, before, after, ok, fail)
     check_converted(spec, directory, after, ok, fail)
     check_text(spec, directory, ok, fail)
+    check_artifacts(spec, directory, ok, fail)
     if spec.get("no_artifacts"):
         strays = [
             n for n in os.listdir(directory)
@@ -234,11 +315,19 @@ def verify(phase):
 
 
 if __name__ == "__main__":
-    mode = sys.argv[1] if len(sys.argv) > 1 else "setup"
+    mode = sys.argv[1].lower() if len(sys.argv) > 1 else "setup"
     which = (sys.argv[2] if len(sys.argv) > 2 else "A").upper()
 
     if which not in PHASES:
         print("phases: " + ", ".join(PHASES))
         sys.exit(2)
 
-    sys.exit(setup(which) if mode == "setup" else verify(which))
+    if mode == "setup":
+        sys.exit(setup(which))
+    if mode == "mark":
+        sys.exit(mark(which))
+    if mode == "verify":
+        sys.exit(verify(which))
+
+    print("commands: setup, mark, verify")
+    sys.exit(2)


### PR DESCRIPTION
## The problem

Without a byte-order mark, UTF-16 bytes usually decode as valid text in **both** byte orders, so the file cannot say which is right. Detection still reports a preference — but a preference is not evidence, and acting on it silently rewrites a file as characters its author never wrote.

EC's own content verification cannot catch this. It decodes the source and re-encodes through the same chosen codec, so both sides agree on the wrong reading and the digests match perfectly.

## The change

Conversion is refused when the opposite byte order also strictly decodes the complete file — reason code `AmbiguousBomlessUtf16`, exit code `5`. The check runs **before** `-WhatIf` reports the file as convertible and before any metadata capture, backup, or write.

Where the opposite byte order is structurally impossible, the byte order is proven from the bytes and conversion proceeds exactly as before.

## The refusal is answerable, not final

`RequiresExplicitSourceChoice` now covers this reason code alongside legacy text, so the **GUI's existing source chooser offers `utf-16le` and `utf-16be`** for these files, and the CLI resolves them with `-From`. This closes the gap where the README promised to "ask you to choose the original encoding" but the chooser only appeared for legacy refusals.

An explicit choice replaces detection only. Strict decoding, output verification, backup verification and atomic installation all still apply.

## Also in this release

- `--version` reads the assembly rather than a literal string.
- The release workflow refuses to publish when the tag and assembly versions disagree.
- Documentation reorganised into focused pages under `docs/`, with the conversion rules stated in one place.

## Verification

**492 tests pass**, 0 warnings. Verified against the Release binary with `-Backup` enabled:

```
detected: utf-16 | BOM: No | result: Refused | AmbiguousBomlessUtf16   exit 5
sha256 before/after: 335ae236… → 335ae236…   text intact
.bak: none      .ecmeta.json: none
```

So the refusal leaves no recovery artifacts even when backups are on — which matters, because a `.bak` beside an unchanged source would be a confusing artifact of a conversion that never happened.

The shared detector is untouched: `UnicodeDetector.cs` and `TextValidation.cs` are byte-identical, so parity with LineEndingNormalizer and CorpusTesters is unaffected.

## Still outstanding before tagging

- Manual GUI smoke phases D and E (staged; the automated orchestration test covers the same path, but not the WinForms interaction).
- Four-corpus audit from the merged commit — required, since this changes conversion policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)