### PR TITLE
Warn when an explicit source answers an unprovable byte order

### DIFF
--- a/sources/EncodingChecker.Tests/BomlessUtf16SafetyTests.cs
+++ b/sources/EncodingChecker.Tests/BomlessUtf16SafetyTests.cs
@@ -118,6 +118,72 @@ public sealed class BomlessUtf16SafetyTests : IDisposable
     }
 
     [Fact]
+    public void ExplicitSourceMatchingTheEstimate_IsStillReportedAsUnprovable()
+    {
+        // The case that shipped silent. Detection prefers little-endian for these
+        // bytes and is wrong; a caller who repeats that guess destroys the file. EC
+        // had already refused it as unprovable, so it holds the one fact that would
+        // warn them - and reported nothing, because the choice agreed with the guess.
+        // Agreeing with an estimate EC cannot prove is not corroboration.
+        string authoritativeText = string.Concat(
+            Enumerable.Repeat("䄀਀䈀", 20));
+        var utf16Be = new UnicodeEncoding(
+            bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: true);
+
+        ConversionReportEntry entry = Convert(
+            "matches-estimate.txt",
+            utf16Be.GetBytes(authoritativeText),
+            sourceEncoding: "utf-16");
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.Equal(
+            ConversionReasonCodes.ExplicitSourceOnUnprovableBomlessUnicode,
+            entry.ReasonCode);
+        Assert.Contains("could not be established", entry.Diagnostic);
+        Assert.Contains("taken on trust", entry.Diagnostic);
+    }
+
+    [Fact]
+    public void ExplicitSourceContradictingTheEstimate_KeepsItsOwnReasonCode()
+    {
+        // The two situations must stay distinguishable in the machine-readable field:
+        // one caller contradicted a guess, the other repeated it, and a script reading
+        // reports should be able to tell which.
+        string authoritativeText = string.Concat(
+            Enumerable.Repeat("䄀਀䈀", 20));
+        var utf16Be = new UnicodeEncoding(
+            bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: true);
+
+        ConversionReportEntry entry = Convert(
+            "differs-from-estimate.txt",
+            utf16Be.GetBytes(authoritativeText),
+            sourceEncoding: "utf-16BE");
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.Equal(
+            ConversionReasonCodes.ExplicitSourceDiffersFromBomlessUnicodeEstimate,
+            entry.ReasonCode);
+    }
+
+    [Fact]
+    public void ExplicitSourceOnAProvableFile_IsNotReported()
+    {
+        // The advisory must not fire for every explicit UTF-16 choice, only where the
+        // byte order could not be established. U+00D8 byte-swaps to an unpaired
+        // surrogate, so big-endian is structurally impossible and the order is proven.
+        var utf16Le = new UnicodeEncoding(
+            bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: true);
+
+        ConversionReportEntry entry = Convert(
+            "provable.txt",
+            utf16Le.GetBytes("Øhello world, this is provable little-endian"),
+            sourceEncoding: "utf-16");
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.Null(entry.ReasonCode);
+    }
+
+    [Fact]
     public void ExplicitUtf16SourceResolvesAnAmbiguousFileButKeepsEveryOtherSafetyCheck()
     {
         string authoritativeText = string.Concat(

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -161,6 +161,15 @@ internal static class ConversionReasonCodes
         nameof(ExplicitSourceConflictsWithDetection);
     internal const string ExplicitSourceDiffersFromBomlessUnicodeEstimate =
         nameof(ExplicitSourceDiffersFromBomlessUnicodeEstimate);
+    /// <summary>
+    /// An explicit source was supplied for a file whose BOM-less UTF-16/32 byte order
+    /// could not be established from its bytes, and it agrees with EC's estimate.
+    /// Distinct from <see cref="ExplicitSourceDiffersFromBomlessUnicodeEstimate"/>:
+    /// agreeing with an estimate EC has already declared unprovable is not evidence,
+    /// so the caller is told the order was taken on trust either way.
+    /// </summary>
+    internal const string ExplicitSourceOnUnprovableBomlessUnicode =
+        nameof(ExplicitSourceOnUnprovableBomlessUnicode);
     internal const string AmbiguousBomlessUtf16 = BomlessUnicodeSafety.AmbiguousReasonCode;
     internal const string StrictValidationFailed = nameof(StrictValidationFailed);
     internal const string SourceSnapshotFailed = nameof(SourceSnapshotFailed);

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -766,14 +766,34 @@ internal static class ScanEngine
         if (entry.Action is null)
             DetectionCounters.RecordClassification();
 
-        // Source snapshots normally carry this result into the reviewed plan. Recheck
-        // here as well for callers of ConvertFiles that supply entries directly.
-        bool automaticBomlessUtf16IsAmbiguous =
-            !entry.SourceEncodingWasSpecified &&
-            (entry.HasAmbiguousBomlessUtf16 || IsAmbiguousBomlessUtf16(
-                path, sourceEncoding, sourceHasBom));
+        // Whether this file's byte order can be established from its bytes is a fact
+        // about the file, not a decision about what to do. Folding the two together
+        // erased the fact whenever a source was supplied: the entry then reached the
+        // advisory below with nothing left to consult but detection's own estimate,
+        // which is the very thing an ambiguous file proves nothing about.
+        //
+        // Source snapshots normally carry this in. Recheck for callers of ConvertFiles
+        // that supply entries directly, testing what detection saw - with an explicit
+        // source, sourceEncoding is the answer being offered, not evidence about the
+        // file, and asking it would always answer no.
+        Encoding? bomlessCandidate = entry.SourceEncodingWasSpecified
+            ? automaticallyDetected
+            : sourceEncoding;
 
-        entry.HasAmbiguousBomlessUtf16 = automaticBomlessUtf16IsAmbiguous;
+        bool candidateHasBom = entry.SourceEncodingWasSpecified
+            ? entry.DetectedEncodingHasBom
+            : sourceHasBom;
+
+        bool bomlessUtf16IsAmbiguous =
+            entry.HasAmbiguousBomlessUtf16 ||
+            (bomlessCandidate is not null && IsAmbiguousBomlessUtf16(
+                path, bomlessCandidate, candidateHasBom));
+
+        entry.HasAmbiguousBomlessUtf16 = bomlessUtf16IsAmbiguous;
+
+        // The decision: refuse automatically only when nobody has supplied an answer.
+        bool automaticBomlessUtf16IsAmbiguous =
+            !entry.SourceEncodingWasSpecified && bomlessUtf16IsAmbiguous;
 
         PlannedAction action = ConversionPolicy.Decide(
             sourceCharset,
@@ -808,19 +828,33 @@ internal static class ScanEngine
         // The optional BOM-less Unicode advisory below is added back for this pass.
         entry.Diagnostic = null;
 
+        // Reported whether or not the choice matches detection's estimate. Matching an
+        // estimate EC cannot prove is not corroboration, and staying silent for it left
+        // the one case most likely to be wrong - the caller repeating a wrong guess -
+        // indistinguishable from an ordinary conversion.
         if (action == PlannedAction.Convert &&
             entry.SourceEncodingWasSpecified &&
             automaticallyDetected is not null &&
             IsUtf16OrUtf32(automaticallyDetected) &&
             !entry.DetectedEncodingHasBom &&
-            automaticallyDetected.CodePage != sourceEncoding.CodePage)
+            (bomlessUtf16IsAmbiguous ||
+             automaticallyDetected.CodePage != sourceEncoding.CodePage))
         {
-            entry.ReasonCode =
-                ConversionReasonCodes.ExplicitSourceDiffersFromBomlessUnicodeEstimate;
-            entry.Diagnostic =
-                $"EC estimated BOM-less {automaticallyDetected.WebName}, but you selected "
-                + $"{sourceEncoding.WebName}. BOM-less Unicode can be ambiguous, so EC used "
-                + "your explicit selection and kept all strict conversion checks enabled.";
+            bool matchesEstimate =
+                automaticallyDetected.CodePage == sourceEncoding.CodePage;
+
+            entry.ReasonCode = matchesEstimate
+                ? ConversionReasonCodes.ExplicitSourceOnUnprovableBomlessUnicode
+                : ConversionReasonCodes.ExplicitSourceDiffersFromBomlessUnicodeEstimate;
+
+            entry.Diagnostic = matchesEstimate
+                ? $"This file's BOM-less {sourceEncoding.WebName} byte order could not be "
+                  + "established from its bytes. Your selection matches EC's estimate, but "
+                  + "that estimate is not evidence, so the order was taken on trust. EC kept "
+                  + "all strict conversion checks enabled."
+                : $"EC estimated BOM-less {automaticallyDetected.WebName}, but you selected "
+                  + $"{sourceEncoding.WebName}. BOM-less Unicode can be ambiguous, so EC used "
+                  + "your explicit selection and kept all strict conversion checks enabled.";
         }
 
         if (action != PlannedAction.Convert)


### PR DESCRIPTION
v3.10.0 refuses BOM-less UTF-16 whose byte order cannot be established, then lets the caller supply one. It reported that choice **only when the choice contradicted detection's estimate** — so it spoke up when the caller was right and stayed silent when they were wrong.

## Measured

On a UTF-16BE file that detection reads as little-endian:

```
-From utf-16le   Converted, no reason code, exit 0
                 䄀ਠ䈀䄀ਠ䈀…  became  A\nBA\nB…

-From utf-16be   Converted + ExplicitSourceDiffersFromBomlessUnicodeEstimate
```

The destroyed file is the silent one, and its report row is indistinguishable from an ordinary conversion.

## Cause

One variable meaning two things. `HasAmbiguousBomlessUtf16` is named for a **fact** — this file's byte order cannot be proven — but was assigned a **decision**: refuse this automatically.

```csharp
bool automaticBomlessUtf16IsAmbiguous =
    !entry.SourceEncodingWasSpecified && (...);   // decision

entry.HasAmbiguousBomlessUtf16 = automaticBomlessUtf16IsAmbiguous;   // overwrites the fact
```

Supplying a source makes the decision false, which erased the fact. Forty lines later the advisory had nothing left to consult but detection's estimate — exactly what an ambiguous file proves nothing about.

## Fix

The fact and the decision are separate. The fallback recheck tests what *detection* saw rather than the caller's answer: with `-From`, `sourceEncoding` is the answer being offered, so asking it would always reply "not ambiguous".

The advisory now fires whenever an explicit source answers an unprovable file. Matching an estimate EC cannot prove is not corroboration, so both cases are reported — under **different** reason codes, because telling a script "differs" when the caller agreed would be untrue.

`ExplicitSourceOnUnprovableBomlessUnicode` is new and additive: callers who saw an empty field now see a value. That is a shipped-behaviour change, so this likely warrants **v3.10.1** rather than a silent patch.

Unchanged and verified: refusal without `-From`, provable byte orders, BOM-carrying files, non-UTF-16 sources.

## Tests

**495 pass.** Three added: the silent case, the contradicting case keeping its own code, and a provable file staying unreported so the advisory cannot fire on every explicit UTF-16 choice.

Checked against a reintroduced bug — exactly the silent-case test fails and the other six hold.

## Why nothing caught this

The suite was green at 492 before the fix. A manual GUI smoke test, a four-corpus audit and a documented release checklist all passed. None touched the case, because the case is *"the caller supplies the same answer the detector guessed"*.

The audit could not have caught it either: it supplies `-From` from each corpus's reference codec, and those files are not ambiguous, so the path never executes. `changed=1, improved=1` was a true statement about a feature with a hole in it — worth recording as a limitation of that audit rather than reassurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)