### PR TITLE
Release v3.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.10.0
+# EncodingChecker v3.10.1
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 

--- a/docs/RELEASE-NOTES-v3.10.1.md
+++ b/docs/RELEASE-NOTES-v3.10.1.md
@@ -1,0 +1,62 @@
+# EncodingChecker v3.10.1
+
+A fix to the BOM-less UTF-16 safety introduced in v3.10.0. That release refuses
+files whose byte order cannot be established from their bytes, then lets you
+supply one. It reported your choice only when the choice contradicted EC's own
+estimate — so it spoke up when you were right and said nothing when you were
+wrong.
+
+## The defect
+
+On a UTF-16BE file that detection reads as little-endian:
+
+```text
+-From utf-16le   Converted, no reason code, exit 0
+                 the text became "A" and "B" repeated
+
+-From utf-16be   Converted, with ExplicitSourceDiffersFromBomlessUnicodeEstimate
+```
+
+The destroyed file was the silent one, and its report row was indistinguishable
+from an ordinary conversion.
+
+EC held the information that would have warned you: it had already refused the
+file as unprovable. One variable carried both that fact and the separate decision
+to refuse automatically, so supplying a source erased the fact along with the
+decision.
+
+## The fix
+
+An explicit source given for a file whose byte order could not be established is
+now always reported, whether or not it matches EC's estimate. Agreeing with an
+estimate EC cannot prove is not corroboration.
+
+The two situations keep separate reason codes, because a script told `differs`
+when the caller agreed would be told something untrue:
+
+| Reason code | Meaning |
+|---|---|
+| `ExplicitSourceOnUnprovableBomlessUnicode` | **New.** Your choice matched EC's estimate, but the byte order was never established; it was taken on trust. |
+| `ExplicitSourceDiffersFromBomlessUnicodeEstimate` | Your choice contradicted EC's estimate. Unchanged. |
+
+The new code is additive: a run that previously produced an empty reason field
+may now produce a value. Scripts matching specific codes are unaffected; a script
+asserting the field is empty will see the change.
+
+## Unchanged
+
+Refusal without an explicit source, structurally provable byte orders, files
+carrying a byte-order mark, and non-UTF-16 sources all behave exactly as in
+v3.10.0. Detection, strict decoding, output verification, backup verification and
+atomic installation are untouched.
+
+## Why v3.10.0's checks did not catch this
+
+The full suite was green, the manual GUI smoke test passed, and the four-corpus
+audit reported one improved file and no regressions. None of them reached this
+case, which is *the caller supplies the same answer the detector guessed*.
+
+The audit could not reach it: it supplies the source codec from each corpus's own
+reference metadata, and those files are not ambiguous, so the fixed path never
+executes. Its result for this release is therefore evidence about the conversion
+engine and says nothing about this fix either way.

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.10.0.0")]
-[assembly: AssemblyFileVersion("3.10.0.0")]
+[assembly: AssemblyVersion("3.10.1.0")]
+[assembly: AssemblyFileVersion("3.10.1.0")]


### PR DESCRIPTION
Version bump and notes for the BOM-less UTF-16 advisory fix already merged in #65.

A run that previously produced an empty reason field may now produce `ExplicitSourceOnUnprovableBomlessUnicode`. That is a shipped-behaviour change, so it gets its own version rather than riding the v3.10.0 tag.

## Audit

Run from a clean checkout of this commit, with both `EC_REPO` and `EC_EXE` pointed at it:

```
commit    8f373a7   worktree clean   assembly 36b923814fb92dae...
```

All four gates, in the order the release checklist now requires:

| Gate | Result |
|---|---|
| Coverage | both runs 4 corpora, 5,207 rows |
| Provenance | all four `run.json` name `8f373a7`, `dirty=False`, same assembly |
| **Integrity** | `All invariants hold across 5078 rows` — exit 0 |
| Comparison vs `rel3100` | `changed=0 improved=0 regressed=0 lateral=0` — exit 0 |

All four metrics identical to v3.10.0.

## What the audit does and does not show

`changed=0` was predicted before the run, and the reason is a limitation worth stating rather than reassurance: **the corpus cannot reach the fixed path.** It supplies each file's source codec from reference metadata, and those files are not ambiguous, so the advisory never executes during a corpus run.

So this result is evidence that the fix did not disturb the conversion engine. It says nothing about whether the fix works. That rests on the three regression tests added in #65, which were checked against a reintroduced bug.

This is also the first time `check_audit_integrity.py` has validated a *fresh* audit — every previous use was against stored runs, after the checker itself was repaired.

495 tests pass, 0 warnings. Binary reports `3.10.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)