### PR TITLE
Make saved plans binding, and every report say what actually happened

### DIFF
--- a/.github/workflows/detector-parity.yml
+++ b/.github/workflows/detector-parity.yml
@@ -1,11 +1,21 @@
 name: Shared Unicode detector parity
 
+# The detector is duplicated in three repositories and nothing but this job keeps
+# the copies honest, so it runs before a change lands as well as after, and a
+# release cannot be cut without it. Every audit record asserts parity held at the
+# tagged commit; this is what makes that assertion true rather than hopeful.
 on:
   push:
+    branches: [ master ]
+  pull_request:
     branches: [ master ]
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   parity:
@@ -27,21 +37,86 @@ jobs:
           ref: main
           path: corpus-testers
 
-      - name: Verify shared Unicode detector
+      - name: Confirm every shared source is present
         shell: pwsh
         run: |
-          $ec = Get-Content 'encoding-checker/sources/EncodingChecker/UnicodeDetector.cs' -Raw
-          $len = Get-Content 'line-ending-normalizer/UnicodeDetector.cs' -Raw
-          $corpus = Get-Content 'corpus-testers/CorpusTesting/UnicodeDetector.cs' -Raw
-          $ec = $ec -replace 'namespace EncodingChecker;', 'namespace SharedUnicodeDetector;'
-          $len = $len -replace 'namespace LineEndingNormalizer;', 'namespace SharedUnicodeDetector;'
-          $corpus = $corpus -replace 'namespace CorpusTesting;', 'namespace SharedUnicodeDetector;'
-          $ec = $ec -replace '^using System;\r?\n', ''
-          $len = $len -replace '^using System;\r?\n', ''
-          $corpus = $corpus -replace '^using System;\r?\n', ''
-          $ec = [regex]::Replace($ec, "`r?`n", "`n").TrimStart([char]0xFEFF)
-          $len = [regex]::Replace($len, "`r?`n", "`n").TrimStart([char]0xFEFF)
-          $corpus = [regex]::Replace($corpus, "`r?`n", "`n").TrimStart([char]0xFEFF)
-          if ($ec -cne $len -or $ec -cne $corpus) {
-            throw 'UnicodeDetector.cs differs between EncodingChecker, LineEndingNormalizer, and CorpusTesters. Keep the shared algorithm synchronized; application-specific TextEncoding wrappers may differ.'
+          # A comparison with nothing to compare would pass. Fail first if a path
+          # stops resolving, which is how a rename would otherwise turn this job
+          # into a rubber stamp.
+          $required = @(
+            'encoding-checker/sources/EncodingChecker/UnicodeDetector.cs',
+            'encoding-checker/sources/EncodingChecker/TextValidation.cs',
+            'line-ending-normalizer/UnicodeDetector.cs',
+            'line-ending-normalizer/TextValidation.cs',
+            'corpus-testers/CorpusTesting/UnicodeDetector.cs',
+            'corpus-testers/CorpusTesting/TextValidation.cs'
+          )
+
+          $missing = $required | Where-Object { -not (Test-Path $_) }
+
+          if ($missing) {
+            throw "Expected shared detector sources are missing: $($missing -join ', ')"
+          }
+
+      - name: Verify shared detector sources
+        shell: pwsh
+        run: |
+          # Compares the algorithm, not the file. The namespace, a leading
+          # `using System;` that only EncodingChecker needs, byte-order marks,
+          # line endings, and runs of blank lines are normalized away; anything
+          # else differing is a real divergence.
+          function Get-Normalized([string] $path, [string] $namespace) {
+            # Read as UTF-8 explicitly. These files are a mix of BOM and BOM-less,
+            # and one carries a non-ASCII character in a comment, so a host whose
+            # default is the system codepage silently mangles the BOM-less copy and
+            # reports a difference that is not in the code. A parity check for an
+            # encoding detector should not itself depend on an encoding default.
+            $text = Get-Content $path -Raw -Encoding utf8
+
+            # The byte-order mark goes next, before the `using` line. One copy begins
+            # with a BOM immediately followed by `using System;`, so stripping that
+            # line first would leave it in place wherever the mark survives the read.
+            $text = $text.TrimStart([char]0xFEFF)
+
+            $text = $text -replace "namespace $namespace;", 'namespace SharedDetector;'
+            $text = $text -replace '^using System;\r?\n', ''
+            $text = [regex]::Replace($text, "`r?`n", "`n")
+            $text = [regex]::Replace($text, "`n{3,}", "`n`n")
+            return $text.Trim()
+          }
+
+          $files = @(
+            @{ Name = 'UnicodeDetector.cs'
+               Ec   = 'encoding-checker/sources/EncodingChecker/UnicodeDetector.cs'
+               Len  = 'line-ending-normalizer/UnicodeDetector.cs'
+               Cor  = 'corpus-testers/CorpusTesting/UnicodeDetector.cs' },
+            @{ Name = 'TextValidation.cs'
+               Ec   = 'encoding-checker/sources/EncodingChecker/TextValidation.cs'
+               Len  = 'line-ending-normalizer/TextValidation.cs'
+               Cor  = 'corpus-testers/CorpusTesting/TextValidation.cs' }
+          )
+
+          $divergent = @()
+
+          foreach ($file in $files) {
+            $ec  = Get-Normalized $file.Ec  'EncodingChecker'
+            $len = Get-Normalized $file.Len 'LineEndingNormalizer'
+            $cor = Get-Normalized $file.Cor 'CorpusTesting'
+
+            $mismatch = @()
+            if ($ec -cne $len) { $mismatch += 'LineEndingNormalizer' }
+            if ($ec -cne $cor) { $mismatch += 'CorpusTesters' }
+
+            if ($mismatch.Count -gt 0) {
+              $divergent += "$($file.Name): EncodingChecker differs from $($mismatch -join ' and ')"
+            } else {
+              Write-Host "$($file.Name): identical across all three repositories"
+            }
+          }
+
+          if ($divergent.Count -gt 0) {
+            throw ("Shared detector sources have diverged:`n  " +
+                   ($divergent -join "`n  ") +
+                   "`nKeep the shared algorithm synchronized; application-specific " +
+                   "TextEncoding wrappers may differ.")
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,13 @@ permissions:
   contents: write
 
 jobs:
+  # A release must not be able to claim detector parity that was never checked at
+  # the commit being tagged.
+  parity:
+    uses: ./.github/workflows/detector-parity.yml
+
   release:
+    needs: parity
     runs-on: windows-latest
 
     env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.10.1
+# EncodingChecker v3.11.0
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -75,6 +75,12 @@ the files again. Only `-Journal`, `-Quiet`, and `-MaxParallelism` may accompany
 it. `-WhatIf`, `-Target`, `-From`, `-Backup`, and file-selection options are
 rejected with `-Apply`.
 
+`-Plan`, `-Apply`, `-Journal`, and `-Report` must use different paths. During
+`-Apply`, the journal path must not name any source file in the saved plan.
+`-Plan`, `-Journal`, and `-Report` also cannot use EC's reserved `.bak`,
+`.ecmeta.json`, or `.unicodechecker.tmp` suffixes, so command output cannot replace
+a backup or recovery artifact.
+
 ## Read-only modes
 
 | Option | Meaning |
@@ -93,11 +99,15 @@ combined with conversion options.
 |---|---|
 | `-Report <path>` | Also write the CSV report as UTF-8 with a BOM for Excel. |
 | `-Journal <path>` | Write a JSON record of the conversion decision and final result for every file. Convert mode only. |
-| `-Quiet` | Print only the final summary on standard output. |
+| `-Quiet` | Suppress per-file CSV and normal summaries. Errors and coverage warnings still go to stderr. |
 | `-Verbose` | Include error details and a result breakdown. |
 | `-MaxParallelism <N>` | Maximum simultaneous files. Default: the smaller of CPU count and 4. |
 
 `-Quiet` and `-Verbose` cannot be combined.
+
+If a GUI conversion is interrupted after writing starts, its journal records
+completed and not-attempted files separately. A command-line Ctrl+C returns
+exit code 4; command-line interruption journals are not yet guaranteed.
 
 ## Examples
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -30,11 +30,23 @@ A pattern without `/` or `\` matches file names at any depth. A pattern with a
 separator matches the path relative to `-BasePath`. `/` and `\` are equivalent.
 `*` and `?` are supported wildcards.
 
-EC always excludes its own `.bak`, `.ecmeta.json`, temporary, plan, journal,
-and report files, along with common metadata and build folders such as `.git`,
-`bin`, `obj`, and `node_modules`. Hidden, system, and reparse-point files are
-left alone. Hidden, system, and reparse-point folders are not entered. EC reports
-these coverage counts, but they do not change the exit code.
+EC always excludes files it can recognise as its own by name: `.bak` backups,
+`.ecmeta.json` recovery records, and `.unicodechecker.tmp` temporaries. It also
+excludes the plan, journal, and report files written by the current command.
+
+It does **not** exclude plans, journals, or reports left by earlier runs. You
+choose those file names, so EC cannot tell them from any other file, and a later
+conversion of the same folder will rewrite them like anything else. Keep exported
+plans, journals, and reports outside the folder you scan.
+
+Common metadata and build folders such as `.git`, `bin`, `obj`, and
+`node_modules` are skipped. Hidden, system, and reparse-point files are left
+alone, and hidden, system, and reparse-point folders are not entered.
+
+EC reports how many files each exclusion skipped, counting only files your
+patterns actually selected — so `-Include "*.bak"` reports that they were
+skipped instead of returning nothing at all. These counts do not change the
+exit code.
 
 ## Conversion
 

--- a/docs/RELEASE-NOTES-v3.11.0.md
+++ b/docs/RELEASE-NOTES-v3.11.0.md
@@ -1,0 +1,91 @@
+# EncodingChecker v3.11.0
+
+This release makes saved plans binding, improves failure reporting, and closes
+several cases where the command line or journal could describe a safer outcome
+than actually occurred.
+
+## Important compatibility changes
+
+- The plan schema changes from 4 to 5 and conversion semantics from 5 to 6.
+  Plans created by v3.10.1 or earlier are refused; create them again with
+  v3.11.0. Older plans do not contain every decision needed by this build.
+- `-Validate` now reports BOM-less UTF-16 with an unprovable byte order as
+  `Invalid`. With `-FailOnChanges`, this returns exit code 2.
+- `-Plan` now returns exit code 3 if any selected file could not be read. The
+  plan is still written so the failed file remains visible.
+- Blank values for `-Plan`, `-Apply`, `-From`, `-Journal`, `-Report`,
+  `-Include`, `-Exclude`, and `-Validate` are rejected with exit code 1.
+- `-Plan`, `-Journal`, and `-Report` cannot use EC's reserved `.bak`,
+  `.ecmeta.json`, or `.unicodechecker.tmp` suffixes. This prevents command
+  output from replacing a backup or recovery artifact, including through a
+  Windows path alias with trailing spaces or periods.
+- `-DetectOnly` with `-Target`, `-WhatIf`, or `-Backup`; `-Validate` with
+  `-WhatIf` or `-Backup`; and `-Quiet` with `-Verbose` are now rejected instead
+  of silently ignoring an option.
+- Journal readers must accept `ConvertedWithWarning`, `InstallationUnknown`,
+  and `NotAttempted`.
+
+## Plan safety
+
+The main fix prevents an applied plan from broadening a reviewed decision. A
+file recorded as `Refuse`, `Skip`, or `Unchanged` cannot later become
+`Convert` merely because the policy is evaluated again. Revalidation may only
+make a saved decision stricter.
+
+This closes a real failure in which `-Apply` converted a file that its plan had
+recorded as `Refuse`, exited successfully, and produced mojibake that ordinary
+output round-trip verification could not recognize.
+
+Plan application also now:
+
+- preserves strict full-file Unicode validation needed by source-conflict checks;
+- rejects a root or source path redirected through a reparse point;
+- reports deleted files as missing rather than as possible links;
+- binds each write to the approved source hash immediately before installation;
+- keeps unreadable, non-writing entries visible without requiring a false hash;
+- rejects plan, report, and journal path collisions, including a journal path
+  that names a planned source file.
+
+## Honest results and journals
+
+- Errors are written to stderr even with `-Quiet`.
+- Scan failures remain processing errors from planning through `-Apply`.
+- Backup failures are recorded as `Failed`, not `InstallationUnknown`.
+- Post-install failures are recorded as `ConvertedWithWarning`; genuinely
+  uncertain installation is recorded as `InstallationUnknown`.
+- Interrupted GUI runs keep a journal. Completion tracking is thread-safe, and
+  files the write pass never reached are recorded as `NotAttempted`.
+- Retrying an interrupted or failed row clears the earlier attempt's status,
+  backup path, recovery-record path, and output hash before recording the retry.
+- Every parallel conversion error updates the original result entry, keeping
+  GUI rows, CSV reports, plans, and journals consistent.
+- EC's selected backup, recovery-record, and temporary files are counted as
+  excluded coverage rather than disappearing from the result.
+
+## Command-line and GUI improvements
+
+- Invalid option combinations and empty filters fail early with actionable text.
+- The GUI counts skipped files separately from unchanged files.
+- Completed and interrupted GUI summaries use the journal's terminal outcomes,
+  so every selected file is counted exactly once.
+- Saved window bounds are restored only when part of the title bar is reachable
+  on a currently attached monitor.
+- A well-formed but damaged settings file with null values falls back to usable
+  defaults instead of preventing the GUI from opening.
+- The BOM-less Unicode advisory uses the same plain explanation in read-only,
+  review, and refusal surfaces.
+
+## Limits
+
+- Installation remains per file, not transactional across a whole batch.
+- A final hash check narrows but cannot eliminate every concurrent-write race.
+- A command-line Ctrl+C returns exit code 4, but a complete interruption journal
+  is currently guaranteed only by the GUI orchestration path.
+- Plans, journals, and reports from earlier commands are ordinary files. Keep
+  them outside the directory being scanned if they must not be processed.
+
+## Verification before release
+
+The release gate is a warning-free Release build, the complete test suite with
+no skipped tests, shared detector parity, the manual GUI smoke test, and the
+four-corpus regression audit where the changed policy is relevant.

--- a/sources/EncodingChecker.Tests/AppliedPlanFidelityTests.cs
+++ b/sources/EncodingChecker.Tests/AppliedPlanFidelityTests.cs
@@ -1,0 +1,306 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Applying a saved plan must never produce an outcome weaker than the one reviewed.
+/// </summary>
+/// <remarks>
+/// A plan is re-decided rather than replayed, so a file that became unsafe after review
+/// is still refused. That direction is deliberate. The opposite direction is the defect
+/// this fixture exists for: <c>ConvertFiles</c> re-runs the whole policy, so any input
+/// the plan schema did not carry was simply absent, and the policy answered a question
+/// it had no evidence for.
+/// <para>
+/// The measured case: a UTF-8 file converted with <c>-From windows-1252</c> is refused
+/// directly, because the explicit source contradicts a proven Unicode reading. The plan
+/// recorded that refusal. Applying it converted the file anyway, wrote mojibake that
+/// output verification structurally cannot catch (both sides decode through the same
+/// wrong codec), and exited 0 with a journal claiming the action had been Convert.
+/// </para>
+/// <para>
+/// Two independent defences are tested separately below, because either one alone would
+/// make the end-to-end test pass and hide the loss of the other.
+/// </para>
+/// </remarks>
+public sealed class AppliedPlanFidelityTests : IDisposable
+{
+    private const int ExpectedClean = 0;
+    private const int ExpectedSafeRefusal = 5;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_planfidelity_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    /// <summary>
+    /// Multibyte UTF-8 that a full strict decode confirms, so detection is reliable and
+    /// an explicit legacy source contradicts it.
+    /// </summary>
+    private string WriteReliableUtf8()
+    {
+        string path = Path.Combine(_root, "utf8.txt");
+        File.WriteAllText(path, "café naïve — déjà vu", new UTF8Encoding(false));
+
+        return path;
+    }
+
+    [Fact]
+    public void PlanThatRefusesAnExplicitSourceConflict_StillRefusesWhenApplied()
+    {
+        string path = WriteReliableUtf8();
+        byte[] original = File.ReadAllBytes(path);
+        string planPath = Path.Combine(_root, "plan.json");
+
+        // Plan mode returns 0 for a refusal by design - a refusal is an expected
+        // preflight result, not a failed preflight. The plan's own contents are the
+        // assertion that matters here.
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", _root, "-Target", "utf-8", "-From", "windows-1252",
+                "-Plan", planPath, "-Quiet"));
+
+        ConversionPlan? plan = ConversionPlan.Load(planPath, out string? loadError);
+
+        Assert.Null(loadError);
+        Assert.NotNull(plan);
+
+        PlannedFile planned = Assert.Single(plan!.Files);
+
+        Assert.Equal(PlannedAction.Refuse, planned.Action);
+        Assert.Equal(
+            ConversionReasonCodes.ExplicitSourceConflictsWithDetection,
+            planned.ReasonCode);
+
+        // The whole point: the same decision, reached again from the saved plan.
+        Assert.Equal(ExpectedSafeRefusal, Run("-Apply", planPath));
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void ThePlanCarriesTheDetectionReliabilityTheVetoDependsOn()
+    {
+        // Provenance fields alone were not enough. This one is a policy input, and
+        // leaving it out is what let the veto silently stop firing at apply time.
+        WriteReliableUtf8();
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Run("-BasePath", _root, "-Target", "utf-8", "-From", "windows-1252",
+            "-Plan", planPath, "-Quiet");
+
+        ConversionPlan plan = ConversionPlan.Load(planPath, out _)!;
+
+        Assert.True(Assert.Single(plan.Files).HasReliableUnicodeDetection);
+    }
+
+    [Fact]
+    public void WithTheReliabilityFlagLost_TheReviewedRefusalStillBinds()
+    {
+        // Defence one alone: simulate a schema that does not carry the policy input,
+        // which is exactly the shape every plan had before this was fixed. The ceiling
+        // has to hold on its own, or the next missing input repeats the defect.
+        string path = WriteReliableUtf8();
+        byte[] original = File.ReadAllBytes(path);
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "windows-1252",
+            TargetEncoding = "utf-8",
+            SourceEncodingWasSpecified = true,
+            DetectedEncodingLabel = "utf-8",
+            HasReliableUnicodeDetection = false, // lost in transit
+            Action = PlannedAction.Refuse,
+            SourceInterpretation = SourceInterpretation.ExplicitSource,
+            ReasonCode = ConversionReasonCodes.ExplicitSourceConflictsWithDetection,
+            Approved = new ApprovedDecision(
+                PlannedAction.Refuse,
+                SourceInterpretation.ExplicitSource,
+                ConversionReasonCodes.ExplicitSourceConflictsWithDetection,
+                "reviewed as refused"),
+        };
+
+        var sink = new EntrySink();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false, maxParallelism: 1,
+            whatIf: false, backup: false, sink.Add, CancellationToken.None);
+
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(ConversionRowResult.Refused, entry.Result);
+        Assert.Equal(
+            ConversionReasonCodes.ExplicitSourceConflictsWithDetection,
+            entry.ReasonCode);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void WithNoCeiling_TheRecomputedVetoStillRefuses()
+    {
+        // Defence two alone: no approved decision at all, so only the recomputed policy
+        // can stop this. Together with the test above, neither defence can be removed
+        // without a test failing.
+        string path = WriteReliableUtf8();
+        byte[] original = File.ReadAllBytes(path);
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "windows-1252",
+            TargetEncoding = "utf-8",
+            SourceEncodingWasSpecified = true,
+            DetectedEncodingLabel = "utf-8",
+            HasReliableUnicodeDetection = true,
+            Approved = null,
+        };
+
+        var sink = new EntrySink();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false, maxParallelism: 1,
+            whatIf: false, backup: false, sink.Add, CancellationToken.None);
+
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void WithNeitherDefence_TheFileIsRewritten()
+    {
+        // The control. If this ever stops rewriting the file, the two tests above have
+        // stopped proving anything and are passing for some unrelated reason.
+        string path = WriteReliableUtf8();
+        byte[] original = File.ReadAllBytes(path);
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "windows-1252",
+            TargetEncoding = "utf-8",
+            SourceEncodingWasSpecified = true,
+            DetectedEncodingLabel = "utf-8",
+            HasReliableUnicodeDetection = false,
+            Approved = null,
+        };
+
+        var sink = new EntrySink();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false, maxParallelism: 1,
+            whatIf: false, backup: false, sink.Add, CancellationToken.None);
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.NotEqual(original, File.ReadAllBytes(path));
+
+        // And this is the damage, derived from the codecs rather than pasted as a
+        // literal: the original bytes read through the wrong codec. The result is
+        // valid UTF-8 holding characters nobody wrote, which verification cannot
+        // catch because both of its sides use that same wrong codec.
+        Assert.Equal(
+            Encoding.GetEncoding("windows-1252").GetString(original),
+            File.ReadAllText(path, new UTF8Encoding(false)));
+    }
+
+    [Fact]
+    public void TheCeilingOnlyBindsDownward_APlannedConvertMayStillBeRefused()
+    {
+        // Re-deciding must still be able to refuse a file the plan approved; that is
+        // why applying re-decides at all. The ceiling must not turn into a floor.
+        string path = Path.Combine(_root, "ambiguous.txt");
+        File.WriteAllBytes(
+            path, new UnicodeEncoding(false, false).GetBytes("Hello World, plain text."));
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-16",
+            TargetEncoding = "utf-8",
+            DetectedEncodingLabel = "utf-16",
+            Approved = new ApprovedDecision(
+                PlannedAction.Convert,
+                SourceInterpretation.AutomaticUnicodeOrAscii,
+                null,
+                null),
+        };
+
+        byte[] original = File.ReadAllBytes(path);
+        var sink = new EntrySink();
+
+        ScanEngine.ConvertFiles(
+            [entry], "utf-8", targetWriteBom: false, maxParallelism: 1,
+            whatIf: false, backup: false, sink.Add, CancellationToken.None);
+
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, entry.ReasonCode);
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void APlanWrittenByAnEarlierSchemaIsRefusedRatherThanReinterpreted()
+    {
+        // Plans written before this fix record decisions this build cannot reproduce,
+        // so they must not be applied at all.
+        WriteReliableUtf8();
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet");
+
+        string downgraded = File.ReadAllText(planPath)
+            .Replace(
+                $"\"PlanVersion\": {ConversionPlan.CurrentPlanVersion}",
+                "\"PlanVersion\": 4",
+                StringComparison.Ordinal);
+
+        Assert.Contains("\"PlanVersion\": 4", downgraded, StringComparison.Ordinal);
+        File.WriteAllText(planPath, downgraded);
+
+        Assert.Null(ConversionPlan.Load(planPath, out string? error));
+        Assert.Contains("schema version 4", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnOrdinaryPlanStillApplies()
+    {
+        // The ceiling must not block work the review approved.
+        string path = Path.Combine(_root, "plain.txt");
+        File.WriteAllText(path, "hello world", new UTF8Encoding(true));
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+        Assert.Equal(ExpectedClean, Run("-Apply", planPath));
+
+        Assert.Equal("hello world", File.ReadAllText(path));
+        Assert.NotEqual(Encoding.UTF8.GetPreamble(), File.ReadAllBytes(path)[..3]);
+    }
+}

--- a/sources/EncodingChecker.Tests/AppliedPlanPathIntegrityTests.cs
+++ b/sources/EncodingChecker.Tests/AppliedPlanPathIntegrityTests.cs
@@ -164,6 +164,31 @@ public sealed class AppliedPlanPathIntegrityTests : IDisposable
     }
 
     [Fact]
+    public void HasReparsePointInPath_ChecksTheFinalPathComponent()
+    {
+        string real = Path.Combine(_root, "real");
+        string elsewhere = Path.Combine(_root, "elsewhere");
+        Directory.CreateDirectory(real);
+        Directory.CreateDirectory(elsewhere);
+
+        string link = Path.Combine(real, "planned-entry");
+        Assert.True(
+            TryCreateJunction(link, elsewhere),
+            "The junction fixture could not be created.");
+
+        try
+        {
+            // This checks the component passed as 'path', not merely its parent chain.
+            // File and directory links expose the same ReparsePoint attribute.
+            Assert.True(DirectoryTraversal.HasReparsePointInPath(real, link));
+        }
+        finally
+        {
+            Assert.True(RunCmd($"rmdir \"{link}\""));
+        }
+    }
+
+    [Fact]
     public void AnOrdinaryNestedPlanStillApplies()
     {
         // The control, and it needs no junction, so it runs in every environment. A
@@ -201,5 +226,18 @@ public sealed class AppliedPlanPathIntegrityTests : IDisposable
         // plan says nothing about - on some machines the temp path itself sits behind
         // a link, which would otherwise reject every plan.
         Assert.False(DirectoryTraversal.HasReparsePointInPath(deep, file));
+    }
+
+    [Fact]
+    public void HasReparsePointInPath_PathOutsideRoot_FailsClosed()
+    {
+        string root = Path.Combine(_root, "root");
+        string outside = Path.Combine(_root, "outside");
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(outside);
+        string file = Path.Combine(outside, "f.txt");
+        File.WriteAllText(file, "x");
+
+        Assert.True(DirectoryTraversal.HasReparsePointInPath(root, file));
     }
 }

--- a/sources/EncodingChecker.Tests/AppliedPlanPathIntegrityTests.cs
+++ b/sources/EncodingChecker.Tests/AppliedPlanPathIntegrityTests.cs
@@ -229,6 +229,40 @@ public sealed class AppliedPlanPathIntegrityTests : IDisposable
     }
 
     [Fact]
+    public void ADeletedPlannedFileIsReportedAsMissingRatherThanAsALink()
+    {
+        // The link check treats an unreadable path as suspect, which is right, but a
+        // deleted file is unreadable for an ordinary reason. Running it before the
+        // existence check made "(no longer exists)" unreachable and told the user their
+        // file might be a symbolic link, which is both wrong and alarming.
+        string real = Path.Combine(_root, "real");
+        Directory.CreateDirectory(real);
+        WriteWithBom(Path.Combine(real, "keep.txt"));
+        WriteWithBom(Path.Combine(real, "gone.txt"));
+
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", real, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+
+        File.Delete(Path.Combine(real, "gone.txt"));
+
+        ConversionPlan plan = ConversionPlan.Load(planPath, out string? error)!;
+
+        Assert.Null(error);
+
+        string reason = Assert.Single(plan.FindStaleFiles());
+
+        Assert.Contains("no longer exists", reason);
+        Assert.DoesNotContain("symbolic link", reason);
+
+        // Still refused, which is the part that must not change.
+        Assert.Equal(ExpectedProcessingErrors, Run("-Apply", planPath));
+        Assert.True(StillHasBom(Path.Combine(real, "keep.txt")));
+    }
+
+    [Fact]
     public void HasReparsePointInPath_PathOutsideRoot_FailsClosed()
     {
         string root = Path.Combine(_root, "root");

--- a/sources/EncodingChecker.Tests/AppliedPlanPathIntegrityTests.cs
+++ b/sources/EncodingChecker.Tests/AppliedPlanPathIntegrityTests.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A plan names paths, and a path is only as stable as the directories above it.
+/// </summary>
+/// <remarks>
+/// Planning refuses a reparse-point <c>-BasePath</c> and traversal never enters one, so
+/// no planned path can legitimately contain one. Applying a plan checked only that the
+/// recorded directory still existed, so the same input was rejected by one entry point
+/// and followed by the other: rename the root away, put a junction in its place, and the
+/// writes land in a tree the reviewer never saw.
+/// <para>
+/// The recorded hashes cannot detect this. Two identical copies hash identically, which
+/// is the same limit as BOM-less UTF-16 in a different guise - bytes cannot say which
+/// file they are.
+/// </para>
+/// <para>
+/// The junction tests return early where <c>mklink</c> is unavailable, matching
+/// <see cref="ReparsePointRootTests"/>. The two tests below them need no junction and so
+/// run everywhere, which is what keeps this fixture from passing vacuously.
+/// </para>
+/// </remarks>
+public sealed class AppliedPlanPathIntegrityTests : IDisposable
+{
+    private const int ExpectedClean = 0;
+    private const int ExpectedProcessingErrors = 3;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_planpath_").FullName;
+
+    public void Dispose()
+    {
+        foreach (string dir in new[] { Path.Combine(_root, "real", "sub"), Path.Combine(_root, "real") })
+        {
+            if (Directory.Exists(dir) &&
+                (File.GetAttributes(dir) & FileAttributes.ReparsePoint) != 0)
+            {
+                RunCmd($"rmdir \"{dir}\"");
+            }
+        }
+
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static bool RunCmd(string arguments)
+    {
+        var psi = new ProcessStartInfo("cmd.exe", "/c " + arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process? proc = Process.Start(psi);
+
+        if (proc is null)
+            return false;
+
+        proc.WaitForExit(10000);
+
+        return proc.ExitCode == 0;
+    }
+
+    /// <summary>Creates a junction, or returns false where the environment forbids it.</summary>
+    private static bool TryCreateJunction(string link, string target) =>
+        RunCmd($"mklink /J \"{link}\" \"{target}\"") && Directory.Exists(link);
+
+    private static int Run(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    private static void WriteWithBom(string path) =>
+        File.WriteAllText(path, "identical bytes", new UTF8Encoding(true));
+
+    private static bool StillHasBom(string path) =>
+        File.ReadAllBytes(path).Take(3).SequenceEqual(Encoding.UTF8.GetPreamble());
+
+    [Fact]
+    public void PlanRootReplacedByAJunction_IsRefusedRatherThanFollowed()
+    {
+        string real = Path.Combine(_root, "real");
+        string other = Path.Combine(_root, "other");
+        Directory.CreateDirectory(real);
+        Directory.CreateDirectory(other);
+        WriteWithBom(Path.Combine(real, "f.txt"));
+        WriteWithBom(Path.Combine(other, "f.txt"));
+
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", real, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+
+        Directory.Move(real, Path.Combine(_root, "real_orig"));
+
+        if (!TryCreateJunction(real, other))
+            return; // mklink unavailable here; nothing to verify.
+
+        Assert.Equal(ExpectedProcessingErrors, Run("-Apply", planPath));
+
+        // Neither tree was written to: not the copy behind the junction, and not the
+        // planned tree either, which no longer sits where the plan says it does.
+        Assert.True(StillHasBom(Path.Combine(other, "f.txt")));
+        Assert.True(StillHasBom(Path.Combine(_root, "real_orig", "f.txt")));
+    }
+
+    [Fact]
+    public void SubdirectoryReplacedByAJunction_IsRefusedEvenThoughTheRootIsReal()
+    {
+        // The root check alone is not enough: only one directory along the path has to
+        // change for the writes to leave the reviewed tree.
+        string real = Path.Combine(_root, "real");
+        string sub = Path.Combine(real, "sub");
+        string elsewhere = Path.Combine(_root, "elsewhere");
+        Directory.CreateDirectory(sub);
+        Directory.CreateDirectory(elsewhere);
+        WriteWithBom(Path.Combine(real, "f.txt"));
+        WriteWithBom(Path.Combine(sub, "g.txt"));
+        WriteWithBom(Path.Combine(elsewhere, "g.txt"));
+
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", real, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+
+        Directory.Delete(sub, recursive: true);
+
+        if (!TryCreateJunction(sub, elsewhere))
+            return; // mklink unavailable here; nothing to verify.
+
+        Assert.Equal(ExpectedProcessingErrors, Run("-Apply", planPath));
+
+        Assert.True(StillHasBom(Path.Combine(elsewhere, "g.txt")));
+
+        // The plan was reviewed as a whole, so the file whose path is still sound is
+        // left alone too rather than half-applying it.
+        Assert.True(StillHasBom(Path.Combine(real, "f.txt")));
+    }
+
+    [Fact]
+    public void AnOrdinaryNestedPlanStillApplies()
+    {
+        // The control, and it needs no junction, so it runs in every environment. A
+        // check that only ever refuses would pass both tests above while having broken
+        // -Apply outright.
+        string real = Path.Combine(_root, "real");
+        string sub = Path.Combine(real, "deep", "nested");
+        Directory.CreateDirectory(sub);
+        WriteWithBom(Path.Combine(real, "f.txt"));
+        WriteWithBom(Path.Combine(sub, "g.txt"));
+
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", real, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+        Assert.Equal(ExpectedClean, Run("-Apply", planPath));
+
+        Assert.False(StillHasBom(Path.Combine(real, "f.txt")));
+        Assert.False(StillHasBom(Path.Combine(sub, "g.txt")));
+    }
+
+    [Fact]
+    public void HasReparsePointInPath_OrdinaryNesting_IsFalseAndStopsAtTheRoot()
+    {
+        string real = Path.Combine(_root, "real");
+        string deep = Path.Combine(real, "a", "b", "c");
+        Directory.CreateDirectory(deep);
+        string file = Path.Combine(deep, "f.txt");
+        File.WriteAllText(file, "x");
+
+        Assert.False(DirectoryTraversal.HasReparsePointInPath(real, file));
+
+        // Walking must stop at the root rather than continuing up into directories the
+        // plan says nothing about - on some machines the temp path itself sits behind
+        // a link, which would otherwise reject every plan.
+        Assert.False(DirectoryTraversal.HasReparsePointInPath(deep, file));
+    }
+}

--- a/sources/EncodingChecker.Tests/ArtifactExclusionCoverageTests.cs
+++ b/sources/EncodingChecker.Tests/ArtifactExclusionCoverageTests.cs
@@ -1,0 +1,141 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Files EC skips as its own must be counted when the caller's patterns selected them.
+/// </summary>
+/// <remarks>
+/// <c>.bak</c>, <c>.ecmeta.json</c> and <c>.unicodechecker.tmp</c> were dropped before
+/// the coverage counters ran, so they appeared in no row, no count and no warning. The
+/// sharp end was <c>-Include "*.bak"</c>: the caller named those files explicitly and
+/// got an empty report and exit 0 - a clean answer to a question EC had not looked at.
+/// <para>
+/// The test is the exclusion's placement, not its existence. Skipping EC's own backups
+/// and sidecars is right; doing it silently is not. The counters were added in v3.9.2
+/// precisely so a clean result could not stand in for complete coverage, and this
+/// group sat outside them.
+/// </para>
+/// </remarks>
+public sealed class ArtifactExclusionCoverageTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_artifactcoverage_").FullName;
+
+    public ArtifactExclusionCoverageTests()
+    {
+        Write("a.txt");
+        Write("b.bak");
+        Write("c.txt" + ConversionMetadataStore.Suffix);
+        Write("d.txt." + EncodingConverter.TempFileSuffix);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private void Write(string name) =>
+        File.WriteAllText(
+            Path.Combine(_root, name), "plain ascii", new UTF8Encoding(false));
+
+    private (List<string> Files, DirectoryTraversal.TraversalCounters Counters) Enumerate(
+        params string[] includePatterns)
+    {
+        var counters = new DirectoryTraversal.TraversalCounters();
+
+        List<string> files =
+        [
+            .. DirectoryTraversal.EnumerateFiles(
+                _root,
+                includeSubdirectories: true,
+                DirectoryTraversal.CompilePatterns(includePatterns, defaultToMatchAll: true),
+                DirectoryTraversal.CompilePatterns(null, defaultToMatchAll: false),
+                excludedFullPaths: null,
+                onWarning: null,
+                counters)
+        ];
+
+        return (files, counters);
+    }
+
+    [Fact]
+    public void AskingForBackupsReportsThemSkippedRatherThanReturningNothing()
+    {
+        (List<string> files, DirectoryTraversal.TraversalCounters counters) =
+            Enumerate("*.bak");
+
+        // Still excluded - that part is deliberate and unchanged.
+        Assert.Empty(files);
+
+        // But no longer silently. An empty report with nothing else said is
+        // indistinguishable from "your files are fine".
+        Assert.Equal(1, counters.FilesExcludedAsEcArtifact);
+    }
+
+    [Fact]
+    public void AllThreeArtifactKindsAreCounted()
+    {
+        // Named through the shared constants, so renaming a suffix cannot quietly
+        // drop one of them out of the count.
+        (List<string> files, DirectoryTraversal.TraversalCounters counters) = Enumerate();
+
+        Assert.Equal(["a.txt"], files.Select(Path.GetFileName));
+        Assert.Equal(3, counters.FilesExcludedAsEcArtifact);
+    }
+
+    [Fact]
+    public void FilesTheCallerDidNotSelectAreNotCounted()
+    {
+        // The control, and the reason the check sits after the pattern match rather
+        // than before it: a count that fires for files outside the requested scope is
+        // noise, and noise in a coverage warning is how the warning stops being read.
+        (List<string> files, DirectoryTraversal.TraversalCounters counters) =
+            Enumerate("*.txt");
+
+        Assert.Equal(["a.txt"], files.Select(Path.GetFileName));
+        Assert.Equal(0, counters.FilesExcludedAsEcArtifact);
+    }
+
+    [Fact]
+    public void OrdinaryFilesAreStillReturnedAndNeverCounted()
+    {
+        // A counter that incremented for everything would satisfy the first two tests
+        // while making the number meaningless.
+        (List<string> files, DirectoryTraversal.TraversalCounters counters) =
+            Enumerate("a.txt");
+
+        Assert.Equal(["a.txt"], files.Select(Path.GetFileName));
+        Assert.Equal(0, counters.FilesExcludedAsEcArtifact);
+        Assert.Equal(0, counters.FilesExcludedByAttribute);
+    }
+
+    [Fact]
+    public void TheGuiCoverageLineMentionsThem()
+    {
+        // The GUI reports coverage in the status bar rather than on stderr, so the
+        // count has to reach that surface too or the window shows a clean scan.
+        var counters = new DirectoryTraversal.TraversalCounters();
+        counters.CountFileExcludedAsEcArtifact();
+
+        string coverage = MainForm.FormatCoverage(counters);
+
+        Assert.Contains("1", coverage, StringComparison.Ordinal);
+        Assert.Contains("not examined", coverage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NothingSkippedProducesNoCoverageText()
+    {
+        Assert.Equal(
+            string.Empty,
+            MainForm.FormatCoverage(new DirectoryTraversal.TraversalCounters()));
+    }
+}

--- a/sources/EncodingChecker.Tests/BackupRecordPairingTests.cs
+++ b/sources/EncodingChecker.Tests/BackupRecordPairingTests.cs
@@ -137,7 +137,7 @@ public sealed class BackupRecordPairingTests : IDisposable
     }
 
     [Fact]
-    public void Invalidate_RemovesEvenAReadOnlyRecord()
+    public void RemoveBeforeBackupReplacement_RemovesEvenAReadOnlyRecord()
     {
         // The backup path clears ReadOnly before replacing; the record must match, or
         // a read-only sidecar would fail the backup instead of being replaced by it.
@@ -145,17 +145,17 @@ public sealed class BackupRecordPairingTests : IDisposable
         File.WriteAllText(RecordPath, "{}");
         File.SetAttributes(RecordPath, FileAttributes.ReadOnly);
 
-        ConversionMetadataStore.Invalidate(FilePath);
+        ConversionMetadataStore.RemoveBeforeBackupReplacement(FilePath);
 
         Assert.False(File.Exists(RecordPath));
     }
 
     [Fact]
-    public void Invalidate_WithNoRecordPresent_IsANoOp()
+    public void RemoveBeforeBackupReplacement_WithNoRecordPresent_IsANoOp()
     {
         File.WriteAllText(FilePath, "hello", new UTF8Encoding(false));
 
-        ConversionMetadataStore.Invalidate(FilePath);
+        ConversionMetadataStore.RemoveBeforeBackupReplacement(FilePath);
 
         Assert.False(File.Exists(RecordPath));
         Assert.True(File.Exists(FilePath));

--- a/sources/EncodingChecker.Tests/BackupRecordPairingTests.cs
+++ b/sources/EncodingChecker.Tests/BackupRecordPairingTests.cs
@@ -1,0 +1,163 @@
+using System.Text;
+using System.Text.Json;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A recovery record must never describe a backup that is no longer there.
+/// </summary>
+/// <remarks>
+/// <c>&lt;file&gt;.bak</c> is a fixed name, so a second conversion replaces the first
+/// one's restore point. The record for the first conversion used to survive that: it
+/// is written only after verification succeeds, so a conversion that failed after the
+/// backup was replaced left the earlier record in place, still asserting a hash, a
+/// source codec and a completed installation for bytes that no longer existed.
+/// <para>
+/// Measured before the fix: convert utf-8 to utf-16 with a backup, then convert to
+/// ascii, which cannot represent the text. The second backup replaced the first, the
+/// conversion failed, and the surviving record claimed "utf-8 to utf-16, Completed"
+/// against a backup that now held the utf-16 file. Not merely unverifiable - wrong
+/// about what the backup contained, in the direction that matters, because someone
+/// reading it would believe their original was recoverable.
+/// </para>
+/// </remarks>
+public sealed class BackupRecordPairingTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_backuppair_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string Convert(string targetCharset, bool targetWriteBom, string? from = null)
+    {
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Convert,
+            TargetCharset = targetCharset,
+            TargetWriteBom = targetWriteBom,
+            SourceCharset = from,
+            Backup = true,
+        };
+
+        var entries = new EntrySink();
+        ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
+
+        return Assert.Single(entries).Result.ToString();
+    }
+
+    private string FilePath => Path.Combine(_root, "f.txt");
+
+    private string BackupPath => FilePath + ".bak";
+
+    private string RecordPath => ConversionMetadataStore.MetadataPathFor(FilePath);
+
+    /// <summary>The invariant, asserted the same way everywhere it is checked.</summary>
+    private void AssertNoRecordDescribesAMissingBackup()
+    {
+        if (!File.Exists(RecordPath))
+            return;
+
+        Assert.True(File.Exists(BackupPath), "A record exists with no backup beside it.");
+
+        string recorded = JsonDocument.Parse(File.ReadAllText(RecordPath))
+            .RootElement.GetProperty("BackupSha256").GetString()!;
+
+        Assert.Equal(
+            ConversionMetadataStore.ComputeSha256(BackupPath),
+            recorded,
+            ignoreCase: true);
+    }
+
+    [Fact]
+    public void SecondConversionFails_NoRecordIsLeftDescribingTheReplacedBackup()
+    {
+        File.WriteAllText(FilePath, "café résumé", new UTF8Encoding(false));
+
+        Assert.Equal(nameof(ConversionRowResult.Converted), Convert("utf-16", targetWriteBom: true));
+        AssertNoRecordDescribesAMissingBackup();
+
+        string firstBackup = ConversionMetadataStore.ComputeSha256(BackupPath);
+
+        // ascii cannot encode the accented characters, so this fails after the backup
+        // has already replaced the first one.
+        Assert.Equal(nameof(ConversionRowResult.Error), Convert("ascii", targetWriteBom: false));
+
+        Assert.NotEqual(firstBackup, ConversionMetadataStore.ComputeSha256(BackupPath));
+        AssertNoRecordDescribesAMissingBackup();
+        Assert.False(
+            File.Exists(RecordPath),
+            "A failed conversion must leave no record at all, not a stale one.");
+    }
+
+    [Fact]
+    public void SecondConversionSucceeds_TheRecordDescribesTheNewBackup()
+    {
+        // The invalidation must not cost a successful conversion its record.
+        File.WriteAllText(FilePath, "café résumé", new UTF8Encoding(false));
+
+        Assert.Equal(nameof(ConversionRowResult.Converted), Convert("utf-16", targetWriteBom: true));
+        Assert.Equal(nameof(ConversionRowResult.Converted), Convert("utf-8", targetWriteBom: false, from: "utf-16"));
+
+        Assert.True(File.Exists(RecordPath));
+        AssertNoRecordDescribesAMissingBackup();
+
+        JsonElement record = JsonDocument.Parse(File.ReadAllText(RecordPath)).RootElement;
+
+        Assert.Equal("utf-16", record.GetProperty("SourceEncodingName").GetString());
+        Assert.Equal("utf-8", record.GetProperty("TargetEncodingName").GetString());
+        Assert.Equal("Completed", record.GetProperty("InstallationState").GetString());
+    }
+
+    [Fact]
+    public void TheFailedRunStillLeavesAUsableBackupOfWhatItWasAboutToChange()
+    {
+        // Removing the record must not be mistaken for removing the restore point.
+        // .bak is "the version this run replaced", and after a failed run that is the
+        // file as it stands now.
+        File.WriteAllText(FilePath, "café résumé", new UTF8Encoding(false));
+
+        Convert("utf-16", targetWriteBom: true);
+        byte[] afterFirst = File.ReadAllBytes(FilePath);
+
+        Convert("ascii", targetWriteBom: false);
+
+        Assert.Equal(afterFirst, File.ReadAllBytes(FilePath));
+        Assert.Equal(afterFirst, File.ReadAllBytes(BackupPath));
+    }
+
+    [Fact]
+    public void Invalidate_RemovesEvenAReadOnlyRecord()
+    {
+        // The backup path clears ReadOnly before replacing; the record must match, or
+        // a read-only sidecar would fail the backup instead of being replaced by it.
+        File.WriteAllText(FilePath, "hello", new UTF8Encoding(false));
+        File.WriteAllText(RecordPath, "{}");
+        File.SetAttributes(RecordPath, FileAttributes.ReadOnly);
+
+        ConversionMetadataStore.Invalidate(FilePath);
+
+        Assert.False(File.Exists(RecordPath));
+    }
+
+    [Fact]
+    public void Invalidate_WithNoRecordPresent_IsANoOp()
+    {
+        File.WriteAllText(FilePath, "hello", new UTF8Encoding(false));
+
+        ConversionMetadataStore.Invalidate(FilePath);
+
+        Assert.False(File.Exists(RecordPath));
+        Assert.True(File.Exists(FilePath));
+    }
+}

--- a/sources/EncodingChecker.Tests/BlankOptionValueSafetyTests.cs
+++ b/sources/EncodingChecker.Tests/BlankOptionValueSafetyTests.cs
@@ -1,0 +1,147 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// An option that arrives with nothing in it must be a usage error, never a default.
+/// </summary>
+/// <remarks>
+/// Every option is tested for presence with <c>IsNullOrWhiteSpace</c>, so a blank value
+/// used to read as "not supplied" and fall through to whatever that option's absence
+/// means. For two options that fall-through wrote files: <c>-Plan ""</c> skipped
+/// <c>WhatIf</c> and performed the conversion its own flag exists to prevent, and
+/// <c>-Apply ""</c> became a whole-directory conversion instead of a reviewed plan.
+/// <para>
+/// These run the real CLI entry point rather than the parser, because the property that
+/// matters is not the error message but that nothing on disk changed.
+/// </para>
+/// </remarks>
+public sealed class BlankOptionValueSafetyTests : IDisposable
+{
+    private const int ExpectedUsageError = 1;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_blankvalue_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    /// <summary>A UTF-8 file with a BOM: converting it to utf-8 without one rewrites it.</summary>
+    private string WriteConvertibleFile()
+    {
+        string path = Path.Combine(_root, "convertible.txt");
+        File.WriteAllText(path, "hello world", new UTF8Encoding(true));
+
+        return path;
+    }
+
+    [Theory]
+    [InlineData("-Plan")]
+    [InlineData("-Apply")]
+    [InlineData("-From")]
+    [InlineData("-Journal")]
+    [InlineData("-Report")]
+    [InlineData("-Include")]
+    [InlineData("-Exclude")]
+    public void BlankOptionValue_IsRejectedAndChangesNothing(string flag)
+    {
+        string path = WriteConvertibleFile();
+        byte[] before = File.ReadAllBytes(path);
+
+        int exitCode = Run("-BasePath", _root, "-Target", "utf-8", flag, "");
+
+        Assert.Equal(ExpectedUsageError, exitCode);
+        Assert.Equal(before, File.ReadAllBytes(path));
+        Assert.Empty(Directory.GetFiles(_root, "*.bak"));
+    }
+
+    [Fact]
+    public void BlankPlanValue_DoesNotSilentlyBecomeARealConversion()
+    {
+        // The specific regression: -Plan is documented as writing a preview and
+        // changing nothing, and the blank value removed exactly that guarantee. The
+        // BOM assertion is what makes this fail loudly rather than just counting bytes.
+        string path = WriteConvertibleFile();
+
+        Assert.Equal(ExpectedUsageError, Run("-BasePath", _root, "-Target", "utf-8", "-Plan", ""));
+
+        byte[] bytes = File.ReadAllBytes(path);
+
+        Assert.Equal(Encoding.UTF8.GetPreamble(), bytes[..3]);
+    }
+
+    [Fact]
+    public void BlankApplyValue_DoesNotSilentlyBecomeADirectoryConversion()
+    {
+        string path = WriteConvertibleFile();
+
+        Assert.Equal(ExpectedUsageError, Run("-BasePath", _root, "-Target", "utf-8", "-Apply", ""));
+
+        byte[] bytes = File.ReadAllBytes(path);
+
+        Assert.Equal(Encoding.UTF8.GetPreamble(), bytes[..3]);
+    }
+
+    [Fact]
+    public void BlankSourceValue_DoesNotSilentlyRevertToAutomaticDetection()
+    {
+        // -From "" fell through to detection, which is a different safety decision
+        // rather than a missing one: legacy bytes would be refused instead of read
+        // as the codec the caller believed they had named.
+        string path = Path.Combine(_root, "legacy.txt");
+        File.WriteAllBytes(path, Encoding.GetEncoding("windows-1252").GetBytes("café"));
+        byte[] before = File.ReadAllBytes(path);
+
+        Assert.Equal(ExpectedUsageError, Run("-BasePath", _root, "-Target", "utf-8", "-From", ""));
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void BlankValueIsRejectedBeforeTheDirectoryIsEvenRead()
+    {
+        // Parsing fails first, so a blank value cannot depend on the scan for safety.
+        Assert.Equal(
+            ExpectedUsageError,
+            Run("-BasePath", Path.Combine(_root, "no-such-folder"), "-Target", "utf-8", "-Plan", ""));
+    }
+
+    [Fact]
+    public void RealValuesStillWork()
+    {
+        // The guard must reject blank values without rejecting ordinary ones.
+        string path = WriteConvertibleFile();
+        string plan = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(0, Run("-BasePath", _root, "-Target", "utf-8", "-Plan", plan, "-Quiet"));
+        Assert.True(File.Exists(plan));
+        Assert.Equal(Encoding.UTF8.GetPreamble(), File.ReadAllBytes(path)[..3]);
+    }
+}

--- a/sources/EncodingChecker.Tests/BomlessUtf16SafetyTests.cs
+++ b/sources/EncodingChecker.Tests/BomlessUtf16SafetyTests.cs
@@ -74,7 +74,7 @@ public sealed class BomlessUtf16SafetyTests : IDisposable
         Assert.Equal(ConversionRowResult.Refused, entry.Result);
         Assert.Equal(PlannedAction.Refuse, entry.Action);
         Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, entry.ReasonCode);
-        Assert.Contains("valid as both UTF-16LE and UTF-16BE", entry.Diagnostic);
+        Assert.Contains("these bytes are also valid UTF-16BE", entry.Diagnostic);
         Assert.Equal(original, File.ReadAllBytes(entry.FilePath));
         Assert.Equal(authoritativeText, utf16Be.GetString(File.ReadAllBytes(entry.FilePath)));
         Assert.False(File.Exists(entry.FilePath + ".bak"));

--- a/sources/EncodingChecker.Tests/CliArgumentParserTests.cs
+++ b/sources/EncodingChecker.Tests/CliArgumentParserTests.cs
@@ -321,6 +321,43 @@ public sealed class CliArgumentParserTests
     }
 
     [Fact]
+    public void TryValidateOptions_CommandOutputsMustUseDifferentFiles()
+    {
+        string root = Directory.CreateTempSubdirectory("ec-output-paths-").FullName;
+
+        try
+        {
+            string shared = Path.Combine(root, "result.json");
+            Program.CliOptions options = ParsedOptions(
+                "-BasePath", root, "-Target", "utf-8",
+                "-Plan", shared, "-Journal", shared);
+
+            Assert.False(Program.TryValidateOptions(options, out string? error));
+            Assert.Contains("resolve to the same file", error);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("-Plan", "review.bak")]
+    [InlineData("-Plan", "review.bak.")]
+    [InlineData("-Journal", "run.ecmeta.json")]
+    [InlineData("-Journal", "run.ecmeta.json ")]
+    [InlineData("-Report", "report.unicodechecker.tmp")]
+    public void TryValidateOptions_CommandOutputsCannotUseRecoveryArtifactSuffixes(
+        string option, string path)
+    {
+        Program.CliOptions options = ParsedOptions(
+            "-BasePath", ".", "-Target", "utf-8", option, path);
+
+        Assert.False(Program.TryValidateOptions(options, out string? error));
+        Assert.Contains("reserved", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryValidateOptions_MissingBasePath_Fails()
     {
         Program.CliOptions options = ParsedOptions("-Target", "utf-8");

--- a/sources/EncodingChecker.Tests/CliArgumentParserTests.cs
+++ b/sources/EncodingChecker.Tests/CliArgumentParserTests.cs
@@ -138,6 +138,61 @@ public sealed class CliArgumentParserTests
         Assert.Equal($"{flag} requires a value.", error);
     }
 
+    [Theory]
+    [InlineData("-BasePath")]
+    [InlineData("-Include")]
+    [InlineData("-Exclude")]
+    [InlineData("-Target")]
+    [InlineData("-From")]
+    [InlineData("-Plan")]
+    [InlineData("-Apply")]
+    [InlineData("-Journal")]
+    [InlineData("-Validate")]
+    [InlineData("-Report")]
+    public void TryTakeValue_BlankValue_IsTreatedAsMissing(string flag)
+    {
+        // Every later test asks IsNullOrWhiteSpace, so a blank value used to read as
+        // "option not supplied" and fall through to the most permissive behaviour.
+        // -Plan "" skipped the preview flag and converted for real; -From "" reverted
+        // to automatic detection. The check belongs in the one place every option's
+        // value passes through, so an option added later cannot reintroduce it.
+        foreach (string blank in new[] { "", "   ", "\t" })
+        {
+            bool result = Program.TryParseArguments(
+                [flag, blank], out _, out string? error);
+
+            Assert.False(result);
+            Assert.Equal($"{flag} requires a value.", error);
+        }
+    }
+
+    [Fact]
+    public void TryTakeValue_BlankMaxParallelism_IsRejectedByItsOwnParseCheck()
+    {
+        // This one reads better as "requires a positive integer" than as a missing
+        // value, so it keeps its own message. What must not differ is the outcome.
+        bool result = Program.TryParseArguments(
+            ["-MaxParallelism", "  "], out _, out string? error);
+
+        Assert.False(result);
+        Assert.Equal("-MaxParallelism requires a positive integer.", error);
+    }
+
+    [Fact]
+    public void TryTakeValue_ValueOfOnlySeparators_IsNotBlankAndReachesValidation()
+    {
+        // The two rules are distinct: parsing rejects a value with nothing in it,
+        // validation rejects one whose content yields no usable pattern. Keeping them
+        // separate is what lets each report the accurate reason.
+        bool result = Program.TryParseArguments(
+            ["-Include", ",,,"], out Program.CliOptions options, out string? error);
+
+        Assert.True(result);
+        Assert.Null(error);
+        Assert.True(options.IncludeSpecified);
+        Assert.Empty(options.Include);
+    }
+
     [Fact]
     public void TryParseArguments_ValueLooksLikeAnotherKnownFlag_IsTreatedAsMissingValue()
     {
@@ -184,11 +239,14 @@ public sealed class CliArgumentParserTests
         return options;
     }
 
+    // Wholly blank values are now rejected one stage earlier, by TryTakeValue, and are
+    // covered by TryTakeValue_BlankValue_IsTreatedAsMissing below. What is left here is
+    // the case parsing cannot catch: a value with real characters in it that still
+    // splits to no pattern at all.
     [Theory]
-    [InlineData("")]
     [InlineData(",,,")]
-    [InlineData("   ")]
     [InlineData(",")]
+    [InlineData(", ,")]
     public void TryValidateOptions_IncludeGivenButUnusable_Fails(string pattern)
     {
         // A filter that parses to nothing must not mean "every file". This is the
@@ -207,8 +265,8 @@ public sealed class CliArgumentParserTests
     }
 
     [Theory]
-    [InlineData("")]
     [InlineData(",,,")]
+    [InlineData(", ,")]
     public void TryValidateOptions_ExcludeGivenButUnusable_Fails(string pattern)
     {
         Program.CliOptions options =

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -163,7 +163,7 @@ public sealed class ConversionConfirmationFormTests : IDisposable
             using var form = new ConversionConfirmationForm(plan);
             string text = AllText(form);
 
-            Assert.Contains("could not", text);
+            Assert.Contains("cannot prove", text);
             Assert.Contains("bomless.txt", text);
             Assert.Contains("not evidence", text);
             Assert.Contains("Convert 1 file(s)", text);
@@ -245,7 +245,7 @@ public sealed class ConversionConfirmationFormTests : IDisposable
             // Wording is now shared by both advisory cases, so the assertion pins the
             // per-file reason - which is what distinguishes them - rather than the
             // heading that no longer mentions disagreement.
-            Assert.Contains("BOM-less byte order EC could not prove", text);
+            Assert.Contains("cannot prove the byte order", text);
             Assert.Contains("bomless.txt", text);
             Assert.Contains("but you selected windows-1252", text);
             Assert.Contains("Convert 1 file(s)", text);

--- a/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionConfirmationFormTests.cs
@@ -110,6 +110,100 @@ public sealed class ConversionConfirmationFormTests : IDisposable
         });
     }
 
+    /// <summary>
+    /// One planned file carrying the given BOM-less advisory reason code.
+    /// </summary>
+    private ConversionPlan PlanWithAdvisory(string reasonCode, string reason)
+    {
+        return new ConversionPlan
+        {
+            CreatedUtc = DateTime.UtcNow.ToString("O"),
+            EcVersion = "test",
+            BaseDirectory = _root,
+            TargetEncoding = "utf-8",
+            TargetHasBom = false,
+            BackupEnabled = true,
+            ExplicitSourceEncoding = "utf-16",
+            Files =
+            [
+                new PlannedFile
+                {
+                    RelativePath = "bomless.txt",
+                    Size = 20,
+                    Sha256 = new string('0', 64),
+                    Action = PlannedAction.Convert,
+                    SourceEncoding = "utf-16",
+                    SourceCodePage = 1200,
+                    SourceHasBom = false,
+                    SourceWasSpecified = true,
+                    DetectedEncoding = "utf-16",
+                    DetectedCodePage = 1200,
+                    SourceInterpretation = SourceInterpretation.ExplicitSource,
+                    ReasonCode = reasonCode,
+                    Reason = reason,
+                },
+            ],
+        };
+    }
+
+    [Fact]
+    public void ItShowsAnExplicitSourceThatMatchesAnUnprovableEstimate()
+    {
+        // v3.10.1 established that agreeing with an estimate EC has already called
+        // unprovable is the more dangerous of the two cases - the caller repeating a
+        // wrong guess. The review dialog matched only the contradicting reason code, so
+        // it warned about the safer choice and stayed silent for the riskier one. That
+        // is the same inversion v3.10.1 fixed, one surface over.
+        ConversionPlan plan = PlanWithAdvisory(
+            ConversionReasonCodes.ExplicitSourceOnUnprovableBomlessUnicode,
+            "Your selection matches EC's estimate, but that estimate is not evidence.");
+
+        UiTest.OnStaThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+            string text = AllText(form);
+
+            Assert.Contains("could not", text);
+            Assert.Contains("bomless.txt", text);
+            Assert.Contains("not evidence", text);
+            Assert.Contains("Convert 1 file(s)", text);
+            Assert.DoesNotContain("Needs a source encoding", text);
+        });
+    }
+
+    [Fact]
+    public void TheAdvisoryDoesNotClaimTheChoiceDiffersWhenItAgrees()
+    {
+        // The old wording said the estimate "differs from your source choice", which is
+        // untrue for the agreeing case and would tell the reader the opposite of the
+        // risk. Each file's own reason carries the distinction instead.
+        ConversionPlan plan = PlanWithAdvisory(
+            ConversionReasonCodes.ExplicitSourceOnUnprovableBomlessUnicode,
+            "Your selection matches EC's estimate.");
+
+        UiTest.OnStaThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            Assert.DoesNotContain("differs from your source choice", AllText(form));
+        });
+    }
+
+    [Fact]
+    public void AnOrdinaryConversionShowsNoAdvisoryAtAll()
+    {
+        // The control. Both tests above would pass against a dialog that showed the
+        // advisory unconditionally.
+        ConversionPlan plan = PlanWithAdvisory(reasonCode: null!, reason: null!);
+
+        UiTest.OnStaThread(() =>
+        {
+            using var form = new ConversionConfirmationForm(plan);
+
+            Assert.DoesNotContain("taken on trust", AllText(form));
+        });
+    }
+
     [Fact]
     public void ItShowsBomlessUnicodeDisagreementWithoutCallingItARefusal()
     {
@@ -148,8 +242,12 @@ public sealed class ConversionConfirmationFormTests : IDisposable
             using var form = new ConversionConfirmationForm(plan);
             string text = AllText(form);
 
-            Assert.Contains("BOM-less Unicode estimate", text);
+            // Wording is now shared by both advisory cases, so the assertion pins the
+            // per-file reason - which is what distinguishes them - rather than the
+            // heading that no longer mentions disagreement.
+            Assert.Contains("BOM-less byte order EC could not prove", text);
             Assert.Contains("bomless.txt", text);
+            Assert.Contains("but you selected windows-1252", text);
             Assert.Contains("Convert 1 file(s)", text);
             Assert.DoesNotContain("Needs a source encoding", text);
         });

--- a/sources/EncodingChecker.Tests/ConversionJournalTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionJournalTests.cs
@@ -330,7 +330,13 @@ public sealed class ConversionJournalTests : IDisposable
             FilePath = path,
             SourceEncoding = "utf-7",
             TargetEncoding = "utf-8",
-            Result = ConversionRowResult.Error,
+
+            // Refused, not Error: this is what ConvertFiles actually records for a codec
+            // the runtime cannot supply. The fixture previously paired Error with this
+            // reason code, a combination production never produces, and relied on a
+            // mapping that turned any Error on a refused entry into Refused - which is
+            // what let a file EC could not even open be journaled as a policy decision.
+            Result = ConversionRowResult.Refused,
             Action = PlannedAction.Refuse,
             SourceInterpretation = SourceInterpretation.NotApplicable,
             ResolvedSourceLabel = "utf-7",

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -403,6 +403,37 @@ public sealed class ConversionPlanTests : IDisposable
         Assert.Equal(1, Run("-Apply", Path.Combine(_root, "absent.json")));
     }
 
+    [Fact]
+    public void ApplyRejectsAJournalPathThatIsAlsoAPlannedSource()
+    {
+        string source = Path.Combine(_root, "journal-source.json");
+        File.WriteAllText(source, "source text", new UTF8Encoding(true));
+        byte[] before = File.ReadAllBytes(source);
+
+        Assert.Equal(0, Plan());
+        Assert.Equal(1, Run("-Apply", PlanPath, "-Journal", source));
+
+        Assert.Equal(before, File.ReadAllBytes(source));
+    }
+
+    [Fact]
+    public void JournalCannotOverwriteTheBackupItAskedEcToCreate()
+    {
+        string source = Path.Combine(_root, "source.txt");
+        File.WriteAllText(source, "source text", new UTF8Encoding(true));
+        byte[] before = File.ReadAllBytes(source);
+
+        Assert.Equal(1, Run(
+            "-BasePath", _root,
+            "-Target", "utf-8",
+            "-Backup",
+            "-Journal", source + ".bak",
+            "-Quiet"));
+
+        Assert.Equal(before, File.ReadAllBytes(source));
+        Assert.False(File.Exists(source + ".bak"));
+    }
+
     [Theory]
     [InlineData("-DetectOnly")]
     [InlineData("-Validate", "utf-8")]

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -455,7 +455,19 @@ public sealed class ConversionPlanTests : IDisposable
 
         Assert.Equal("shift_jis", plan.ExplicitSourceEncoding);
         Assert.True(Assert.Single(plan.Files).SourceWasSpecified);
-        Assert.Contains("detection bypassed", plan.Summarize());
+
+        string summary = plan.Summarize();
+
+        Assert.Contains("shift_jis", summary);
+        Assert.Contains("chosen by you", summary);
+
+        // Detection is replaced as the codec used, not skipped: it still runs, and its
+        // result is what the conflicting-source refusal and the BOM-less advisories are
+        // decided against. Saying it was bypassed described the absence of the very
+        // input whose loss let an applied plan convert a file recorded as refused.
+        Assert.Contains("detection still ran", summary);
+        Assert.DoesNotContain("bypassed", summary);
+        Assert.NotNull(Assert.Single(plan.Files).DetectedEncoding);
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/DocumentedOptionContractTests.cs
+++ b/sources/EncodingChecker.Tests/DocumentedOptionContractTests.cs
@@ -1,0 +1,191 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// The combinations docs/CLI.md calls invalid must actually be rejected.
+/// </summary>
+/// <remarks>
+/// The documentation stated a contract the validator only partly enforced. Five of the
+/// eight options named for <c>-DetectOnly</c> were rejected; <c>-Target</c>,
+/// <c>-WhatIf</c> and <c>-Backup</c> were accepted and silently ignored, as were
+/// <c>-WhatIf</c> and <c>-Backup</c> under <c>-Validate</c>, and <c>-Quiet</c> with
+/// <c>-Verbose</c>.
+/// <para>
+/// Nothing destructive happened, because the read-only modes write nothing whatever
+/// they are handed. The cost is to automation: a script that meant to convert, and
+/// passed <c>-DetectOnly</c> by mistake or left it in, got exit 0 and a clean report
+/// and no indication that its <c>-Target</c> had been dropped.
+/// </para>
+/// </remarks>
+public sealed class DocumentedOptionContractTests : IDisposable
+{
+    private const int ExpectedClean = 0;
+    private const int ExpectedUsageError = 1;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_optioncontract_").FullName;
+
+    public DocumentedOptionContractTests() =>
+        File.WriteAllText(
+            Path.Combine(_root, "a.txt"), "plain ascii", new UTF8Encoding(false));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(out string stderr, params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            using var errors = new StringWriter();
+            Console.SetOut(new StringWriter());
+            Console.SetError(errors);
+
+            int exitCode = Program.RunConsoleMode(args);
+            stderr = errors.ToString();
+
+            return exitCode;
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    private static int Run(params string[] args) => Run(out _, args);
+
+    [Theory]
+    [InlineData("-Validate", "us-ascii")]
+    [InlineData("-Target", "utf-8")]
+    [InlineData("-From", "windows-1252")]
+    [InlineData("-WhatIf", null)]
+    [InlineData("-Backup", null)]
+    [InlineData("-Plan", "plan.json")]
+    [InlineData("-Apply", "plan.json")]
+    [InlineData("-Journal", "journal.json")]
+    public void DetectOnlyRejectsEveryOptionTheDocumentationNames(string flag, string? value)
+    {
+        // The full list from docs/CLI.md, so the two cannot drift apart unnoticed.
+        string[] args = value is null
+            ? ["-BasePath", _root, "-DetectOnly", flag]
+            : ["-BasePath", _root, "-DetectOnly", flag, Resolve(value)];
+
+        Assert.Equal(ExpectedUsageError, Run(out string stderr, args));
+        Assert.Contains(flag, stderr, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Turns a fixture value into a usable one, creating a real plan where the option
+    /// needs one.
+    /// </summary>
+    /// <remarks>
+    /// <c>-Apply</c> checks that the plan exists before it checks what it was combined
+    /// with, so a placeholder path is rejected for the wrong reason and proves nothing
+    /// about the conflict.
+    /// </remarks>
+    private string Resolve(string value)
+    {
+        if (value != "plan.json")
+            return value;
+
+        string planPath = Path.Combine(_root, "real-plan.json");
+
+        if (!File.Exists(planPath))
+        {
+            Assert.Equal(
+                ExpectedClean,
+                Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+        }
+
+        return planPath;
+    }
+
+    [Theory]
+    [InlineData("-Target", "utf-8")]
+    [InlineData("-From", "windows-1252")]
+    [InlineData("-WhatIf", null)]
+    [InlineData("-Backup", null)]
+    public void ValidateRejectsConversionOptions(string flag, string? value)
+    {
+        string[] args = value is null
+            ? ["-BasePath", _root, "-Validate", "us-ascii", flag]
+            : ["-BasePath", _root, "-Validate", "us-ascii", flag, value];
+
+        Assert.Equal(ExpectedUsageError, Run(out string stderr, args));
+        Assert.Contains(flag, stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void QuietAndVerboseCannotBeCombined()
+    {
+        Assert.Equal(
+            ExpectedUsageError,
+            Run(out string stderr, "-BasePath", _root, "-DetectOnly", "-Quiet", "-Verbose"));
+
+        Assert.Contains("-Quiet", stderr, StringComparison.Ordinal);
+        Assert.Contains("-Verbose", stderr, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("-DetectOnly")]
+    [InlineData("-DetectOnly", "-Quiet")]
+    [InlineData("-DetectOnly", "-Verbose")]
+    [InlineData("-DetectOnly", "-FailOnChanges")]
+    [InlineData("-DetectOnly", "-MaxParallelism", "2")]
+    [InlineData("-Validate", "us-ascii")]
+    [InlineData("-Validate", "us-ascii", "-FailOnChanges")]
+    [InlineData("-Validate", "us-ascii", "-Quiet")]
+    public void CombinationsTheDocumentationAllowsStillWork(params string[] rest)
+    {
+        // The control. Rejecting every pair would satisfy both theories above while
+        // making the read-only modes unusable.
+        Assert.Equal(ExpectedClean, Run(["-BasePath", _root, .. rest]));
+    }
+
+    [Fact]
+    public void TheAmbiguousRefusalNamesBothByteOrdersAndNeitherIsEcsOwnGuess()
+    {
+        // The message declared the two orders indistinguishable and then recommended
+        // "-From utf-16", which resolves to the very reading it had just refused to
+        // stand behind - and under a name that cannot express either choice.
+        string diagnostic = BomlessUnicodeSafety.DescribeRefusal(
+            new UnicodeEncoding(bigEndian: false, byteOrderMark: false));
+
+        Assert.Contains("-From utf-16le", diagnostic, StringComparison.Ordinal);
+        Assert.Contains("-From utf-16be", diagnostic, StringComparison.Ordinal);
+
+        // The bare alias must not be offered as a resolution on its own.
+        Assert.DoesNotContain("-From utf-16.", diagnostic, StringComparison.Ordinal);
+        Assert.DoesNotContain("-From utf-16)", diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothNamedByteOrdersAreOptionsEcActuallyAccepts()
+    {
+        // A message naming an encoding the CLI would reject is worse than no advice.
+        foreach (string charset in new[] { "utf-16le", "utf-16be" })
+        {
+            var options = new Program.CliOptions
+            {
+                BasePath = _root,
+                Target = "utf-8",
+                From = charset,
+            };
+
+            Assert.True(Program.TryValidateOptions(options, out string? error), error);
+        }
+    }
+}

--- a/sources/EncodingChecker.Tests/InterruptedRunJournalTests.cs
+++ b/sources/EncodingChecker.Tests/InterruptedRunJournalTests.cs
@@ -67,7 +67,8 @@ public sealed class InterruptedRunJournalTests : IDisposable
     private OrchestrationResult RunCancellingAfter(
         int stopAfter,
         List<ConversionReportEntry> entries,
-        out List<string> converted)
+        out List<string> converted,
+        int maxParallelism = 1)
     {
         using var cancellation = new CancellationTokenSource();
         var written = new List<string>();
@@ -82,8 +83,7 @@ public sealed class InterruptedRunJournalTests : IDisposable
             targetWriteBom: false,
             backup: false,
             preview: false,
-            // One file at a time, so "cancel after N" is exact rather than a race.
-            maxParallelism: 1,
+            maxParallelism,
             onEntry: entry =>
             {
                 lock (gate)
@@ -161,6 +161,45 @@ public sealed class InterruptedRunJournalTests : IDisposable
     }
 
     [Fact]
+    public void ParallelCancellationAccountsForEveryCompletedCallback()
+    {
+        // ConvertFiles invokes callbacks concurrently. Completion tracking must therefore
+        // remain complete even when several workers finish while cancellation propagates.
+        for (int i = 1; i <= 64; i++)
+            Write($"parallel-{i:D2}.txt");
+
+        List<ConversionReportEntry> entries = Scan();
+
+        OrchestrationResult result =
+            RunCancellingAfter(2, entries, out List<string> converted, maxParallelism: 8);
+
+        Assert.Equal(OrchestrationOutcome.Interrupted, result.Outcome);
+        Assert.NotEmpty(converted);
+
+        ConversionJournal journal = result.Journal!;
+        Assert.Equal(entries.Count, journal.Entries.Count);
+
+        HashSet<string> convertedNames =
+        [
+            .. converted.Select(path => Path.GetFileName(path)!)
+        ];
+
+        foreach (JournalEntry item in journal.Entries)
+        {
+            if (convertedNames.Contains(item.RelativePath))
+            {
+                Assert.Equal(ConversionStatus.Converted, item.Status);
+                Assert.False(StillHasBom(Path.Combine(_root, item.RelativePath)));
+            }
+            else
+            {
+                Assert.Equal(ConversionStatus.NotAttempted, item.Status);
+                Assert.True(StillHasBom(Path.Combine(_root, item.RelativePath)));
+            }
+        }
+    }
+
+    [Fact]
     public void AnUninterruptedRunIsStillReportedAsConverted()
     {
         // The control. Returning Interrupted unconditionally, or marking everything
@@ -183,6 +222,36 @@ public sealed class InterruptedRunJournalTests : IDisposable
         Assert.Equal(ConversionStatus.Converted, recorded.Status);
         Assert.NotNull(recorded.Sha256After);
         Assert.False(StillHasBom(Path.Combine(_root, "only.txt")));
+    }
+
+    [Fact]
+    public void RetryingAnInterruptedRunDoesNotKeepNotAttemptedStatuses()
+    {
+        // The same rows remain in the GUI after interruption. A retry must replace the
+        // first run's NotAttempted markers with what the second run actually did.
+        for (int i = 1; i <= 6; i++)
+            Write($"retry-{i}.txt");
+
+        List<ConversionReportEntry> entries = Scan();
+
+        OrchestrationResult interrupted =
+            RunCancellingAfter(2, entries, out _);
+
+        Assert.Equal(OrchestrationOutcome.Interrupted, interrupted.Outcome);
+        Assert.Contains(entries, entry => entry.NotAttempted);
+
+        var retry = new ConversionOrchestrator(_ => ConfirmationResponse.Proceed);
+
+        OrchestrationResult completed = retry.Run(
+            entries, _root, "utf-16", targetWriteBom: true, backup: false,
+            preview: false, maxParallelism: 1, onEntry: _ => { },
+            CancellationToken.None);
+
+        Assert.Equal(OrchestrationOutcome.Converted, completed.Outcome);
+        Assert.All(entries, entry => Assert.False(entry.NotAttempted));
+        Assert.All(
+            completed.Journal!.Entries,
+            entry => Assert.Equal(ConversionStatus.Converted, entry.Status));
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/InterruptedRunJournalTests.cs
+++ b/sources/EncodingChecker.Tests/InterruptedRunJournalTests.cs
@@ -1,0 +1,208 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Cancelling a conversion that has already written files must still record what it did.
+/// </summary>
+/// <remarks>
+/// Cancellation left <see cref="ConversionOrchestrator.Run"/> by exception, so the
+/// orchestration result was never built and the journal went with it. Files converted
+/// before the cancellation stayed converted with nothing recording the writes - the one
+/// case where the audit trail is most needed is the one where it did not exist.
+/// <para>
+/// There is a trap underneath: an entry keeps the deciding pass's result until the write
+/// pass overwrites it, so a file the run never reached still reads as Converted. A
+/// journal built without allowing for that reports conversions that never happened,
+/// which is worse than no journal at all.
+/// </para>
+/// </remarks>
+public sealed class InterruptedRunJournalTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_interrupted_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    /// <summary>A UTF-8 file with a BOM, so converting to utf-8 rewrites it.</summary>
+    private string Write(string name)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllText(path, $"content of {name}", new UTF8Encoding(true));
+
+        return path;
+    }
+
+    private static bool StillHasBom(string path) =>
+        File.ReadAllBytes(path).Take(3).SequenceEqual(Encoding.UTF8.GetPreamble());
+
+    private List<ConversionReportEntry> Scan()
+    {
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Detect,
+        };
+
+        var sink = new EntrySink();
+        ScanEngine.ScanDirectory(options, sink.Add, CancellationToken.None);
+
+        return sink.ToList();
+    }
+
+    /// <summary>
+    /// Runs a conversion that cancels itself once <paramref name="stopAfter"/> files
+    /// have been written.
+    /// </summary>
+    private OrchestrationResult RunCancellingAfter(
+        int stopAfter,
+        List<ConversionReportEntry> entries,
+        out List<string> converted)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var written = new List<string>();
+        object gate = new();
+
+        var orchestrator = new ConversionOrchestrator(_ => ConfirmationResponse.Proceed);
+
+        OrchestrationResult result = orchestrator.Run(
+            entries,
+            _root,
+            "utf-8",
+            targetWriteBom: false,
+            backup: false,
+            preview: false,
+            // One file at a time, so "cancel after N" is exact rather than a race.
+            maxParallelism: 1,
+            onEntry: entry =>
+            {
+                lock (gate)
+                {
+                    if (entry.Result == ConversionRowResult.Converted)
+                        written.Add(entry.FilePath);
+
+                    if (written.Count >= stopAfter)
+                        cancellation.Cancel();
+                }
+            },
+            cancellation.Token);
+
+        converted = written;
+
+        return result;
+    }
+
+    [Fact]
+    public void ACancelledRunStillProducesAJournalOfWhatItWrote()
+    {
+        for (int i = 1; i <= 6; i++)
+            Write($"f{i}.txt");
+
+        List<ConversionReportEntry> entries = Scan();
+
+        OrchestrationResult result =
+            RunCancellingAfter(2, entries, out List<string> converted);
+
+        Assert.Equal(OrchestrationOutcome.Interrupted, result.Outcome);
+
+        // The point of the fix: the record of the writes survives the cancellation.
+        Assert.NotNull(result.Journal);
+        Assert.Equal(entries.Count, result.Journal!.Entries.Count);
+
+        Assert.All(
+            converted,
+            path => Assert.False(
+                StillHasBom(path), "a file reported converted was not rewritten"));
+    }
+
+    [Fact]
+    public void FilesTheRunNeverReachedAreNotReportedAsConverted()
+    {
+        // The trap. Every entry arrives at the write pass already marked Converted by
+        // the deciding pass, so a journal that trusts that reports the whole batch as
+        // done however early the cancellation landed.
+        for (int i = 1; i <= 6; i++)
+            Write($"f{i}.txt");
+
+        List<ConversionReportEntry> entries = Scan();
+
+        OrchestrationResult result =
+            RunCancellingAfter(2, entries, out List<string> converted);
+
+        ConversionJournal journal = result.Journal!;
+
+        int reportedConverted = journal.Entries.Count(
+            e => e.Status == ConversionStatus.Converted);
+
+        int reportedNotAttempted = journal.Entries.Count(
+            e => e.Status == ConversionStatus.NotAttempted);
+
+        Assert.Equal(converted.Count, reportedConverted);
+        Assert.Equal(entries.Count - converted.Count, reportedNotAttempted);
+
+        // And the files it never reached still hold their original bytes, which is what
+        // makes NotAttempted the true statement rather than merely the cautious one.
+        foreach (JournalEntry entry in journal.Entries
+                     .Where(e => e.Status == ConversionStatus.NotAttempted))
+        {
+            Assert.True(StillHasBom(Path.Combine(_root, entry.RelativePath)));
+            Assert.Null(entry.Sha256After);
+        }
+    }
+
+    [Fact]
+    public void AnUninterruptedRunIsStillReportedAsConverted()
+    {
+        // The control. Returning Interrupted unconditionally, or marking everything
+        // NotAttempted, would satisfy both tests above.
+        Write("only.txt");
+
+        List<ConversionReportEntry> entries = Scan();
+
+        using var cancellation = new CancellationTokenSource();
+        var orchestrator = new ConversionOrchestrator(_ => ConfirmationResponse.Proceed);
+
+        OrchestrationResult result = orchestrator.Run(
+            entries, _root, "utf-8", targetWriteBom: false, backup: false,
+            preview: false, maxParallelism: 1, onEntry: _ => { }, cancellation.Token);
+
+        Assert.Equal(OrchestrationOutcome.Converted, result.Outcome);
+
+        JournalEntry recorded = Assert.Single(result.Journal!.Entries);
+
+        Assert.Equal(ConversionStatus.Converted, recorded.Status);
+        Assert.NotNull(recorded.Sha256After);
+        Assert.False(StillHasBom(Path.Combine(_root, "only.txt")));
+    }
+
+    [Fact]
+    public void DecliningAtTheReviewIsStillReportedAsUntouched()
+    {
+        // Interrupted must not swallow the outcome it was split away from: declining
+        // the confirmation writes nothing and has no journal to keep.
+        Write("declined.txt");
+
+        List<ConversionReportEntry> entries = Scan();
+
+        var orchestrator = new ConversionOrchestrator(_ => ConfirmationResponse.Cancel);
+
+        OrchestrationResult result = orchestrator.Run(
+            entries, _root, "utf-8", targetWriteBom: false, backup: false,
+            preview: false, maxParallelism: 1, onEntry: _ => { },
+            CancellationToken.None);
+
+        Assert.Equal(OrchestrationOutcome.Cancelled, result.Outcome);
+        Assert.Null(result.Journal);
+        Assert.True(StillHasBom(Path.Combine(_root, "declined.txt")));
+    }
+}

--- a/sources/EncodingChecker.Tests/JournalOutcomeFidelityTests.cs
+++ b/sources/EncodingChecker.Tests/JournalOutcomeFidelityTests.cs
@@ -1,0 +1,254 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// The journal must describe what became of each file, not what was intended for it.
+/// </summary>
+/// <remarks>
+/// One status table was wrong in both directions. A file EC never opened was recorded
+/// as <c>Refused</c> - a safety decision - while the run reporting it exited 3, so the
+/// audit record and the exit code disagreed about every locked file. And conversion can
+/// fail after the replacement is installed, when the recovery record cannot be marked
+/// complete or attributes cannot be restored; those were recorded as <c>Failed</c>,
+/// documented as "not touched", for a file that had already been rewritten.
+/// <para>
+/// The post-installation cases are asserted at the journal boundary rather than end to
+/// end. Both need an I/O failure inside a window of a few instructions after
+/// <c>File.Replace</c> returns, which cannot be produced reliably from outside the
+/// process; what is testable, and what was wrong, is the mapping.
+/// </para>
+/// </remarks>
+public sealed class JournalOutcomeFidelityTests : IDisposable
+{
+    private const int ExpectedProcessingErrors = 3;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_journalfidelity_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    private string Write(string name, string content = "plain ascii")
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllText(path, content, new UTF8Encoding(false));
+
+        return path;
+    }
+
+    private JournalEntry Journal(ConversionReportEntry entry) =>
+        Assert.Single(
+            ConversionJournal.FromRun(
+                [entry], _root, "utf-8", targetHasBom: false, backupEnabled: true,
+                explicitSource: null, surface: "Test",
+                startedUtc: DateTime.UtcNow).Entries);
+
+    [Fact]
+    public void AFileThatCouldNotBeOpenedIsFailedNotRefused()
+    {
+        // End to end, because this one is producible: an exclusive handle denies the
+        // scan the same way another process would.
+        Write("good.txt");
+        string locked = Write("locked.txt");
+        string journalPath = Path.Combine(_root, "journal.json");
+
+        using (new FileStream(locked, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.Equal(
+                ExpectedProcessingErrors,
+                Run("-BasePath", _root, "-Target", "utf-8-bom",
+                    "-Journal", journalPath, "-Quiet"));
+        }
+
+        ConversionJournal written = ReadJournal(journalPath);
+
+        JournalEntry failed =
+            Assert.Single(written.Entries, e => e.RelativePath == "locked.txt");
+
+        // The run exits 3. An audit record calling that a policy refusal contradicts it.
+        Assert.Equal(ConversionStatus.Failed, failed.Status);
+        Assert.Equal(ConversionReasonCodes.ScanFailed, failed.ReasonCode);
+        Assert.Null(failed.Sha256After);
+    }
+
+    [Fact]
+    public void AGenuineRefusalIsStillRefused()
+    {
+        // The control. Mapping every error to Failed would satisfy the test above while
+        // erasing the distinction the journal exists to record.
+        File.WriteAllBytes(
+            Path.Combine(_root, "ambiguous.txt"),
+            new UnicodeEncoding(bigEndian: false, byteOrderMark: false)
+                .GetBytes("Hello World, this is plain text."));
+        string journalPath = Path.Combine(_root, "journal.json");
+
+        Run("-BasePath", _root, "-Target", "utf-8", "-Journal", journalPath, "-Quiet");
+
+        JournalEntry refused = Assert.Single(ReadJournal(journalPath).Entries);
+
+        Assert.Equal(ConversionStatus.Refused, refused.Status);
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, refused.ReasonCode);
+    }
+
+    [Fact]
+    public void AFailureAfterInstallationIsNotReportedAsUntouched()
+    {
+        // ReplacementCommitted: true with a failure is exactly what RecoveryRecordError
+        // and MetadataRestoreFailed produce once the file is already replaced.
+        string path = Write("installed.txt");
+
+        JournalEntry recorded = Journal(new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-8",
+            TargetEncoding = "utf-8",
+            Action = PlannedAction.Convert,
+            SourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii,
+            Result = ConversionRowResult.Error,
+            ReplacementCommitted = true,
+            OutputSha256 = new string('a', 64),
+            ReasonCode = nameof(ConversionErrorCode.RecoveryRecordError),
+        });
+
+        Assert.Equal(ConversionStatus.ConvertedWithWarning, recorded.Status);
+
+        // The file changed, so it needs an after-hash; Failed would have left it null.
+        Assert.Equal(new string('a', 64), recorded.Sha256After);
+    }
+
+    [Fact]
+    public void AnUndeterminedInstallationSaysSoRatherThanGuessing()
+    {
+        // ReplacementCommitted: null is the converter reporting that it cannot tell.
+        // Failed would claim the file is untouched and ConvertedWithWarning would claim
+        // it was installed; neither was established.
+        string path = Write("unknown.txt", "what is actually on disk");
+
+        JournalEntry recorded = Journal(new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-8",
+            TargetEncoding = "utf-8",
+            Action = PlannedAction.Convert,
+            SourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii,
+            Result = ConversionRowResult.Error,
+            ReplacementCommitted = null,
+            OutputSha256 = new string('a', 64),
+            ReasonCode = nameof(ConversionErrorCode.ReplacementError),
+        });
+
+        Assert.Equal(ConversionStatus.InstallationUnknown, recorded.Status);
+
+        // Whether those verified bytes were installed is the open question, so the
+        // record reports what is on disk instead of asserting the answer.
+        Assert.NotEqual(new string('a', 64), recorded.Sha256After);
+        Assert.Equal(ConversionMetadataStore.ComputeSha256(path), recorded.Sha256After);
+    }
+
+    [Fact]
+    public void AFailureBeforeInstallationIsStillFailedAndUntouched()
+    {
+        // The control for both cases above. Backup and verification failures leave the
+        // original in place, and that is exactly what Failed is for.
+        string path = Write("untouched.txt");
+
+        JournalEntry recorded = Journal(new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-8",
+            TargetEncoding = "utf-8",
+            Action = PlannedAction.Convert,
+            SourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii,
+            Result = ConversionRowResult.Error,
+            ReplacementCommitted = false,
+            ReasonCode = ConversionReasonCodes.BackupFailed,
+        });
+
+        Assert.Equal(ConversionStatus.Failed, recorded.Status);
+        Assert.Null(recorded.Sha256After);
+    }
+
+    [Fact]
+    public void TheAfterHashIsTheOneVerificationPassed()
+    {
+        // The journal is written after the whole batch, so re-reading records whatever
+        // is on disk by then rather than what this run installed and verified. The two
+        // are made to differ here so the assertion can tell which was used.
+        string path = Write("verified.txt", "the bytes now on disk");
+        string verified = new('b', 64);
+
+        JournalEntry recorded = Journal(new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-8",
+            TargetEncoding = "utf-8",
+            Action = PlannedAction.Convert,
+            SourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii,
+            Result = ConversionRowResult.Converted,
+            ReplacementCommitted = true,
+            OutputSha256 = verified,
+        });
+
+        Assert.Equal(ConversionStatus.Converted, recorded.Status);
+        Assert.Equal(verified, recorded.Sha256After);
+        Assert.NotEqual(ConversionMetadataStore.ComputeSha256(path), recorded.Sha256After);
+    }
+
+    [Fact]
+    public void WithoutARecoveryRecordTheAfterHashFallsBackToReadingTheFile()
+    {
+        // No backup means no verified output hash was ever computed, so the fallback
+        // has to stay. Losing it would leave converted files with no after-hash at all.
+        string path = Write("nobackup.txt");
+
+        JournalEntry recorded = Journal(new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-8",
+            TargetEncoding = "utf-8",
+            Action = PlannedAction.Convert,
+            SourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii,
+            Result = ConversionRowResult.Converted,
+            ReplacementCommitted = true,
+            OutputSha256 = null,
+        });
+
+        Assert.Equal(ConversionMetadataStore.ComputeSha256(path), recorded.Sha256After);
+    }
+
+    private static ConversionJournal ReadJournal(string path)
+    {
+        using FileStream stream = File.OpenRead(path);
+
+        return System.Text.Json.JsonSerializer.Deserialize<ConversionJournal>(stream)!;
+    }
+}

--- a/sources/EncodingChecker.Tests/JournalOutcomeFidelityTests.cs
+++ b/sources/EncodingChecker.Tests/JournalOutcomeFidelityTests.cs
@@ -198,6 +198,31 @@ public sealed class JournalOutcomeFidelityTests : IDisposable
     }
 
     [Fact]
+    public void ARealBackupFailureIsRecordedAsFailedNotInstallationUnknown()
+    {
+        // A directory at the fixed backup path makes backup creation fail before the
+        // converter starts. The journal must not imply that installation may have run.
+        string path = Path.Combine(_root, "backup-fails.txt");
+        File.WriteAllText(path, "plain text", new UTF8Encoding(true));
+        byte[] before = File.ReadAllBytes(path);
+        Directory.CreateDirectory(path + ".bak");
+
+        string journalPath = Path.Combine(_root, "backup-failure-journal.json");
+
+        Assert.Equal(
+            ExpectedProcessingErrors,
+            Run("-BasePath", _root, "-Include", "backup-fails.txt", "-Target", "utf-8",
+                "-Backup", "-Journal", journalPath, "-Quiet"));
+
+        JournalEntry recorded = Assert.Single(ReadJournal(journalPath).Entries);
+
+        Assert.Equal(ConversionStatus.Failed, recorded.Status);
+        Assert.Equal(ConversionReasonCodes.BackupFailed, recorded.ReasonCode);
+        Assert.Null(recorded.Sha256After);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
     public void TheAfterHashIsTheOneVerificationPassed()
     {
         // The journal is written after the whole batch, so re-reading records whatever

--- a/sources/EncodingChecker.Tests/PlanPreflightReportingTests.cs
+++ b/sources/EncodingChecker.Tests/PlanPreflightReportingTests.cs
@@ -177,7 +177,7 @@ public sealed class PlanPreflightReportingTests : IDisposable
         Assert.NotNull(plan);
 
         PlannedFile unreadable =
-            Assert.Single(plan!.Files.Where(f => f.RelativePath == "locked.txt"));
+            Assert.Single(plan!.Files, f => f.RelativePath == "locked.txt");
 
         // Recorded, visible, and making no claim about bytes it could not read.
         Assert.Equal(PlannedAction.Refuse, unreadable.Action);

--- a/sources/EncodingChecker.Tests/PlanPreflightReportingTests.cs
+++ b/sources/EncodingChecker.Tests/PlanPreflightReportingTests.cs
@@ -1,0 +1,257 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A plan run must report files it could not read, and a plan holding one must remain
+/// usable for the files it could.
+/// </summary>
+/// <remarks>
+/// Two defects met here. The plan branch returned before the <c>Error</c> check, so a
+/// run that never opened some of its files exited 0 - the same scan without
+/// <c>-Plan</c> exited 3. And planning deliberately records an unreadable file as a
+/// refusal with an empty hash, "rather than silently dropping" it, while loading
+/// rejected any entry without one. A single transiently locked file therefore produced
+/// a plan that reported success and could never be applied, taking every readable file
+/// with it.
+/// <para>
+/// The fixture holds a real exclusive handle rather than simulating the failure, so
+/// what is exercised is the same <see cref="IOException"/> path a locked file produces
+/// in the field. A second open in the same process is blocked by
+/// <see cref="FileShare.None"/> exactly as it would be from another one.
+/// </para>
+/// </remarks>
+public sealed class PlanPreflightReportingTests : IDisposable
+{
+    private const int ExpectedClean = 0;
+    private const int ExpectedUsageError = 1;
+    private const int ExpectedChangesNeeded = 2;
+    private const int ExpectedProcessingErrors = 3;
+    private const int ExpectedSafeRefusal = 5;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_planpreflight_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(out string stderr, params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            using var errors = new StringWriter();
+            Console.SetOut(new StringWriter());
+            Console.SetError(errors);
+
+            int exitCode = Program.RunConsoleMode(args);
+            stderr = errors.ToString();
+
+            return exitCode;
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    private static int Run(params string[] args) => Run(out _, args);
+
+    /// <summary>A UTF-8 file with a BOM, so converting to utf-8 rewrites it.</summary>
+    private string Write(string name)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllText(path, "hello world", new UTF8Encoding(true));
+
+        return path;
+    }
+
+    /// <summary>Denies every other handle, producing the same failure as a locked file.</summary>
+    private static FileStream HoldExclusively(string path) =>
+        new(path, FileMode.Open, FileAccess.Read, FileShare.None);
+
+    private static bool StillHasBom(string path) =>
+        File.ReadAllBytes(path).Take(3).SequenceEqual(Encoding.UTF8.GetPreamble());
+
+    [Fact]
+    public void PlanOverAnUnreadableFile_ExitsThreeLikeTheSameScanWithoutPlan()
+    {
+        Write("good.txt");
+        string locked = Write("locked.txt");
+        string planPath = Path.Combine(_root, "plan.json");
+
+        using (HoldExclusively(locked))
+        {
+            // The control is the same scan without -Plan: whatever it reports, the plan
+            // run must not report better.
+            Assert.Equal(
+                ExpectedProcessingErrors,
+                Run("-BasePath", _root, "-Target", "utf-8", "-WhatIf", "-Quiet"));
+
+            Assert.Equal(
+                ExpectedProcessingErrors,
+                Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+        }
+
+        // The plan is still written and still names the file, so exit 3 is diagnosable.
+        Assert.True(File.Exists(planPath));
+    }
+
+    [Fact]
+    public void TheUnreadableFileIsNamedOnStderrEvenWhenQuiet()
+    {
+        // -Quiet suppresses the CSV, which was the only place the reason appeared. An
+        // exit code with nothing to act on is not a report.
+        string locked = Write("locked.txt");
+
+        using (HoldExclusively(locked))
+        {
+            Run(out string stderr, "-BasePath", _root, "-Target", "utf-8", "-Quiet");
+
+            Assert.Contains("locked.txt", stderr);
+        }
+    }
+
+    [Fact]
+    public void ErrorsOutrankFailOnChanges()
+    {
+        // Published precedence is 3 before 2. A run that both needs changes and failed
+        // to read something must report the failure.
+        Write("good.txt");
+        string locked = Write("locked.txt");
+        string planPath = Path.Combine(_root, "plan.json");
+
+        using (HoldExclusively(locked))
+        {
+            Assert.Equal(
+                ExpectedProcessingErrors,
+                Run("-BasePath", _root, "-Target", "utf-8", "-FailOnChanges",
+                    "-Plan", planPath, "-Quiet"));
+        }
+    }
+
+    [Fact]
+    public void ACleanPlanStillExitsZeroAndFailOnChangesStillReturnsTwo()
+    {
+        // The control. Returning 3 unconditionally would satisfy every test above.
+        Write("good.txt");
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(
+            ExpectedClean,
+            Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet"));
+
+        Assert.Equal(
+            ExpectedChangesNeeded,
+            Run("-BasePath", _root, "-Target", "utf-8", "-FailOnChanges",
+                "-Plan", planPath, "-Quiet"));
+    }
+
+    [Fact]
+    public void APlanHoldingAnUnreadableFileStillAppliesTheReadableOnes()
+    {
+        string good = Write("good.txt");
+        string locked = Write("locked.txt");
+        string planPath = Path.Combine(_root, "plan.json");
+
+        using (HoldExclusively(locked))
+        {
+            Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet");
+        }
+
+        ConversionPlan? plan = ConversionPlan.Load(planPath, out string? error);
+
+        Assert.Null(error);
+        Assert.NotNull(plan);
+
+        PlannedFile unreadable =
+            Assert.Single(plan!.Files.Where(f => f.RelativePath == "locked.txt"));
+
+        // Recorded, visible, and making no claim about bytes it could not read.
+        Assert.Equal(PlannedAction.Refuse, unreadable.Action);
+        Assert.Equal(string.Empty, unreadable.Sha256);
+
+        // The hashless refusal must not be reported as changed content.
+        Assert.Empty(plan.FindStaleFiles());
+
+        Assert.Equal(ExpectedSafeRefusal, Run("-Apply", planPath));
+
+        Assert.False(StillHasBom(good));
+        Assert.True(StillHasBom(locked));
+    }
+
+    [Fact]
+    public void APlanSchedulingAConversionWithoutAHashIsStillRefused()
+    {
+        // The safety property must not be weakened by the fix. A hash is what pins a
+        // conversion to reviewed content, so an entry that will be written still needs
+        // one; only entries that will not be written are exempt.
+        Write("good.txt");
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet");
+
+        string json = File.ReadAllText(planPath);
+        string hash = ConversionMetadataStore.ComputeSha256(
+            Path.Combine(_root, "good.txt"));
+
+        Assert.Contains(hash, json, StringComparison.OrdinalIgnoreCase);
+
+        string stripped = json.Replace(hash, string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        Assert.NotEqual(json, stripped);
+        File.WriteAllText(planPath, stripped);
+
+        Assert.Null(ConversionPlan.Load(planPath, out string? error));
+        Assert.Contains("good.txt", error);
+        Assert.Equal(ExpectedUsageError, Run("-Apply", planPath));
+    }
+
+    [Fact]
+    public void ARefusalThatDidRecordAHashStillGoesStaleWhenItChanges()
+    {
+        // Exempting hashless entries must not exempt entries that have one. A plan is
+        // reviewed as a whole, so a refused file whose bytes moved still invalidates it.
+        //
+        // BOM-less UTF-16 whose byte order cannot be proven is the dependable refusal
+        // fixture. Short legacy text is not: sample-based detection accepts a truncated
+        // trailing sequence, so "café" in windows-1252 reads as UTF-8 and plans as
+        // Unchanged rather than as a refusal.
+        string path = Path.Combine(_root, "ambiguous.txt");
+        File.WriteAllBytes(
+            path,
+            new UnicodeEncoding(bigEndian: false, byteOrderMark: false)
+                .GetBytes("Hello World, this is plain text."));
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Run("-BasePath", _root, "-Target", "utf-8", "-Plan", planPath, "-Quiet");
+
+        ConversionPlan plan = ConversionPlan.Load(planPath, out _)!;
+        PlannedFile refused = Assert.Single(plan.Files);
+
+        Assert.Equal(PlannedAction.Refuse, refused.Action);
+        Assert.NotEqual(string.Empty, refused.Sha256);
+        Assert.Empty(plan.FindStaleFiles());
+
+        File.WriteAllBytes(
+            path,
+            new UnicodeEncoding(bigEndian: false, byteOrderMark: false)
+                .GetBytes("Hello World, this is different text now."));
+
+        Assert.Contains(
+            "contents changed",
+            Assert.Single(ConversionPlan.Load(planPath, out _)!.FindStaleFiles()));
+    }
+}

--- a/sources/EncodingChecker.Tests/PlanPreflightReportingTests.cs
+++ b/sources/EncodingChecker.Tests/PlanPreflightReportingTests.cs
@@ -186,7 +186,7 @@ public sealed class PlanPreflightReportingTests : IDisposable
         // The hashless refusal must not be reported as changed content.
         Assert.Empty(plan.FindStaleFiles());
 
-        Assert.Equal(ExpectedSafeRefusal, Run("-Apply", planPath));
+        Assert.Equal(ExpectedProcessingErrors, Run("-Apply", planPath));
 
         Assert.False(StillHasBom(good));
         Assert.True(StillHasBom(locked));
@@ -217,6 +217,40 @@ public sealed class PlanPreflightReportingTests : IDisposable
         Assert.Null(ConversionPlan.Load(planPath, out string? error));
         Assert.Contains("good.txt", error);
         Assert.Equal(ExpectedUsageError, Run("-Apply", planPath));
+    }
+
+    [Fact]
+    public void AFileLostDuringPlanMaterializationBecomesAnExplainedError()
+    {
+        // This is the narrow race after the deciding pass but before FromEntries reads
+        // the source. The plan must remain complete without claiming a policy refusal.
+        string path = Path.Combine(_root, "vanished.txt");
+
+        var entry = new ConversionReportEntry
+        {
+            FilePath = path,
+            SourceEncoding = "utf-8",
+            SourceHasBom = true,
+            TargetEncoding = "utf-8",
+            TargetHasBom = false,
+            Action = PlannedAction.Convert,
+            SourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii,
+            Result = ConversionRowResult.Converted,
+        };
+
+        ConversionPlan plan = ConversionPlan.FromEntries(
+            [entry], _root, "utf-8", targetHasBom: false,
+            backupEnabled: false, explicitSource: null);
+
+        PlannedFile planned = Assert.Single(plan.Files);
+        Assert.Equal(PlannedAction.Refuse, planned.Action);
+        Assert.Equal(string.Empty, planned.Sha256);
+        Assert.Equal(ConversionReasonCodes.SourceSnapshotFailed, planned.ReasonCode);
+
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(SourceInterpretation.NotApplicable, entry.SourceInterpretation);
+        Assert.Contains("could not be read consistently", entry.Diagnostic);
     }
 
     [Fact]

--- a/sources/EncodingChecker.Tests/ReadOnlyModeAmbiguityTests.cs
+++ b/sources/EncodingChecker.Tests/ReadOnlyModeAmbiguityTests.cs
@@ -1,0 +1,221 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Every mode must agree about whether a BOM-less UTF-16 byte order can be established.
+/// </summary>
+/// <remarks>
+/// Ambiguity was computed only for <see cref="ScanAction.Convert"/>, so the same bytes
+/// got three different confidences from one build: <c>-DetectOnly</c> reported utf-16
+/// with no caveat and exit 0, <c>-Validate "utf-16"</c> reported the file valid and
+/// exit 0, and <c>-Target</c> refused it with exit 5. The validate row is the one that
+/// mattered - a CI gate went green on a file EC had already decided it could not read
+/// safely, and a later conversion of that same tree halts.
+/// <para>
+/// Byte-swapped Latin text lands in the CJK range, so both byte orders decode strictly
+/// and the file cannot say which it is. That is a fact about the bytes, not a property
+/// of conversion, so it now holds in every mode.
+/// </para>
+/// </remarks>
+public sealed class ReadOnlyModeAmbiguityTests : IDisposable
+{
+    private const int ExpectedClean = 0;
+    private const int ExpectedChangesNeeded = 2;
+    private const int ExpectedSafeRefusal = 5;
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_ambiguity_modes_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(params string[] args)
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    /// <summary>Latin text in BOM-less UTF-16LE, which decodes equally well as BE.</summary>
+    private string WriteAmbiguous(string name = "ambiguous.txt")
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllBytes(
+            path,
+            new UnicodeEncoding(bigEndian: false, byteOrderMark: false)
+                .GetBytes("Hello World, this is plain text."));
+
+        return path;
+    }
+
+    /// <summary>BOM-less UTF-16LE whose opposite order is structurally impossible.</summary>
+    private string WriteProvable(string name = "provable.txt")
+    {
+        string path = Path.Combine(_root, name);
+
+        // U+00D8 is stored little-endian as D8 00, which read big-endian is an unpaired
+        // high surrogate, so strict UTF-16BE decoding rejects the file.
+        //
+        // A supplementary-plane character does NOT work here, which is worth recording:
+        // byte-swapping the surrogate pair D83D DE00 yields 3DD8 and 00DE, both ordinary
+        // scalars, so such a file remains ambiguous.
+        File.WriteAllBytes(
+            path,
+            new UnicodeEncoding(bigEndian: false, byteOrderMark: false)
+                .GetBytes("Hello Ø World, plain text here now ok."));
+
+        return path;
+    }
+
+    private List<ConversionReportEntry> Scan(ScanAction action, params string[] validCharsets)
+    {
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = action,
+            ValidCharsets = validCharsets.Length == 0 ? null : validCharsets,
+            TargetCharset = action == ScanAction.Convert ? "utf-8" : null,
+            WhatIf = action == ScanAction.Convert,
+        };
+
+        var sink = new EntrySink();
+        ScanEngine.ScanDirectory(options, sink.Add, CancellationToken.None);
+
+        return sink.ToList();
+    }
+
+    [Fact]
+    public void DetectOnly_ReportsThatTheByteOrderIsAnEstimate()
+    {
+        WriteAmbiguous();
+
+        ConversionReportEntry entry = Assert.Single(Scan(ScanAction.Detect));
+
+        Assert.Equal("utf-16", entry.SourceEncoding);
+
+        // Nothing failed and nothing was withheld, so the result stays Unchanged; the
+        // row has to say which of the two readings it is reporting.
+        Assert.Equal(ConversionRowResult.Unchanged, entry.Result);
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, entry.ReasonCode);
+        Assert.Contains("estimate", entry.Diagnostic);
+
+        // The refusal wording would be false here: nothing was going to be converted.
+        Assert.DoesNotContain("no conversion was performed", entry.Diagnostic);
+    }
+
+    [Fact]
+    public void Validate_DoesNotPassAFileWhoseIdentityItCannotEstablish()
+    {
+        WriteAmbiguous();
+
+        ConversionReportEntry entry = Assert.Single(Scan(ScanAction.Validate, "utf-16"));
+
+        Assert.Equal(ConversionRowResult.Invalid, entry.Result);
+        Assert.Equal(ConversionReasonCodes.AmbiguousBomlessUtf16, entry.ReasonCode);
+
+        // The reason must not read as "wrong encoding": the label was allowed, and it is
+        // the file's membership of it that cannot be confirmed.
+        Assert.Contains("is in the allowed list", entry.Diagnostic);
+    }
+
+    [Fact]
+    public void EveryModeAgreesAboutTheSameBytes()
+    {
+        // The point of the fix. Before it, these three lines disagreed.
+        string path = WriteAmbiguous();
+        byte[] original = File.ReadAllBytes(path);
+
+        Assert.Equal(ExpectedClean, Run("-BasePath", _root, "-DetectOnly"));
+        Assert.Equal(
+            ExpectedChangesNeeded,
+            Run("-BasePath", _root, "-Validate", "utf-16", "-FailOnChanges", "-Quiet"));
+        Assert.Equal(
+            ExpectedSafeRefusal,
+            Run("-BasePath", _root, "-Target", "utf-8", "-WhatIf", "-Quiet"));
+
+        Assert.Equal(original, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void AProvableByteOrderStillPassesEveryMode()
+    {
+        // The control. A check that flagged all BOM-less UTF-16 would satisfy the tests
+        // above while making -Validate useless for the encoding it exists to check.
+        WriteProvable();
+
+        ConversionReportEntry detected = Assert.Single(Scan(ScanAction.Detect));
+
+        Assert.Equal("utf-16", detected.SourceEncoding);
+        Assert.Null(detected.ReasonCode);
+        Assert.False(detected.HasAmbiguousBomlessUtf16);
+
+        ConversionReportEntry validated =
+            Assert.Single(Scan(ScanAction.Validate, "utf-16"));
+
+        Assert.Equal(ConversionRowResult.Unchanged, validated.Result);
+        Assert.Null(validated.ReasonCode);
+
+        ConversionReportEntry converted = Assert.Single(Scan(ScanAction.Convert));
+
+        Assert.Equal(PlannedAction.Convert, converted.Action);
+    }
+
+    [Fact]
+    public void AFileWithAByteOrderMarkIsNeverAmbiguous()
+    {
+        // A BOM settles the question, which is exactly the remedy the diagnostic offers.
+        //
+        // Encoding.GetBytes never emits a preamble whatever the constructor was given,
+        // so the marker is written explicitly. Relying on byteOrderMark: true produces a
+        // BOM-less file, and the test then asserts the opposite of what it claims.
+        var utf16 = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+        string path = Path.Combine(_root, "withbom.txt");
+        File.WriteAllBytes(
+            path,
+            [
+                .. utf16.GetPreamble(),
+                .. utf16.GetBytes("Hello World, this is plain text."),
+            ]);
+
+        ConversionReportEntry entry = Assert.Single(Scan(ScanAction.Detect));
+
+        Assert.False(entry.HasAmbiguousBomlessUtf16);
+        Assert.Null(entry.ReasonCode);
+    }
+
+    [Fact]
+    public void NonUtf16FilesAreUnaffected()
+    {
+        // The ambiguity probe is guarded by code page before it opens anything, so the
+        // ordinary case must not acquire a reason code or a second read.
+        File.WriteAllText(Path.Combine(_root, "plain.txt"), "just ascii here");
+
+        ConversionReportEntry entry = Assert.Single(Scan(ScanAction.Detect));
+
+        Assert.Equal("us-ascii", entry.SourceEncoding);
+        Assert.False(entry.HasAmbiguousBomlessUtf16);
+        Assert.Null(entry.ReasonCode);
+    }
+}

--- a/sources/EncodingChecker.Tests/RecordedProvenanceTests.cs
+++ b/sources/EncodingChecker.Tests/RecordedProvenanceTests.cs
@@ -1,0 +1,228 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// What the plan, the summary, and the sidecar say about a run must be true of it.
+/// </summary>
+public sealed class RecordedProvenanceTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_provenance_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string Write(string name, string text, string charset)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllBytes(path, Encoding.GetEncoding(charset).GetBytes(text));
+
+        return path;
+    }
+
+    private List<ConversionReportEntry> Scan()
+    {
+        var sink = new EntrySink();
+
+        ScanEngine.ScanDirectory(
+            new ScanDirectoryOptions { BaseDirectory = _root, Action = ScanAction.Detect },
+            sink.Add,
+            CancellationToken.None);
+
+        return sink.ToList();
+    }
+
+    /// <summary>
+    /// Runs a preview, answering the review by choosing <paramref name="choices"/> in
+    /// turn - one encoding per round, each scoped to the files still refused.
+    /// </summary>
+    private ConversionPlan? PlanAfterChoosing(
+        List<ConversionReportEntry> entries, params string[] choices)
+    {
+        int round = 0;
+        ConversionPlan? last = null;
+
+        var orchestrator = new ConversionOrchestrator(plan =>
+        {
+            last = plan;
+
+            if (round >= choices.Length)
+                return ConfirmationResponse.Cancel;
+
+            string charset = choices[round++];
+
+            // Scope each answer to one refused file, which is what the dialog does and
+            // what makes a mixed-source batch reachable at all.
+            string? target = plan.Files
+                .Where(f => f.NeedsSourceChoice)
+                .Select(f => plan.ResolvePath(f))
+                .FirstOrDefault(p => p is not null);
+
+            return target is null
+                ? ConfirmationResponse.Cancel
+                : new ConfirmationResponse(
+                    ConfirmationChoice.ChooseSourceEncoding, charset, [target]);
+        });
+
+        orchestrator.Run(
+            entries, _root, "utf-8", targetWriteBom: false, backup: false,
+            preview: false, maxParallelism: 1, onEntry: _ => { },
+            CancellationToken.None);
+
+        return last;
+    }
+
+    [Fact]
+    public void ABatchResolvedWithSeveralEncodingsNamesNoneOfThemAsTheRunsSource()
+    {
+        // The GUI scopes each choice to the files it was ticked for, so a batch can end
+        // with every file explicit and no two agreeing. Recording entries[0]'s label
+        // stated one encoding for a run that used another.
+        Write("a.txt", "café résumé façade", "windows-1252");
+        Write("b.txt", "привет мир текст", "koi8-r");
+
+        List<ConversionReportEntry> entries = Scan();
+
+        Assert.Equal(2, entries.Count);
+
+        ConversionPlan? plan = PlanAfterChoosing(entries, "windows-1252", "koi8-r");
+
+        Assert.NotNull(plan);
+
+        string[] chosen =
+        [
+            .. plan!.Files.Where(f => f.SourceWasSpecified)
+                          .Select(f => f.SourceEncoding)
+                          .Distinct(StringComparer.OrdinalIgnoreCase)
+        ];
+
+        Assert.Equal(2, chosen.Length);
+
+        // No single answer, so the run-level field claims none. The per-file source
+        // still carries the truth, and only it can describe a mixed run.
+        Assert.Null(plan.ExplicitSourceEncoding);
+
+        string summary = plan.Summarize();
+
+        Assert.Contains("chosen per file", summary);
+        Assert.Contains("windows-1252", summary);
+        Assert.Contains("koi8-r", summary);
+    }
+
+    [Fact]
+    public void OneEncodingForTheWholeBatchIsStillNamed()
+    {
+        // The control. Reporting null whenever anything was chosen would satisfy the
+        // test above and throw away the case where a single answer is correct.
+        Write("a.txt", "café résumé façade", "windows-1252");
+        Write("b.txt", "naïve déjà vu", "windows-1252");
+
+        ConversionPlan? plan =
+            PlanAfterChoosing(Scan(), "windows-1252", "windows-1252");
+
+        Assert.NotNull(plan);
+        Assert.Equal("windows-1252", plan!.ExplicitSourceEncoding);
+        Assert.Contains("windows-1252 (chosen by you", plan.Summarize());
+    }
+
+    [Fact]
+    public void TheSummaryDoesNotClaimDetectionWasBypassed()
+    {
+        // Detection is replaced as the codec used, not skipped: it still runs and its
+        // result is recorded, and it is what the conflicting-source refusal and the
+        // BOM-less advisories are decided against. EC-01 was that check failing to
+        // reach an applied plan, so a summary announcing its absence is exactly wrong.
+        Write("a.txt", "café résumé façade", "windows-1252");
+
+        ConversionPlan? plan = PlanAfterChoosing(Scan(), "windows-1252");
+
+        Assert.NotNull(plan);
+
+        string summary = plan!.Summarize();
+
+        Assert.DoesNotContain("bypassed", summary);
+        Assert.Contains("detection still ran", summary);
+
+        // And it did run: the plan carries what it concluded.
+        Assert.NotNull(Assert.Single(plan.Files).DetectedEncoding);
+    }
+
+    [Fact]
+    public void NothingChosenIsStillDescribedAsDetected()
+    {
+        Write("a.txt", "plain ascii text", "ascii");
+
+        ConversionPlan plan = ConversionPlan.FromEntries(
+            RunPolicyOver(Scan()), _root, "utf-8", targetHasBom: false,
+            backupEnabled: false, explicitSource: null);
+
+        Assert.Contains("detected per file", plan.Summarize());
+    }
+
+    [Fact]
+    public void TheSidecarsOutputHashMatchesTheBytesThatWereInstalled()
+    {
+        // EC-14. The record carried the source digest in both fields, so its two hashes
+        // were one measurement written twice and a reader could not tell that anything
+        // had been compared. The value is the same either way - verification has already
+        // proven the texts equal - so the assertion has to come from outside: decode the
+        // installed file and hash it the way the converter does.
+        string path = Write("legacy.txt", "café résumé façade", "windows-1252");
+
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Convert,
+            SourceCharset = "windows-1252",
+            TargetCharset = "utf-8",
+            Backup = true,
+        };
+
+        var sink = new EntrySink();
+        ScanEngine.ScanDirectory(options, sink.Add, CancellationToken.None);
+
+        Assert.Equal(ConversionRowResult.Converted, Assert.Single(sink).Result);
+
+        ConversionMetadata sidecar = System.Text.Json.JsonSerializer
+            .Deserialize<ConversionMetadata>(
+                File.ReadAllText(ConversionMetadataStore.MetadataPathFor(path)))!;
+
+        string installed = DecodedTextSha256(path, new UTF8Encoding(false));
+
+        Assert.Equal(installed, sidecar.OutputTextSha256);
+        Assert.Equal(installed, sidecar.SourceTextSha256);
+    }
+
+    /// <summary>
+    /// SHA-256 over the decoded text, matching how the converter digests content.
+    /// </summary>
+    private static string DecodedTextSha256(string path, Encoding encoding)
+    {
+        char[] chars = encoding.GetChars(File.ReadAllBytes(path));
+
+        return Convert.ToHexStringLower(
+            SHA256.HashData(MemoryMarshal.AsBytes<char>(chars)));
+    }
+
+    /// <summary>Decides the entries without writing, so they can be planned.</summary>
+    private List<ConversionReportEntry> RunPolicyOver(List<ConversionReportEntry> entries)
+    {
+        ScanEngine.ConvertFiles(
+            entries, "utf-8", targetWriteBom: false, maxParallelism: 1,
+            whatIf: true, backup: false, _ => { }, CancellationToken.None);
+
+        return entries;
+    }
+}

--- a/sources/EncodingChecker.Tests/ResultEntryReconciliationTests.cs
+++ b/sources/EncodingChecker.Tests/ResultEntryReconciliationTests.cs
@@ -8,10 +8,8 @@ namespace EncodingChecker.Tests;
 ///
 /// A row's entry lives in ListViewItem.Tag and is what OnExportReport writes to CSV,
 /// while the GUI's per-row presentation is driven by whatever entry came back from
-/// processing. Those are normally the same instance, because processing mutates the
-/// entry in place - but ScanEngine.RunParallel substitutes a fresh error entry when a
-/// file throws, and a substitute that never reached Tag would leave the exported CSV
-/// reporting a stale pre-error result for a row the GUI showed as failed.
+/// processing. Processing must mutate that same instance even when a file operation
+/// throws; substituting another entry would leave the CSV reporting stale scan state.
 /// </summary>
 public sealed class ResultEntryReconciliationTests : IDisposable
 {
@@ -217,7 +215,9 @@ public sealed class ResultEntryReconciliationTests : IDisposable
         ConversionReportEntry failsEntry = new()
         {
             FilePath = fails,
-            SourceEncoding = "utf-8",
+            // BOM-less UTF-16 checks open the file before EncodingConverter. This forces
+            // RunParallel's outer exception path rather than the converter's own result.
+            SourceEncoding = "utf-16",
             SourceHasBom = false,
             TargetEncoding = "utf-8",
         };

--- a/sources/EncodingChecker.Tests/SettingsDefaultsTests.cs
+++ b/sources/EncodingChecker.Tests/SettingsDefaultsTests.cs
@@ -74,4 +74,32 @@ public sealed class SettingsDefaultsTests
         Assert.True(restored.CreateBackup);
         Assert.True(restored.IncludeSubdirectories);
     }
+
+    [Fact]
+    public void ExplicitlyNullXmlValuesAreRepairedBeforeTheGuiUsesThem()
+    {
+        // XmlSerializer accepts xsi:nil for these public reference fields. A damaged
+        // but well-formed settings file must therefore fall back to usable defaults
+        // instead of crashing the application while it opens.
+        const string xml = """
+            <?xml version="1.0"?>
+            <Settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <WindowPosition xsi:nil="true" />
+              <RecentDirectories xsi:nil="true" />
+              <FileMasks xsi:nil="true" />
+              <ValidCharsets xsi:nil="true" />
+            </Settings>
+            """;
+
+        var serializer = new XmlSerializer(typeof(Settings));
+        using var buffer = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var restored = (Settings)serializer.Deserialize(buffer)!;
+
+        restored.NormalizeAfterLoad();
+
+        Assert.NotNull(restored.WindowPosition);
+        Assert.Empty(restored.RecentDirectories);
+        Assert.Equal(string.Empty, restored.FileMasks);
+        Assert.Empty(restored.ValidCharsets);
+    }
 }

--- a/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
+++ b/sources/EncodingChecker.Tests/StaleConversionStateTests.cs
@@ -206,6 +206,33 @@ public sealed class StaleConversionStateTests : IDisposable
     }
 
     [Fact]
+    public void FailedRetryDoesNotKeepPriorBackupOrOutputEvidence()
+    {
+        const string original = "café Привет";
+
+        string path = Path.Combine(_root, "retry-evidence.txt");
+        File.WriteAllText(path, original, new UTF8Encoding(false));
+
+        ConversionReportEntry entry = Entry(path, "utf-8");
+
+        Convert(entry, "utf-16", targetWriteBom: true, backup: true);
+
+        Assert.Equal(ConversionRowResult.Converted, entry.Result);
+        Assert.NotNull(entry.BackupPath);
+        Assert.NotNull(entry.RecoveryMetadataPath);
+        Assert.NotNull(entry.OutputSha256);
+
+        Convert(entry, "windows-1252", targetWriteBom: false, backup: false);
+
+        Assert.Equal(ConversionRowResult.Error, entry.Result);
+        Assert.False(entry.ReplacementCommitted);
+        Assert.Null(entry.BackupPath);
+        Assert.Null(entry.RecoveryMetadataPath);
+        Assert.Null(entry.OutputSha256);
+        Assert.Equal(original, File.ReadAllText(path, Encoding.Unicode));
+    }
+
+    [Fact]
     public void UnknownSourceEncoding_IsSkipped_NotDecodedWithAGuess()
     {
         string path = Path.Combine(_root, "unknown.txt");

--- a/sources/EncodingChecker.Tests/StatusAndWindowRestoreTests.cs
+++ b/sources/EncodingChecker.Tests/StatusAndWindowRestoreTests.cs
@@ -1,0 +1,205 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// Two things the window tells the user, and one it does to itself.
+/// </summary>
+public sealed class StatusAndWindowRestoreTests
+{
+    private static string Describe(bool wasPreview, bool stopped, params ConversionRowResult[] results)
+    {
+        var tally = new MainForm.ConversionTally();
+
+        foreach (ConversionRowResult result in results)
+            tally.Count(result);
+
+        return tally.Describe(wasPreview, stopped);
+    }
+
+    [Fact]
+    public void SkippedFilesAreNotCountedAsUnchanged()
+    {
+        // EC-12. Skipped fell into an "everything else" arm, so a file whose encoding
+        // EC could not identify was reported as already being in the target encoding -
+        // the opposite of what happened. The CLI has always listed them separately.
+        string status = Describe(
+            wasPreview: false,
+            stopped: false,
+            ConversionRowResult.Converted,
+            ConversionRowResult.Skipped,
+            ConversionRowResult.Skipped);
+
+        Assert.Contains("1 converted", status);
+        Assert.Contains("2 skipped", status);
+        Assert.Contains("0 unchanged", status);
+    }
+
+    [Fact]
+    public void InvalidFilesAreCountedAsSkippedRatherThanUnchanged()
+    {
+        // Invalid is a file the run did not convert, not one that needed no conversion.
+        string status = Describe(
+            wasPreview: false, stopped: false, ConversionRowResult.Invalid);
+
+        Assert.Contains("1 skipped", status);
+        Assert.Contains("0 unchanged", status);
+    }
+
+    [Fact]
+    public void EveryOutcomeIsCountedExactlyOnce()
+    {
+        // The control. A tally that dropped a category, or counted one twice, would
+        // still satisfy the two tests above.
+        string status = Describe(
+            wasPreview: false,
+            stopped: false,
+            ConversionRowResult.Converted,
+            ConversionRowResult.Unchanged,
+            ConversionRowResult.Skipped,
+            ConversionRowResult.Invalid,
+            ConversionRowResult.Refused,
+            ConversionRowResult.Error);
+
+        Assert.Contains("1 converted", status);
+        Assert.Contains("1 unchanged", status);
+        Assert.Contains("2 skipped", status);
+        Assert.Contains("1 refused", status);
+        Assert.Contains("1 failed", status);
+    }
+
+    [Theory]
+    [InlineData(true, true, "Preview cancelled")]
+    [InlineData(true, false, "Preview complete")]
+    [InlineData(false, true, "Conversion cancelled")]
+    [InlineData(false, false, "Conversion complete")]
+    public void TheHeadlineSaysWhichKindOfRunEndedAndHow(
+        bool wasPreview, bool stopped, string expected)
+    {
+        Assert.StartsWith(expected, Describe(wasPreview, stopped));
+    }
+
+    [Fact]
+    public void APreviewSaysWouldBeConvertedRatherThanConverted()
+    {
+        Assert.Contains(
+            "would be converted",
+            Describe(wasPreview: true, stopped: false, ConversionRowResult.Converted));
+    }
+
+    // ---- CX-12: restoring the window
+
+    private static readonly Rectangle Primary = new(0, 0, 1920, 1080);
+
+    [Fact]
+    public void APositionOnAMonitorThatIsGoneIsNotRestored()
+    {
+        // The window would come back where nothing can reach it, and there is no way
+        // back from inside the application.
+        var saved = new Rectangle(3000, 400, 900, 700);
+
+        Assert.False(WindowPosition.IsReachable(saved, [Primary]));
+    }
+
+    [Fact]
+    public void APositionLeftOfThePrimaryMonitorIsRestored()
+    {
+        // Negative coordinates are ordinary on a multi-monitor setup. Rejecting them
+        // outright, as the old check did, threw away good positions on every desktop
+        // with a monitor placed left of or above the primary one.
+        var secondary = new Rectangle(-1920, 0, 1920, 1080);
+        var saved = new Rectangle(-1500, 200, 900, 700);
+
+        Assert.True(WindowPosition.IsReachable(saved, [Primary, secondary]));
+    }
+
+    [Fact]
+    public void AnOrdinaryPositionIsRestored()
+    {
+        // The control. A check that refused everything would pass the first test while
+        // making EC forget its window position on every launch.
+        Assert.True(
+            WindowPosition.IsReachable(new Rectangle(100, 100, 900, 700), [Primary]));
+    }
+
+    [Fact]
+    public void AWindowBarelyOverlappingIsTreatedAsUnreachable()
+    {
+        // A few pixels of overlap is not a window you can grab hold of.
+        var saved = new Rectangle(1900, 1060, 900, 700);
+
+        Assert.False(WindowPosition.IsReachable(saved, [Primary]));
+    }
+
+    [Fact]
+    public void AWindowSmallerThanTheVisibilityMarginStillCounts()
+    {
+        // The margin is what must be reachable, or the whole window when it is smaller
+        // than that - otherwise a small window could never be restored anywhere.
+        var saved = new Rectangle(10, 10, 40, 30);
+
+        Assert.True(WindowPosition.IsReachable(saved, [Primary]));
+    }
+
+    [Fact]
+    public void NoMonitorsMeansNoRestore()
+    {
+        Assert.False(WindowPosition.IsReachable(new Rectangle(0, 0, 900, 700), []));
+    }
+
+    /// <summary>The bounds a form ends up with after restoring the given position.</summary>
+    private static Rectangle Restore(WindowPosition saved, params Rectangle[] screens)
+    {
+        Rectangle result = Rectangle.Empty;
+
+        UiTest.OnStaThread(() =>
+        {
+            using var form = new Form();
+            form.SetBounds(50, 60, 300, 200);
+
+            saved.ApplyTo(form, screens);
+
+            result = form.Bounds;
+        });
+
+        return result;
+    }
+
+    [Fact]
+    public void RestoringAPositionOnAMissingMonitorLeavesTheFormWhereItIs()
+    {
+        // IsReachable being right is not enough; ApplyTo has to consult it.
+        var saved = new WindowPosition { Left = 3000, Top = 400, Width = 900, Height = 700 };
+
+        Assert.Equal(new Rectangle(50, 60, 300, 200), Restore(saved, Primary));
+    }
+
+    [Fact]
+    public void RestoringAValidPositionMovesTheForm()
+    {
+        var saved = new WindowPosition { Left = 120, Top = 130, Width = 900, Height = 700 };
+
+        Assert.Equal(new Rectangle(120, 130, 900, 700), Restore(saved, Primary));
+    }
+
+    [Fact]
+    public void RestoringANegativePositionOnASecondMonitorMovesTheForm()
+    {
+        // The old check rejected this outright, discarding a good position on any
+        // desktop with a monitor left of or above the primary one.
+        var secondary = new Rectangle(-1920, 0, 1920, 1080);
+        var saved = new WindowPosition { Left = -1500, Top = 200, Width = 900, Height = 700 };
+
+        Assert.Equal(
+            new Rectangle(-1500, 200, 900, 700), Restore(saved, Primary, secondary));
+    }
+
+    [Fact]
+    public void AnUnsavedPositionLeavesTheFormWhereItIs()
+    {
+        // The defaults, which mean "nothing was ever saved".
+        Assert.Equal(
+            new Rectangle(50, 60, 300, 200), Restore(new WindowPosition(), Primary));
+    }
+}

--- a/sources/EncodingChecker.Tests/StatusAndWindowRestoreTests.cs
+++ b/sources/EncodingChecker.Tests/StatusAndWindowRestoreTests.cs
@@ -72,7 +72,7 @@ public sealed class StatusAndWindowRestoreTests
     [Theory]
     [InlineData(true, true, "Preview cancelled")]
     [InlineData(true, false, "Preview complete")]
-    [InlineData(false, true, "Conversion cancelled")]
+    [InlineData(false, true, "Conversion stopped")]
     [InlineData(false, false, "Conversion complete")]
     public void TheHeadlineSaysWhichKindOfRunEndedAndHow(
         bool wasPreview, bool stopped, string expected)
@@ -86,6 +86,24 @@ public sealed class StatusAndWindowRestoreTests
         Assert.Contains(
             "would be converted",
             Describe(wasPreview: true, stopped: false, ConversionRowResult.Converted));
+    }
+
+    [Fact]
+    public void JournalOutcomesKeepInterruptedTotalsComplete()
+    {
+        var tally = new MainForm.ConversionTally();
+
+        tally.Count(ConversionStatus.Converted);
+        tally.Count(ConversionStatus.ConvertedWithWarning);
+        tally.Count(ConversionStatus.InstallationUnknown);
+        tally.Count(ConversionStatus.NotAttempted);
+
+        string status = tally.Describe(wasPreview: false, stopped: true);
+
+        Assert.StartsWith("Conversion stopped", status);
+        Assert.Contains("1 converted with warning", status);
+        Assert.Contains("1 installation unknown", status);
+        Assert.Contains("1 not attempted", status);
     }
 
     // ---- CX-12: restoring the window
@@ -128,6 +146,16 @@ public sealed class StatusAndWindowRestoreTests
     {
         // A few pixels of overlap is not a window you can grab hold of.
         var saved = new Rectangle(1900, 1060, 900, 700);
+
+        Assert.False(WindowPosition.IsReachable(saved, [Primary]));
+    }
+
+    [Fact]
+    public void AWindowWithOnlyItsBottomEdgeVisibleIsUnreachable()
+    {
+        // Restoring this rectangle would show part of the client area, but its title bar
+        // would remain off-screen and the user could not drag it back.
+        var saved = new Rectangle(100, -620, 900, 700);
 
         Assert.False(WindowPosition.IsReachable(saved, [Primary]));
     }

--- a/sources/EncodingChecker/BomlessUnicodeSafety.cs
+++ b/sources/EncodingChecker/BomlessUnicodeSafety.cs
@@ -46,10 +46,14 @@ internal static class BomlessUnicodeSafety
 
         (string detectedName, string oppositeName) = Names(detectedEncoding);
 
+        // Both orders are named, and EC's own estimate is not singled out. WebName is
+        // "utf-16" for either one, so suggesting it steered the caller straight back
+        // into the reading this refusal exists to question - under a name that cannot
+        // express the choice being made.
         return $"EC detected BOM-less {detectedName}, but the same bytes are valid as both "
                + $"{detectedName} and {oppositeName}. EC cannot determine the byte order "
-               + "safely, so no conversion was performed. Add a byte-order mark or choose "
-               + $"the source encoding explicitly (for example, -From {detectedEncoding.WebName}).";
+               + "safely, so no conversion was performed. Add a byte-order mark, or say "
+               + "which order the file uses with -From utf-16le or -From utf-16be.";
     }
 
     /// <summary>

--- a/sources/EncodingChecker/BomlessUnicodeSafety.cs
+++ b/sources/EncodingChecker/BomlessUnicodeSafety.cs
@@ -46,34 +46,29 @@ internal static class BomlessUnicodeSafety
 
         (string detectedName, string oppositeName) = Names(detectedEncoding);
 
-        // Both orders are named, and EC's own estimate is not singled out. WebName is
-        // "utf-16" for either one, so suggesting it steered the caller straight back
-        // into the reading this refusal exists to question - under a name that cannot
-        // express the choice being made.
-        return $"EC detected BOM-less {detectedName}, but the same bytes are valid as both "
-               + $"{detectedName} and {oppositeName}. EC cannot determine the byte order "
-               + "safely, so no conversion was performed. Add a byte-order mark, or say "
-               + "which order the file uses with -From utf-16le or -From utf-16be.";
+        return Describe(detectedName, oppositeName, conversionRefused: true);
     }
 
-    /// <summary>
-    /// Describes the same fact for modes that convert nothing.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="DescribeRefusal"/> speaks of a conversion withheld, which would be
-    /// meaningless here. The fact reported is the same one.
-    /// </remarks>
+    /// <summary>Describes the ambiguity without implying that conversion was attempted.</summary>
     internal static string DescribeUnprovableByteOrder(Encoding detectedEncoding)
     {
         ArgumentNullException.ThrowIfNull(detectedEncoding);
 
         (string detectedName, string oppositeName) = Names(detectedEncoding);
 
-        return $"EC read this file as BOM-less {detectedName}, but the same bytes are "
-               + $"equally valid as {oppositeName}. Which one it is cannot be established "
-               + "from the file, so the encoding reported here is an estimate rather than "
-               + "a finding. Add a byte-order mark to settle it.";
+        return Describe(detectedName, oppositeName, conversionRefused: false);
     }
+
+    private static string Describe(
+        string detectedName,
+        string oppositeName,
+        bool conversionRefused) =>
+        $"EC estimates BOM-less {detectedName}, but these bytes are also valid "
+        + $"{oppositeName}. The byte order cannot be proven from the file. "
+        + (conversionRefused
+            ? "No conversion was performed. Add a byte-order mark, or specify "
+              + "-From utf-16le or -From utf-16be."
+            : "Add a byte-order mark to identify it.");
 
     private static (string Detected, string Opposite) Names(Encoding detectedEncoding) =>
         detectedEncoding.CodePage == 1200

--- a/sources/EncodingChecker/BomlessUnicodeSafety.cs
+++ b/sources/EncodingChecker/BomlessUnicodeSafety.cs
@@ -44,16 +44,35 @@ internal static class BomlessUnicodeSafety
     {
         ArgumentNullException.ThrowIfNull(detectedEncoding);
 
-        string detectedName = detectedEncoding.CodePage == 1200
-            ? "UTF-16LE"
-            : "UTF-16BE";
-        string oppositeName = detectedEncoding.CodePage == 1200
-            ? "UTF-16BE"
-            : "UTF-16LE";
+        (string detectedName, string oppositeName) = Names(detectedEncoding);
 
         return $"EC detected BOM-less {detectedName}, but the same bytes are valid as both "
                + $"{detectedName} and {oppositeName}. EC cannot determine the byte order "
                + "safely, so no conversion was performed. Add a byte-order mark or choose "
                + $"the source encoding explicitly (for example, -From {detectedEncoding.WebName}).";
     }
+
+    /// <summary>
+    /// Describes the same fact for modes that convert nothing.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DescribeRefusal"/> speaks of a conversion withheld, which would be
+    /// meaningless here. The fact reported is the same one.
+    /// </remarks>
+    internal static string DescribeUnprovableByteOrder(Encoding detectedEncoding)
+    {
+        ArgumentNullException.ThrowIfNull(detectedEncoding);
+
+        (string detectedName, string oppositeName) = Names(detectedEncoding);
+
+        return $"EC read this file as BOM-less {detectedName}, but the same bytes are "
+               + $"equally valid as {oppositeName}. Which one it is cannot be established "
+               + "from the file, so the encoding reported here is an estimate rather than "
+               + "a finding. Add a byte-order mark to settle it.";
+    }
+
+    private static (string Detected, string Opposite) Names(Encoding detectedEncoding) =>
+        detectedEncoding.CodePage == 1200
+            ? ("UTF-16LE", "UTF-16BE")
+            : ("UTF-16BE", "UTF-16LE");
 }

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -136,13 +136,10 @@ internal sealed class ConversionConfirmationForm : Form
                 MaximumSize = new Size(660, 0),
                 Padding = new Padding(0, 8, 0, 8),
                 ForeColor = Color.FromArgb(150, 80, 0),
-                // Neutral wording: each file's own reason says which case it is, and
-                // "differs from your choice" is untrue for the agreeing one.
                 Text =
-                    $"{advisories.Count} file(s) have a BOM-less byte order EC could not "
-                    + "prove from their bytes. EC will use the source encoding you chose "
-                    + "and every strict check still applies, but the byte order itself is "
-                    + "being taken on trust. Review these files:"
+                    $"For {advisories.Count} file(s), EC cannot prove the byte order of "
+                    + "the BOM-less Unicode source. EC will use your choice while keeping "
+                    + "strict decoding and output verification enabled. Review these files:"
                     + Environment.NewLine + examples,
             });
         }
@@ -152,8 +149,7 @@ internal sealed class ConversionConfirmationForm : Form
         body.Controls.Add(Rows(
         [
             ("Directory", _plan.BaseDirectory),
-            // Read from the files, so a batch resolved with several encodings is not
-            // described as though one of them applied to all of it.
+            // The per-file choices are authoritative for mixed batches.
             ("Source encoding",
              _plan.Files.Any(f => f.SourceWasSpecified)
                  ? _plan.DescribeSourceChoice() + "; strict checks still apply"

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -80,12 +80,17 @@ internal sealed class ConversionConfirmationForm : Form
         ConversionPlanSummary summary = _plan.Summary;
         int convert = summary.ReadyToConvert;
         List<PlannedFile> refused = Refused;
+        // Both reason codes. Agreeing with an estimate EC has already called unprovable
+        // is not corroboration, so the matching case needs saying at least as much as
+        // the contradicting one.
         List<PlannedFile> advisories =
         [
             .. _plan.Files.Where(f =>
                 f.Action == PlannedAction.Convert &&
-                f.ReasonCode == ConversionReasonCodes
-                    .ExplicitSourceDiffersFromBomlessUnicodeEstimate)
+                (f.ReasonCode == ConversionReasonCodes
+                     .ExplicitSourceDiffersFromBomlessUnicodeEstimate ||
+                 f.ReasonCode == ConversionReasonCodes
+                     .ExplicitSourceOnUnprovableBomlessUnicode))
         ];
 
         body.Controls.Add(Heading(
@@ -131,10 +136,14 @@ internal sealed class ConversionConfirmationForm : Form
                 MaximumSize = new Size(660, 0),
                 Padding = new Padding(0, 8, 0, 8),
                 ForeColor = Color.FromArgb(150, 80, 0),
+                // Neutral wording: each file's own reason says which case it is, and
+                // "differs from your choice" is untrue for the agreeing one.
                 Text =
-                    $"{advisories.Count} file(s) have a BOM-less Unicode estimate that "
-                    + "differs from your source choice. EC will use your choice, but review "
-                    + "these files carefully:" + Environment.NewLine + examples,
+                    $"{advisories.Count} file(s) have a BOM-less byte order EC could not "
+                    + "prove from their bytes. EC will use the source encoding you chose "
+                    + "and every strict check still applies, but the byte order itself is "
+                    + "being taken on trust. Review these files:"
+                    + Environment.NewLine + examples,
             });
         }
 

--- a/sources/EncodingChecker/ConversionConfirmationForm.cs
+++ b/sources/EncodingChecker/ConversionConfirmationForm.cs
@@ -152,10 +152,12 @@ internal sealed class ConversionConfirmationForm : Form
         body.Controls.Add(Rows(
         [
             ("Directory", _plan.BaseDirectory),
+            // Read from the files, so a batch resolved with several encodings is not
+            // described as though one of them applied to all of it.
             ("Source encoding",
-             string.IsNullOrEmpty(_plan.ExplicitSourceEncoding)
-                 ? "EC converts automatically only when it can identify the source safely"
-                 : $"{_plan.ExplicitSourceEncoding} (chosen by you; strict checks still apply)"),
+             _plan.Files.Any(f => f.SourceWasSpecified)
+                 ? _plan.DescribeSourceChoice() + "; strict checks still apply"
+                 : "EC converts automatically only when it can identify the source safely"),
             ("Backups", _plan.BackupEnabled
                 ? "enabled — original as <file>.bak; record as <file>.ecmeta.json"
                 : "OFF — originals will not be kept"),

--- a/sources/EncodingChecker/ConversionJournal.cs
+++ b/sources/EncodingChecker/ConversionJournal.cs
@@ -220,7 +220,13 @@ internal sealed record ConversionJournal
 
         foreach (ConversionReportEntry entry in entries)
         {
-            ConversionStatus status = entry.Result switch
+            ConversionStatus status = entry switch
+            {
+                // First, because the result still holds what the deciding pass expected
+                // rather than what happened - the run stopped before this file.
+                { NotAttempted: true } => ConversionStatus.NotAttempted,
+
+                _ => entry.Result switch
             {
                 // A preview records the decision, not a conversion that happened.
                 ConversionRowResult.Converted when preview
@@ -244,6 +250,7 @@ internal sealed record ConversionJournal
                 // which reports 3, and dressed an I/O error as a safety judgement.
                 ConversionRowResult.Error => ConversionStatus.Failed,
                 _ => ConversionStatus.NotAttempted,
+            },
             };
 
             // Record the encoding actually used to read the source file.

--- a/sources/EncodingChecker/ConversionJournal.cs
+++ b/sources/EncodingChecker/ConversionJournal.cs
@@ -28,25 +28,13 @@ internal enum ConversionStatus
     /// <summary>Conversion was attempted but did not complete; not touched.</summary>
     Failed,
 
-    /// <summary>
-    /// Rewritten and verified, but a step after installation failed.
-    /// </summary>
-    /// <remarks>
-    /// Installation is not the last step: the recovery record still has to be marked
-    /// complete and attributes restored. Reporting those as <see cref="Failed"/> told
-    /// the reader the file was not touched, when it had already been replaced.
-    /// </remarks>
+    /// <summary>Rewritten and verified, but a later bookkeeping step failed.</summary>
     ConvertedWithWarning,
 
     /// <summary>
     /// Installation failed in a way that left the file's state undetermined.
     /// </summary>
-    /// <remarks>
-    /// Replacement can fail with the temporary file already gone, so EC cannot tell
-    /// whether the destination was replaced. Both <see cref="Failed"/> and
-    /// <see cref="ConvertedWithWarning"/> would assert something no one established;
-    /// this says only what is known, which is that the file needs inspecting.
-    /// </remarks>
+    /// <remarks>The file must be inspected because EC cannot prove either outcome.</remarks>
     InstallationUnknown,
 
     /// <summary>
@@ -56,10 +44,7 @@ internal enum ConversionStatus
     NotAttempted,
 }
 
-/// <summary>
-///
-/// One file's journal entry: what EC believed, decided, and actually wrote.
-/// </summary>
+/// <summary>One file's journal entry: what EC believed, decided, and actually wrote.</summary>
 internal sealed record JournalEntry
 {
     public required string RelativePath { get; init; }
@@ -222,8 +207,7 @@ internal sealed record ConversionJournal
         {
             ConversionStatus status = entry switch
             {
-                // First, because the result still holds what the deciding pass expected
-                // rather than what happened - the run stopped before this file.
+                // This overrides the preview result left by the deciding pass.
                 { NotAttempted: true } => ConversionStatus.NotAttempted,
 
                 _ => entry.Result switch
@@ -236,18 +220,14 @@ internal sealed record ConversionJournal
                 ConversionRowResult.Skipped => ConversionStatus.Skipped,
                 ConversionRowResult.Refused => ConversionStatus.Refused,
 
-                // What the file is, not what was intended for it. A run that replaced
-                // the file and then failed a later step has changed it, and one that
-                // could not determine the outcome has established nothing either way.
+                // Replacement state outranks the general error result.
                 ConversionRowResult.Error when entry.ReplacementCommitted == true
                     => ConversionStatus.ConvertedWithWarning,
                 ConversionRowResult.Error when entry.ReplacementCommitted is null &&
                                                entry.Action == PlannedAction.Convert
                     => ConversionStatus.InstallationUnknown,
 
-                // A file EC could not open is a failure, not a policy decision. Mapping
-                // it to Refused made the journal disagree with the run's own exit code,
-                // which reports 3, and dressed an I/O error as a safety judgement.
+                // Read failures are processing errors, not policy refusals.
                 ConversionRowResult.Error => ConversionStatus.Failed,
                 _ => ConversionStatus.NotAttempted,
             },
@@ -272,15 +252,7 @@ internal sealed record ConversionJournal
                                ?? entry.ExpectedSourceSha256
                                ?? Hash(entry.FilePath),
 
-                // Any status that changed the file needs an after-hash, including one
-                // whose later step failed. Prefer the hash verification passed: it is
-                // what this run installed, where re-reading records whatever is on disk
-                // once the whole batch has finished.
-                //
-                // Undetermined installation is the exception. The verified hash would
-                // claim those bytes were installed, which is the open question; reading
-                // the file says what is actually there, which is what a reader has to
-                // go on.
+                // Use the verified output hash unless installation itself is uncertain.
                 Sha256After = status switch
                 {
                     ConversionStatus.Converted or ConversionStatus.ConvertedWithWarning

--- a/sources/EncodingChecker/ConversionJournal.cs
+++ b/sources/EncodingChecker/ConversionJournal.cs
@@ -29,6 +29,27 @@ internal enum ConversionStatus
     Failed,
 
     /// <summary>
+    /// Rewritten and verified, but a step after installation failed.
+    /// </summary>
+    /// <remarks>
+    /// Installation is not the last step: the recovery record still has to be marked
+    /// complete and attributes restored. Reporting those as <see cref="Failed"/> told
+    /// the reader the file was not touched, when it had already been replaced.
+    /// </remarks>
+    ConvertedWithWarning,
+
+    /// <summary>
+    /// Installation failed in a way that left the file's state undetermined.
+    /// </summary>
+    /// <remarks>
+    /// Replacement can fail with the temporary file already gone, so EC cannot tell
+    /// whether the destination was replaced. Both <see cref="Failed"/> and
+    /// <see cref="ConvertedWithWarning"/> would assert something no one established;
+    /// this says only what is known, which is that the file needs inspecting.
+    /// </remarks>
+    InstallationUnknown,
+
+    /// <summary>
     /// Decided but deliberately not carried out, such as in a preview or after an earlier
     /// failure stopped the run.
     /// </summary>
@@ -208,8 +229,19 @@ internal sealed record ConversionJournal
                 ConversionRowResult.Unchanged => ConversionStatus.Unchanged,
                 ConversionRowResult.Skipped => ConversionStatus.Skipped,
                 ConversionRowResult.Refused => ConversionStatus.Refused,
-                ConversionRowResult.Error when entry.Action == PlannedAction.Refuse
-                    => ConversionStatus.Refused,
+
+                // What the file is, not what was intended for it. A run that replaced
+                // the file and then failed a later step has changed it, and one that
+                // could not determine the outcome has established nothing either way.
+                ConversionRowResult.Error when entry.ReplacementCommitted == true
+                    => ConversionStatus.ConvertedWithWarning,
+                ConversionRowResult.Error when entry.ReplacementCommitted is null &&
+                                               entry.Action == PlannedAction.Convert
+                    => ConversionStatus.InstallationUnknown,
+
+                // A file EC could not open is a failure, not a policy decision. Mapping
+                // it to Refused made the journal disagree with the run's own exit code,
+                // which reports 3, and dressed an I/O error as a safety judgement.
                 ConversionRowResult.Error => ConversionStatus.Failed,
                 _ => ConversionStatus.NotAttempted,
             };
@@ -233,10 +265,22 @@ internal sealed record ConversionJournal
                                ?? entry.ExpectedSourceSha256
                                ?? Hash(entry.FilePath),
 
-                // Only a completed conversion needs an after-hash.
-                Sha256After = status == ConversionStatus.Converted
-                    ? Hash(entry.FilePath)
-                    : null,
+                // Any status that changed the file needs an after-hash, including one
+                // whose later step failed. Prefer the hash verification passed: it is
+                // what this run installed, where re-reading records whatever is on disk
+                // once the whole batch has finished.
+                //
+                // Undetermined installation is the exception. The verified hash would
+                // claim those bytes were installed, which is the open question; reading
+                // the file says what is actually there, which is what a reader has to
+                // go on.
+                Sha256After = status switch
+                {
+                    ConversionStatus.Converted or ConversionStatus.ConvertedWithWarning
+                        => entry.OutputSha256 ?? Hash(entry.FilePath),
+                    ConversionStatus.InstallationUnknown => Hash(entry.FilePath),
+                    _ => null,
+                },
 
                 DetectionMode = entry.SourceEncodingWasSpecified ? "Explicit" : "Detected",
                 DetectedEncoding = entry.DetectedEncodingLabel,

--- a/sources/EncodingChecker/ConversionMetadata.cs
+++ b/sources/EncodingChecker/ConversionMetadata.cs
@@ -150,25 +150,15 @@ internal static class ConversionMetadataStore
     internal static string MetadataPathFor(string filePath) => filePath + Suffix;
 
     /// <summary>
-    /// Removes any existing record for this file, so nothing describes a backup that is
-    /// about to be replaced.
+    /// Removes the recovery record immediately before its fixed-name backup is replaced.
     /// </summary>
     /// <remarks>
-    /// The backup and its record are one unit. A record is only meaningful next to the
-    /// exact backup it was written for, and <c>&lt;file&gt;.bak</c> is a fixed name, so
-    /// a second conversion replaces the first one's restore point. Leaving the first
-    /// record in place left it asserting a hash, a source codec and a completed
-    /// installation for bytes that no longer existed - not merely unverifiable, but
-    /// positively wrong about what the backup contained.
-    /// <para>
-    /// Failure is reported to the caller rather than swallowed: a backup that cannot be
-    /// separated from a stale record is not a restore point, and conversion must stop
-    /// instead of creating the pair this exists to prevent.
-    /// </para>
+    /// A record must not survive replacement of the backup it describes. Deletion
+    /// failures propagate so conversion stops instead of leaving a misleading pair.
     /// </remarks>
     /// <exception cref="IOException">The record exists and could not be removed.</exception>
     /// <exception cref="UnauthorizedAccessException">The record could not be removed.</exception>
-    internal static void Invalidate(string filePath)
+    internal static void RemoveBeforeBackupReplacement(string filePath)
     {
         string path = MetadataPathFor(filePath);
 

--- a/sources/EncodingChecker/ConversionMetadata.cs
+++ b/sources/EncodingChecker/ConversionMetadata.cs
@@ -149,6 +149,37 @@ internal static class ConversionMetadataStore
 
     internal static string MetadataPathFor(string filePath) => filePath + Suffix;
 
+    /// <summary>
+    /// Removes any existing record for this file, so nothing describes a backup that is
+    /// about to be replaced.
+    /// </summary>
+    /// <remarks>
+    /// The backup and its record are one unit. A record is only meaningful next to the
+    /// exact backup it was written for, and <c>&lt;file&gt;.bak</c> is a fixed name, so
+    /// a second conversion replaces the first one's restore point. Leaving the first
+    /// record in place left it asserting a hash, a source codec and a completed
+    /// installation for bytes that no longer existed - not merely unverifiable, but
+    /// positively wrong about what the backup contained.
+    /// <para>
+    /// Failure is reported to the caller rather than swallowed: a backup that cannot be
+    /// separated from a stale record is not a restore point, and conversion must stop
+    /// instead of creating the pair this exists to prevent.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="IOException">The record exists and could not be removed.</exception>
+    /// <exception cref="UnauthorizedAccessException">The record could not be removed.</exception>
+    internal static void Invalidate(string filePath)
+    {
+        string path = MetadataPathFor(filePath);
+
+        if (!File.Exists(path))
+            return;
+
+        // Match the backup's own handling of a read-only destination.
+        File.SetAttributes(path, FileAttributes.Normal);
+        File.Delete(path);
+    }
+
     internal static string ComputeSha256(string path)
     {
         using FileStream stream = new(

--- a/sources/EncodingChecker/ConversionOrchestrator.cs
+++ b/sources/EncodingChecker/ConversionOrchestrator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -52,14 +53,7 @@ internal enum OrchestrationOutcome
     /// <summary>The run could not be planned. Nothing was written.</summary>
     CouldNotPlan,
 
-    /// <summary>
-    /// Cancelled after writing began. Files already converted stay converted.
-    /// </summary>
-    /// <remarks>
-    /// Distinct from <see cref="Cancelled"/>, which is the user declining before
-    /// anything is written. Collapsing the two reported a run that changed files as
-    /// one that changed nothing, and discarded the record of the writes that happened.
-    /// </remarks>
+    /// <summary>Stopped after writing began; completed files remain converted.</summary>
     Interrupted,
 }
 
@@ -81,14 +75,7 @@ internal sealed record OrchestrationResult
 /// <summary>
 /// Decides, confirms, and carries out exactly the confirmed conversion plan.
 /// </summary>
-/// <remarks>
-/// The orchestration is kept separate from the UI so the complete sequence can be tested
-/// independently of any form or event handler.
-/// <para>
-/// Classification and conversion use the same entries. The UI only confirms the decided
-/// plan; it does not perform another detection pass.
-///</para>
-/// </remarks>
+/// <remarks>The UI confirms these decisions; it never detects the files again.</remarks>
 internal sealed class ConversionOrchestrator
 {
     private readonly Func<ConversionPlan, ConfirmationResponse> _confirm;
@@ -132,9 +119,12 @@ internal sealed class ConversionOrchestrator
 
         DateTime startedUtc = DateTime.UtcNow;
 
-        // View is informational. Re-detect the selected automatic-source files while
-        // hashing the same locked bytes, so the plan never combines stale detection with
-        // a newer source hash. Explicit choices are hashed but not detected.
+        // Rows survive between GUI runs; write evidence must not survive with them.
+        foreach (ConversionReportEntry entry in entries)
+            entry.ResetAttemptEvidence();
+
+        // Detection and hashing share one read, so the plan cannot mix different bytes.
+        // Detection still runs for explicit choices to preserve provenance and safety vetoes.
         ScanEngine.RefreshSourceSnapshots(
             entries,
             maxParallelism,
@@ -227,10 +217,9 @@ internal sealed class ConversionOrchestrator
             // Carry the approved hashes into the write pass to narrow the time-of-check gap.
             BindToPlannedBytes(entries, plan);
 
-            // Cancellation here is not "nothing happened": whatever finished before it
-            // is on disk. The journal is the only record of those writes, and letting
-            // the exception escape threw it away along with the run.
-            var reached = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            // Callbacks are concurrent, so completion tracking must be thread-safe.
+            var reached = new ConcurrentDictionary<string, byte>(
+                StringComparer.OrdinalIgnoreCase);
 
             try
             {
@@ -239,27 +228,25 @@ internal sealed class ConversionOrchestrator
                     backup, whatIf: false, maxParallelism,
                     entry =>
                     {
-                        reached.Add(entry.FilePath);
+                        reached.TryAdd(entry.FilePath, 0);
                         onEntry(entry);
                     },
                     cancellationToken);
             }
             catch (OperationCanceledException)
             {
-                // Entries the run never got to still carry the deciding pass's result,
-                // which for a convertible file is Converted. Journaling that as-is would
-                // report files as converted that were never opened.
+                // The preview result remains on files the write pass never reached.
                 foreach (ConversionReportEntry entry in entries)
-                    entry.NotAttempted = !reached.Contains(entry.FilePath);
+                    entry.NotAttempted = !reached.ContainsKey(entry.FilePath);
 
                 return new OrchestrationResult
                 {
                     Outcome = OrchestrationOutcome.Interrupted,
                     Plan = plan,
                     Message =
-                        $"Cancelled after converting {reached.Count} of {entries.Count} "
-                        + "file(s). Files already converted were left converted; the rest "
-                        + "were not touched. Export the journal for the full record.",
+                        $"Conversion stopped after processing {reached.Count} of "
+                        + $"{entries.Count} file(s). Completed writes remain in place; "
+                        + "export the journal for details.",
                     Journal = ConversionJournal.FromRun(
                         entries,
                         baseDirectory,
@@ -293,20 +280,7 @@ internal sealed class ConversionOrchestrator
         }
     }
 
-    /// <summary>
-    /// The one source encoding chosen for this run, or <see langword="null"/> when
-    /// there is no single answer.
-    /// </summary>
-    /// <remarks>
-    /// The GUI scopes each choice to the files it was ticked for, so a batch resolved
-    /// in several rounds can end with every file explicit and no two agreeing. Taking
-    /// the first entry's label recorded one encoding for a run that used others.
-    /// <para>
-    /// Null covers both "nothing was chosen" and "several were"; the per-file source
-    /// and detection mode distinguish them, and only they can describe a mixed run
-    /// accurately.
-    /// </para>
-    /// </remarks>
+    /// <summary>The common explicit source, or null for none or a mixed batch.</summary>
     private static string? SingleExplicitSource(
         IReadOnlyList<ConversionReportEntry> entries,
         Func<ConversionReportEntry, string> label)
@@ -341,9 +315,7 @@ internal sealed class ConversionOrchestrator
             onEntry,
             cancellationToken);
 
-    /// <summary>
-    /// Replaces detection with the user's source encoding for the refused files in scope.
-    /// </summary>
+    /// <summary>Uses the chosen source for the refused files in scope.</summary>
     /// <returns><see langword="false"/> when no refused file matched the scope.</returns>
     private static bool ApplyChosenSource(
         string? charset,
@@ -369,7 +341,7 @@ internal sealed class ConversionOrchestrator
             if (scope is not null && !scope.Contains(entry.FilePath))
                 continue;
 
-            // Use the existing source override so conversion reads the chosen encoding.
+            // Detection stays recorded; only the effective source changes.
             entry.CurrentCharsetLabel = charset;
             entry.SourceEncodingWasSpecified = true;
             entry.Diagnostic = null;

--- a/sources/EncodingChecker/ConversionOrchestrator.cs
+++ b/sources/EncodingChecker/ConversionOrchestrator.cs
@@ -51,6 +51,16 @@ internal enum OrchestrationOutcome
 
     /// <summary>The run could not be planned. Nothing was written.</summary>
     CouldNotPlan,
+
+    /// <summary>
+    /// Cancelled after writing began. Files already converted stay converted.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Cancelled"/>, which is the user declining before
+    /// anything is written. Collapsing the two reported a run that changed files as
+    /// one that changed nothing, and discarded the record of the writes that happened.
+    /// </remarks>
+    Interrupted,
 }
 
 /// <summary>The result of a run and the plan shown to the user.</summary>
@@ -153,10 +163,7 @@ internal sealed class ConversionOrchestrator
             {
                 plan = ConversionPlan.FromEntries(
                     entries, baseDirectory, targetCharset, targetWriteBom, backup,
-                    explicitSource: entries.All(e => e.SourceEncodingWasSpecified)
-                                    && entries.Count > 0
-                        ? entries[0].EffectiveSourceLabel
-                        : null);
+                    SingleExplicitSource(entries, e => e.EffectiveSourceLabel));
             }
             catch (InvalidOperationException ex)
             {
@@ -220,14 +227,54 @@ internal sealed class ConversionOrchestrator
             // Carry the approved hashes into the write pass to narrow the time-of-check gap.
             BindToPlannedBytes(entries, plan);
 
-            RunPass(
-                entries, targetCharset, targetWriteBom,
-                backup, whatIf: false, maxParallelism, onEntry, cancellationToken);
+            // Cancellation here is not "nothing happened": whatever finished before it
+            // is on disk. The journal is the only record of those writes, and letting
+            // the exception escape threw it away along with the run.
+            var reached = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            string? explicitSource = entries.All(e => e.SourceEncodingWasSpecified)
-                                     && entries.Count > 0
-                ? entries[0].ResolvedSourceLabel ?? entries[0].EffectiveSourceLabel
-                : null;
+            try
+            {
+                RunPass(
+                    entries, targetCharset, targetWriteBom,
+                    backup, whatIf: false, maxParallelism,
+                    entry =>
+                    {
+                        reached.Add(entry.FilePath);
+                        onEntry(entry);
+                    },
+                    cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Entries the run never got to still carry the deciding pass's result,
+                // which for a convertible file is Converted. Journaling that as-is would
+                // report files as converted that were never opened.
+                foreach (ConversionReportEntry entry in entries)
+                    entry.NotAttempted = !reached.Contains(entry.FilePath);
+
+                return new OrchestrationResult
+                {
+                    Outcome = OrchestrationOutcome.Interrupted,
+                    Plan = plan,
+                    Message =
+                        $"Cancelled after converting {reached.Count} of {entries.Count} "
+                        + "file(s). Files already converted were left converted; the rest "
+                        + "were not touched. Export the journal for the full record.",
+                    Journal = ConversionJournal.FromRun(
+                        entries,
+                        baseDirectory,
+                        targetCharset,
+                        targetWriteBom,
+                        backup,
+                        SingleExplicitSource(
+                            entries, e => e.ResolvedSourceLabel ?? e.EffectiveSourceLabel),
+                        surface: "Gui",
+                        startedUtc),
+                };
+            }
+
+            string? explicitSource = SingleExplicitSource(
+                entries, e => e.ResolvedSourceLabel ?? e.EffectiveSourceLabel);
 
             return new OrchestrationResult
             {
@@ -244,6 +291,35 @@ internal sealed class ConversionOrchestrator
                     startedUtc),
             };
         }
+    }
+
+    /// <summary>
+    /// The one source encoding chosen for this run, or <see langword="null"/> when
+    /// there is no single answer.
+    /// </summary>
+    /// <remarks>
+    /// The GUI scopes each choice to the files it was ticked for, so a batch resolved
+    /// in several rounds can end with every file explicit and no two agreeing. Taking
+    /// the first entry's label recorded one encoding for a run that used others.
+    /// <para>
+    /// Null covers both "nothing was chosen" and "several were"; the per-file source
+    /// and detection mode distinguish them, and only they can describe a mixed run
+    /// accurately.
+    /// </para>
+    /// </remarks>
+    private static string? SingleExplicitSource(
+        IReadOnlyList<ConversionReportEntry> entries,
+        Func<ConversionReportEntry, string> label)
+    {
+        if (entries.Count == 0 || !entries.All(e => e.SourceEncodingWasSpecified))
+            return null;
+
+        string[] distinct =
+        [
+            .. entries.Select(label).Distinct(StringComparer.OrdinalIgnoreCase)
+        ];
+
+        return distinct.Length == 1 ? distinct[0] : null;
     }
 
     private static void RunPass(

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -448,24 +448,24 @@ internal sealed record ConversionPlan
                 continue;
             }
 
-            // A plan records paths, and a path is only as stable as the directories
-            // above it. Planning refuses a reparse-point root and traversal never enters
-            // one, so a reparse point appearing here means the tree being written to is
-            // no longer the tree that was reviewed. The hash cannot detect it: an
-            // identical copy behind a junction hashes identically.
-            if (DirectoryTraversal.HasReparsePointInPath(BaseDirectory, path))
-            {
-                stale.Add(
-                    $"{path} (the file or a directory in its path is now a symbolic " +
-                    "link, another reparse point, or could not be inspected)");
-                continue;
-            }
-
             try
             {
+                // Existence first: a missing file makes every path component
+                // uninspectable, and the link check would then report it as one.
                 if (!File.Exists(path))
                 {
                     stale.Add($"{path} (no longer exists)");
+                    continue;
+                }
+
+                // A path is only as stable as the components above it, and the hash
+                // cannot see the difference: an identical copy behind a link hashes
+                // identically.
+                if (DirectoryTraversal.HasReparsePointInPath(BaseDirectory, path))
+                {
+                    stale.Add(
+                        $"{path} (the file or a directory in its path is now a symbolic " +
+                        "link, another reparse point, or could not be inspected)");
                     continue;
                 }
 

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -455,6 +455,19 @@ internal sealed record ConversionPlan
                 continue;
             }
 
+            // A plan records paths, and a path is only as stable as the directories
+            // above it. Planning refuses a reparse-point root and traversal never enters
+            // one, so a reparse point appearing here means the tree being written to is
+            // no longer the tree that was reviewed. The hash cannot detect it: an
+            // identical copy behind a junction hashes identically.
+            if (DirectoryTraversal.HasReparsePointInPath(BaseDirectory, path))
+            {
+                stale.Add(
+                    $"{path} (a directory in its path is now a symbolic link or " +
+                    "other reparse point)");
+                continue;
+            }
+
             try
             {
                 if (!File.Exists(path))

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -102,13 +102,7 @@ internal sealed record PlannedFile
     /// <summary>Whether automatic detection found the encoding's BOM.</summary>
     public bool DetectedHasBom { get; init; }
 
-    /// <summary>
-    /// Whether the detected Unicode identity passed strict full-file validation.
-    /// </summary>
-    /// <remarks>
-    /// This policy input must survive save/load so explicit-source conflict decisions
-    /// remain reproducible when the plan is applied.
-    /// </remarks>
+    /// <summary>Whether strict full-file validation confirmed the detected Unicode codec.</summary>
     public bool HasReliableUnicodeDetection { get; init; }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -126,13 +120,7 @@ internal sealed record PlannedFile
         ConversionPolicy.RequiresExplicitSourceChoice(SourceInterpretation, ReasonCode);
 }
 
-/// <summary>
-/// The decision an approved plan recorded for one file, carried into the write pass.
-/// </summary>
-/// <remarks>
-/// Applying a plan may become stricter if a file is no longer safe, but it must never
-/// turn a reviewed non-writing action into a conversion.
-/// </remarks>
+/// <summary>A reviewed decision that revalidation may tighten but never broaden.</summary>
 internal sealed record ApprovedDecision(
     PlannedAction Action,
     SourceInterpretation SourceInterpretation,
@@ -220,10 +208,17 @@ internal sealed record ConversionPlan
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                // Keep unreadable files visible in the plan rather than silently dropping them.
+                // Keep the file visible and make the failed snapshot a terminal result.
                 hash = string.Empty;
                 size = 0;
                 action = PlannedAction.Refuse;
+                entry.Action = PlannedAction.Refuse;
+                entry.SourceInterpretation = SourceInterpretation.NotApplicable;
+                entry.Result = ConversionRowResult.Error;
+                entry.ReplacementCommitted = false;
+                entry.ReasonCode = ConversionReasonCodes.SourceSnapshotFailed;
+                entry.Diagnostic =
+                    $"The source could not be read consistently for planning: {ex.Message}";
             }
 
             // Record the encoding the conversion will actually use.
@@ -347,12 +342,7 @@ internal sealed record ConversionPlan
                     return null;
                 }
 
-                // A hash is required only where bytes will be written: it is what pins
-                // the conversion to the reviewed content. An entry that will not be
-                // written makes no such claim, and planning deliberately records an
-                // unreadable file as a refusal with no hash so it stays visible rather
-                // than vanishing from the plan. Demanding one here rejected that whole
-                // plan, taking every readable file with it.
+                // Only writes need a hash; hashless refusals remain visible and harmless.
                 if (file.Action == PlannedAction.Convert &&
                     string.IsNullOrWhiteSpace(file.Sha256))
                 {
@@ -388,7 +378,8 @@ internal sealed record ConversionPlan
         {
             full = Path.GetFullPath(Path.Combine(root, file.RelativePath));
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+        catch (Exception ex) when (
+            ex is IOException or ArgumentException or NotSupportedException)
         {
             return null;
         }
@@ -467,17 +458,14 @@ internal sealed record ConversionPlan
 
             try
             {
-                // Existence first: a missing file makes every path component
-                // uninspectable, and the link check would then report it as one.
+                // Check existence first so a missing file is not mislabeled as a link.
                 if (!File.Exists(path))
                 {
                     stale.Add($"{path} (no longer exists)");
                     continue;
                 }
 
-                // A path is only as stable as the components above it, and the hash
-                // cannot see the difference: an identical copy behind a link hashes
-                // identically.
+                // A matching hash cannot reveal that a link redirected the path.
                 if (DirectoryTraversal.HasReparsePointInPath(BaseDirectory, path))
                 {
                     stale.Add(
@@ -486,10 +474,7 @@ internal sealed record ConversionPlan
                     continue;
                 }
 
-                // An entry recorded without a hash could not be read when the plan was
-                // made, so there is nothing to compare against. It is a refusal, so no
-                // bytes are written either way; comparing would report every such file
-                // as changed and invalidate the plan for the files that are fine.
+                // Hashless entries are non-writing errors already recorded by the plan.
                 if (!string.IsNullOrWhiteSpace(file.Sha256) &&
                     ConversionMetadataStore.ComputeSha256(path) != file.Sha256)
                 {
@@ -505,17 +490,7 @@ internal sealed record ConversionPlan
         return stale;
     }
 
-    /// <summary>
-    /// How the source encoding was arrived at, read from the files rather than from
-    /// the run-level field, which cannot describe a batch that chose more than one.
-    /// </summary>
-    /// <remarks>
-    /// An explicit source replaces detection as the codec used, but detection still
-    /// runs and its result is recorded: it is what the conflicting-source refusal and
-    /// the BOM-less advisories are decided against. Calling that "bypassed" told the
-    /// reader the safety input was skipped, when its absence was the defect that let
-    /// an applied plan convert a file it had recorded as refused.
-    /// </remarks>
+    /// <summary>Describes per-file source choices accurately for mixed batches.</summary>
     internal string DescribeSourceChoice()
     {
         string[] chosen =

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -337,10 +337,26 @@ internal sealed record ConversionPlan
             {
                 if (file is null ||
                     string.IsNullOrWhiteSpace(file.RelativePath) ||
-                    string.IsNullOrWhiteSpace(file.Sha256) ||
                     string.IsNullOrWhiteSpace(file.SourceEncoding))
                 {
-                    error = "The plan contains an incomplete file entry.";
+                    error = "The plan contains an incomplete file entry"
+                            + (file?.RelativePath is { Length: > 0 } named
+                                ? $": {named}."
+                                : ".");
+                    return null;
+                }
+
+                // A hash is required only where bytes will be written: it is what pins
+                // the conversion to the reviewed content. An entry that will not be
+                // written makes no such claim, and planning deliberately records an
+                // unreadable file as a refusal with no hash so it stays visible rather
+                // than vanishing from the plan. Demanding one here rejected that whole
+                // plan, taking every readable file with it.
+                if (file.Action == PlannedAction.Convert &&
+                    string.IsNullOrWhiteSpace(file.Sha256))
+                {
+                    error = $"The plan schedules '{file.RelativePath}' for conversion "
+                            + "without recording the contents it was reviewed against.";
                     return null;
                 }
             }
@@ -469,8 +485,15 @@ internal sealed record ConversionPlan
                     continue;
                 }
 
-                if (ConversionMetadataStore.ComputeSha256(path) != file.Sha256)
+                // An entry recorded without a hash could not be read when the plan was
+                // made, so there is nothing to compare against. It is a refusal, so no
+                // bytes are written either way; comparing would report every such file
+                // as changed and invalidate the plan for the files that are fine.
+                if (!string.IsNullOrWhiteSpace(file.Sha256) &&
+                    ConversionMetadataStore.ComputeSha256(path) != file.Sha256)
+                {
                     stale.Add($"{path} (contents changed since the plan was made)");
+                }
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -504,6 +505,40 @@ internal sealed record ConversionPlan
         return stale;
     }
 
+    /// <summary>
+    /// How the source encoding was arrived at, read from the files rather than from
+    /// the run-level field, which cannot describe a batch that chose more than one.
+    /// </summary>
+    /// <remarks>
+    /// An explicit source replaces detection as the codec used, but detection still
+    /// runs and its result is recorded: it is what the conflicting-source refusal and
+    /// the BOM-less advisories are decided against. Calling that "bypassed" told the
+    /// reader the safety input was skipped, when its absence was the defect that let
+    /// an applied plan convert a file it had recorded as refused.
+    /// </remarks>
+    internal string DescribeSourceChoice()
+    {
+        string[] chosen =
+        [
+            .. Files.Where(f => f.SourceWasSpecified)
+                    .Select(f => f.SourceEncoding)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+        ];
+
+        if (chosen.Length == 0)
+            return "detected per file";
+
+        string detail = chosen.Length == 1
+            ? chosen[0]
+            : $"{chosen.Length} chosen per file ({string.Join(", ", chosen)})";
+
+        bool everyFile = Files.All(f => f.SourceWasSpecified);
+
+        return everyFile
+            ? $"{detail} (chosen by you; detection still ran and is recorded)"
+            : $"{detail} for some files, detected for the rest";
+    }
+
     /// <summary>The summary shown before the user decides.</summary>
     internal string Summarize()
     {
@@ -521,10 +556,7 @@ internal sealed record ConversionPlan
             string.Empty,
             $"Directory:                    {BaseDirectory}",
             $"Target:                       {ScanEngine.DescribeTarget(TargetEncoding, TargetHasBom)}",
-            "Source encoding:              "
-                + (string.IsNullOrEmpty(ExplicitSourceEncoding)
-                    ? "detected per file"
-                    : $"{ExplicitSourceEncoding} (specified; detection bypassed)"),
+            $"Source encoding:              {DescribeSourceChoice()}",
             $"Backups:                      {(BackupEnabled ? "enabled" : "DISABLED")}",
             $"Guarantees:                   {ConversionSemantics.Describes}",
             string.Empty,

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -37,11 +37,11 @@ internal sealed record ConversionSemantics
     /// <summary>
     /// Changes only when the meaning of an existing plan's decisions changes.
     /// </summary>
-    internal const int Current = 5;
+    internal const int Current = 6;
 
     /// <summary>The guarantees of <see cref="Current"/> shown to the reader.</summary>
     internal const string Describes =
-        "source-bound detection, strict codecs, verified output, atomic install, explicit source required for legacy text, proven BOM-less UTF-16 byte order";
+        "source-bound detection, strict codecs, verified output, atomic install, explicit source required for legacy text, proven BOM-less UTF-16 byte order, a reviewed refusal is binding";
 
     /// <summary>Malformed input is rejected rather than replaced.</summary>
     public bool StrictDecoding { get; init; } = true;
@@ -101,6 +101,19 @@ internal sealed record PlannedFile
     /// <summary>Whether automatic detection found the encoding's BOM.</summary>
     public bool DetectedHasBom { get; init; }
 
+    /// <summary>
+    /// Whether detection was confirmed by a complete strict Unicode decode when this
+    /// plan was made.
+    /// </summary>
+    /// <remarks>
+    /// This is a policy input, not provenance: it is what lets an explicit source that
+    /// contradicts a proven Unicode or ASCII reading be refused. Recording it keeps the
+    /// decision reproducible when the plan is applied. Without it the veto had nothing
+    /// to fire on at apply time, and a refusal the reviewer approved became a silent
+    /// conversion.
+    /// </remarks>
+    public bool HasReliableUnicodeDetection { get; init; }
+
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public required SourceInterpretation SourceInterpretation { get; init; }
 
@@ -117,6 +130,22 @@ internal sealed record PlannedFile
 }
 
 /// <summary>
+/// The decision an approved plan recorded for one file, carried into the write pass.
+/// </summary>
+/// <remarks>
+/// A plan is re-decided rather than replayed, so that a file which became unsafe after
+/// review is still refused. That direction is the point; the opposite direction is not.
+/// This makes the reviewed decision a ceiling: applying a plan may refuse more than the
+/// review did, never less. Any policy input the plan schema does not carry is absent at
+/// apply time, and without the ceiling its refusal silently becomes a conversion.
+/// </remarks>
+internal sealed record ApprovedDecision(
+    PlannedAction Action,
+    SourceInterpretation SourceInterpretation,
+    string? ReasonCode,
+    string? Diagnostic);
+
+/// <summary>
 /// A conversion plan that can be reviewed before execution and then applied as approved.
 /// </summary>
 /// <remarks>
@@ -130,7 +159,7 @@ internal sealed record PlannedFile
 internal sealed record ConversionPlan
 {
     /// <summary>The plan file schema version.</summary>
-    internal const int CurrentPlanVersion = 4;
+    internal const int CurrentPlanVersion = 5;
 
     public int PlanVersion { get; init; } = CurrentPlanVersion;
 
@@ -232,6 +261,7 @@ internal sealed record ConversionPlan
                 DetectedEncoding = entry.DetectedEncodingLabel,
                 DetectedCodePage = detectedCodePage,
                 DetectedHasBom = entry.DetectedEncodingHasBom,
+                HasReliableUnicodeDetection = entry.HasReliableUnicodeDetection,
                 SourceInterpretation = entry.SourceInterpretation
                     ?? throw new InvalidOperationException(
                         $"'{entry.FilePath}' reached a conversion plan without being "

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -102,15 +102,11 @@ internal sealed record PlannedFile
     public bool DetectedHasBom { get; init; }
 
     /// <summary>
-    /// Whether detection was confirmed by a complete strict Unicode decode when this
-    /// plan was made.
+    /// Whether the detected Unicode identity passed strict full-file validation.
     /// </summary>
     /// <remarks>
-    /// This is a policy input, not provenance: it is what lets an explicit source that
-    /// contradicts a proven Unicode or ASCII reading be refused. Recording it keeps the
-    /// decision reproducible when the plan is applied. Without it the veto had nothing
-    /// to fire on at apply time, and a refusal the reviewer approved became a silent
-    /// conversion.
+    /// This policy input must survive save/load so explicit-source conflict decisions
+    /// remain reproducible when the plan is applied.
     /// </remarks>
     public bool HasReliableUnicodeDetection { get; init; }
 
@@ -133,11 +129,8 @@ internal sealed record PlannedFile
 /// The decision an approved plan recorded for one file, carried into the write pass.
 /// </summary>
 /// <remarks>
-/// A plan is re-decided rather than replayed, so that a file which became unsafe after
-/// review is still refused. That direction is the point; the opposite direction is not.
-/// This makes the reviewed decision a ceiling: applying a plan may refuse more than the
-/// review did, never less. Any policy input the plan schema does not carry is absent at
-/// apply time, and without the ceiling its refusal silently becomes a conversion.
+/// Applying a plan may become stricter if a file is no longer safe, but it must never
+/// turn a reviewed non-writing action into a conversion.
 /// </remarks>
 internal sealed record ApprovedDecision(
     PlannedAction Action,
@@ -463,8 +456,8 @@ internal sealed record ConversionPlan
             if (DirectoryTraversal.HasReparsePointInPath(BaseDirectory, path))
             {
                 stale.Add(
-                    $"{path} (a directory in its path is now a symbolic link or " +
-                    "other reparse point)");
+                    $"{path} (the file or a directory in its path is now a symbolic " +
+                    "link, another reparse point, or could not be inspected)");
                 continue;
             }
 

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -94,6 +94,17 @@ internal sealed class ConversionReportEntry
     internal PlannedAction? Action { get; set; }
 
     /// <summary>
+    /// What a reviewed plan decided for this file, or <see langword="null"/> when this
+    /// run is not carrying out a saved plan. Internal state; not in CSV.
+    /// </summary>
+    /// <remarks>
+    /// Present only for <c>-Apply</c>. The GUI re-decides in memory and deliberately
+    /// clears <see cref="Action"/> so that supplying a source can turn a refusal into a
+    /// conversion; a saved plan has no such conversation, so its refusals bind.
+    /// </remarks>
+    internal ApprovedDecision? Approved { get; set; }
+
+    /// <summary>
     /// The charset label the next conversion will use to read this file.
     /// </summary>
     /// <remarks>

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -190,6 +190,18 @@ internal sealed class ConversionReportEntry
     /// The recovery sidecar prepared by this run. Its state says whether installation completed.
     /// </summary>
     internal string? RecoveryMetadataPath { get; set; }
+
+    /// <summary>Clears evidence that belongs only to the previous conversion attempt.</summary>
+    internal void ResetAttemptEvidence()
+    {
+        ResolvedSourceLabel = null;
+        JournalSourceSha256 = null;
+        NotAttempted = false;
+        ReplacementCommitted = null;
+        OutputSha256 = null;
+        BackupPath = null;
+        RecoveryMetadataPath = null;
+    }
 }
 
 /// <summary>Stable reason codes written to reports and journals.</summary>

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -153,6 +153,27 @@ internal sealed class ConversionReportEntry
     /// <summary>Stable machine-readable reason for a non-success outcome.</summary>
     internal string? ReasonCode { get; set; }
 
+    /// <summary>
+    /// Whether the converted file reached its destination, or <see langword="null"/>
+    /// when the outcome is unknown or nothing was attempted.
+    /// </summary>
+    /// <remarks>
+    /// Conversion can fail after installation succeeds - completing the recovery record
+    /// or restoring attributes. Without this the journal reported such a file as
+    /// untouched, which is the opposite of what happened.
+    /// </remarks>
+    internal bool? ReplacementCommitted { get; set; }
+
+    /// <summary>
+    /// SHA-256 of the exact bytes verified before installation, when a recovery record
+    /// was written. Internal state; not in CSV.
+    /// </summary>
+    /// <remarks>
+    /// Preferred over re-reading the file afterwards, which records whatever is on disk
+    /// at journal time rather than what this run verified and installed.
+    /// </remarks>
+    internal string? OutputSha256 { get; set; }
+
     /// <summary>The backup created by this run, even if conversion later failed.</summary>
     internal string? BackupPath { get; set; }
 

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -154,6 +154,15 @@ internal sealed class ConversionReportEntry
     internal string? ReasonCode { get; set; }
 
     /// <summary>
+    /// Whether the run ended before it reached this file. Internal state; not in CSV.
+    /// </summary>
+    /// <remarks>
+    /// An entry keeps the deciding pass's result until the write pass overwrites it,
+    /// so a file the run never got to still reads as Converted. This says otherwise.
+    /// </remarks>
+    internal bool NotAttempted { get; set; }
+
+    /// <summary>
     /// Whether the converted file reached its destination, or <see langword="null"/>
     /// when the outcome is unknown or nothing was attempted.
     /// </summary>

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -39,11 +39,7 @@ internal static class DirectoryTraversal
         IgnoreInaccessible = false,
     };
 
-    // Files are enumerated without an attribute filter so the excluded ones can be
-    // counted rather than vanishing. AttributesToSkip drops them inside the OS
-    // enumeration, which left a scan unable to distinguish "this folder is clean"
-    // from "this folder holds files I never looked at". The same attributes are
-    // still excluded below; they are now counted first.
+    // Enumerate all files so excluded attributes remain visible in coverage counts.
     private static readonly EnumerationOptions FileWalkOptions = new()
     {
         AttributesToSkip = FileAttributes.None,
@@ -56,10 +52,7 @@ internal static class DirectoryTraversal
     /// <summary>
     /// Counts files a scan never examined, so a report can say so.
     /// </summary>
-    /// <remarks>
-    /// Incremented while <see cref="Parallel.ForEach"/> pulls from the traversal, so
-    /// the increments are interlocked rather than assumed to be serialized.
-    /// </remarks>
+    /// <remarks>Parallel traversal requires interlocked counters.</remarks>
     internal sealed class TraversalCounters
     {
         private int _filesExcludedByAttribute;
@@ -91,10 +84,10 @@ internal static class DirectoryTraversal
     /// <summary>
     /// Files always excluded from scans, regardless of include patterns.
     /// </summary>
-    private static bool IsAlwaysExcludedFile(string fileName) =>
-        fileName.EndsWith(".bak", StringComparison.OrdinalIgnoreCase) ||
-        fileName.EndsWith(ConversionMetadataStore.Suffix, StringComparison.OrdinalIgnoreCase) ||
-        fileName.EndsWith("." + EncodingConverter.TempFileSuffix, StringComparison.OrdinalIgnoreCase);
+    internal static bool HasReservedArtifactSuffix(string path) =>
+        path.EndsWith(".bak", StringComparison.OrdinalIgnoreCase) ||
+        path.EndsWith(ConversionMetadataStore.Suffix, StringComparison.OrdinalIgnoreCase) ||
+        path.EndsWith("." + EncodingConverter.TempFileSuffix, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Returns true for symlink, junction, or other reparse-point directories.
@@ -116,14 +109,7 @@ internal static class DirectoryTraversal
         }
     }
 
-    /// <summary>
-    /// Whether the planned file or any directory up to and including
-    /// <paramref name="root"/> is a reparse point or cannot be inspected.
-    /// </summary>
-    /// <remarks>
-    /// A link appearing after planning can redirect reads even when the target has the
-    /// same hash. Failure to reach the recorded root is also treated as stale.
-    /// </remarks>
+    /// <summary>Whether the planned path can still be trusted to reach its recorded root.</summary>
     internal static bool HasReparsePointInPath(string root, string path)
     {
         string normalizedRoot =
@@ -216,12 +202,8 @@ internal static class DirectoryTraversal
                     MatchesAny(relativePath, excludePatterns))
                     continue;
 
-                // Both exclusions are tested after the patterns, so a file the caller
-                // never asked about cannot inflate the coverage counts - and one they
-                // did ask about cannot vanish from them. A backup or sidecar left by an
-                // earlier run is still skipped, but "-Include *.bak" now reports that it
-                // was skipped instead of answering with an empty, successful report.
-                if (IsAlwaysExcludedFile(fileName))
+                // Count only excluded artifacts that the caller's patterns selected.
+                if (HasReservedArtifactSuffix(fileName))
                 {
                     counters?.CountFileExcludedAsEcArtifact();
                     continue;

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -92,10 +92,13 @@ internal static class DirectoryTraversal
     /// Attribute-read failures are treated conservatively.
     /// </summary>
     internal static bool IsReparsePointDirectory(string dir)
+        => IsReparsePointOrUnreadable(dir);
+
+    private static bool IsReparsePointOrUnreadable(string path)
     {
         try
         {
-            return (File.GetAttributes(dir) & FileAttributes.ReparsePoint) != 0;
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
         }
         catch (Exception ex) when (
             ex is IOException or UnauthorizedAccessException)
@@ -105,26 +108,23 @@ internal static class DirectoryTraversal
     }
 
     /// <summary>
-    /// Whether any directory from the file's own folder up to and including
-    /// <paramref name="root"/> is a reparse point.
+    /// Whether the planned file or any directory up to and including
+    /// <paramref name="root"/> is a reparse point or cannot be inspected.
     /// </summary>
     /// <remarks>
-    /// A scan never enters a reparse-point directory, so no planned path can legitimately
-    /// contain one. If one appears later, the tree the plan described has been replaced by
-    /// a different tree, and the recorded hashes cannot say so: two identical copies hash
-    /// identically. Attribute-read failures are treated conservatively, matching
-    /// <see cref="IsReparsePointDirectory"/>.
+    /// A link appearing after planning can redirect reads even when the target has the
+    /// same hash. Failure to reach the recorded root is also treated as stale.
     /// </remarks>
     internal static bool HasReparsePointInPath(string root, string path)
     {
         string normalizedRoot =
             Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
 
-        string? current = Path.GetDirectoryName(Path.GetFullPath(path));
+        string? current = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
 
         while (current is not null)
         {
-            if (IsReparsePointDirectory(current))
+            if (IsReparsePointOrUnreadable(current))
                 return true;
 
             // Stop at the root; what lies above it is not part of the plan's scope.
@@ -139,7 +139,8 @@ internal static class DirectoryTraversal
             current = Path.GetDirectoryName(current);
         }
 
-        return false;
+        // The path was not beneath the recorded root.
+        return true;
     }
 
     /// <summary>

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -64,6 +64,7 @@ internal static class DirectoryTraversal
     {
         private int _filesExcludedByAttribute;
         private int _directoriesExcludedByAttribute;
+        private int _filesExcludedAsEcArtifact;
 
         /// <summary>Matching files skipped for being hidden, system, or reparse points.</summary>
         internal int FilesExcludedByAttribute => Volatile.Read(ref _filesExcludedByAttribute);
@@ -72,8 +73,16 @@ internal static class DirectoryTraversal
         internal int DirectoriesExcludedByAttribute =>
             Volatile.Read(ref _directoriesExcludedByAttribute);
 
+        /// <summary>
+        /// Matching files skipped for being EC's own backups, sidecars, or temporaries.
+        /// </summary>
+        internal int FilesExcludedAsEcArtifact => Volatile.Read(ref _filesExcludedAsEcArtifact);
+
         internal void CountFileExcludedByAttribute() =>
             Interlocked.Increment(ref _filesExcludedByAttribute);
+
+        internal void CountFileExcludedAsEcArtifact() =>
+            Interlocked.Increment(ref _filesExcludedAsEcArtifact);
 
         internal void CountDirectoryExcludedByAttribute() =>
             Interlocked.Increment(ref _directoriesExcludedByAttribute);
@@ -190,9 +199,6 @@ internal static class DirectoryTraversal
                 string file = info.FullName;
                 string fileName = info.Name;
 
-                if (IsAlwaysExcludedFile(fileName))
-                    continue;
-
                 // Compare full paths because the scan root may itself be relative.
                 if (excludedFullPaths is not null &&
                     excludedFullPaths.Contains(
@@ -210,8 +216,17 @@ internal static class DirectoryTraversal
                     MatchesAny(relativePath, excludePatterns))
                     continue;
 
-                // Count only matching files. Files outside the requested scope and EC's
-                // own artifacts must not inflate the incomplete-coverage warning.
+                // Both exclusions are tested after the patterns, so a file the caller
+                // never asked about cannot inflate the coverage counts - and one they
+                // did ask about cannot vanish from them. A backup or sidecar left by an
+                // earlier run is still skipped, but "-Include *.bak" now reports that it
+                // was skipped instead of answering with an empty, successful report.
+                if (IsAlwaysExcludedFile(fileName))
+                {
+                    counters?.CountFileExcludedAsEcArtifact();
+                    continue;
+                }
+
                 if ((info.Attributes & ExcludedFileAttributes) != 0)
                 {
                     counters?.CountFileExcludedByAttribute();

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -105,6 +105,44 @@ internal static class DirectoryTraversal
     }
 
     /// <summary>
+    /// Whether any directory from the file's own folder up to and including
+    /// <paramref name="root"/> is a reparse point.
+    /// </summary>
+    /// <remarks>
+    /// A scan never enters a reparse-point directory, so no planned path can legitimately
+    /// contain one. If one appears later, the tree the plan described has been replaced by
+    /// a different tree, and the recorded hashes cannot say so: two identical copies hash
+    /// identically. Attribute-read failures are treated conservatively, matching
+    /// <see cref="IsReparsePointDirectory"/>.
+    /// </remarks>
+    internal static bool HasReparsePointInPath(string root, string path)
+    {
+        string normalizedRoot =
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+
+        string? current = Path.GetDirectoryName(Path.GetFullPath(path));
+
+        while (current is not null)
+        {
+            if (IsReparsePointDirectory(current))
+                return true;
+
+            // Stop at the root; what lies above it is not part of the plan's scope.
+            if (string.Equals(
+                    Path.TrimEndingDirectorySeparator(current),
+                    normalizedRoot,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            current = Path.GetDirectoryName(current);
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Enumerates matching files while skipping excluded directories and reparse points.
     /// </summary>
     internal static IEnumerable<string> EnumerateFiles(

--- a/sources/EncodingChecker/EncodingConverter.Verification.cs
+++ b/sources/EncodingChecker/EncodingConverter.Verification.cs
@@ -21,6 +21,16 @@ internal static partial class EncodingConverter
 
         /// <summary>Whether the target BOM state matched the requested policy.</summary>
         internal bool BomVerified { get; init; }
+
+        /// <summary>
+        /// The digest computed by decoding the installed output, present on success.
+        /// </summary>
+        /// <remarks>
+        /// Carried out so the recovery record can state a hash it actually measured.
+        /// Copying the source digest into both fields makes the record read as two
+        /// agreeing measurements when it holds one value written twice.
+        /// </remarks>
+        internal byte[]? OutputHash { get; init; }
     }
 
     // Used only for same-run content verification.
@@ -109,6 +119,7 @@ internal static partial class EncodingConverter
                     Success = true,
                     ScalarsCompared = sourceDigest.ScalarCount,
                     BomVerified = bomVerified,
+                    OutputHash = targetDigest.Hash,
                 };
             }
 

--- a/sources/EncodingChecker/EncodingConverter.cs
+++ b/sources/EncodingChecker/EncodingConverter.cs
@@ -477,7 +477,19 @@ internal static partial class EncodingConverter
                     SourceBytes = sourceBytesProcessed,
                     SourceSha256 = sourceFileSha,
                     SourceTextSha256 = System.Convert.ToHexStringLower(sourceDigest.Hash),
-                    OutputTextSha256 = System.Convert.ToHexStringLower(sourceDigest.Hash),
+
+                    // The digest verification computed from the output, not a second
+                    // copy of the source one. Verification has already established the
+                    // two are equal, so no test can tell the difference by value - which
+                    // is exactly why falling back to the source digest here would let
+                    // the record quietly go back to holding one measurement written
+                    // twice. Success without an output digest is a contradiction, so
+                    // say so loudly instead.
+                    OutputTextSha256 = System.Convert.ToHexStringLower(
+                        verification.OutputHash
+                        ?? throw new InvalidOperationException(
+                            "Verification reported success without recording the "
+                            + "digest it computed from the output.")),
                     OutputSha256 = outputFileSha,
                     SourceEncoding = sourceEncoding.WebName,
                     SourceCodePage = sourceEncoding.CodePage,

--- a/sources/EncodingChecker/MainForm.Execution.cs
+++ b/sources/EncodingChecker/MainForm.Execution.cs
@@ -372,12 +372,18 @@ public partial class MainForm
         if (counters is null)
             return string.Empty;
 
-        var parts = new List<string>(2);
+        var parts = new List<string>(3);
 
         if (counters.FilesExcludedByAttribute > 0)
         {
             parts.Add(
                 $"{counters.FilesExcludedByAttribute} matching file(s) not examined");
+        }
+
+        if (counters.FilesExcludedAsEcArtifact > 0)
+        {
+            parts.Add(
+                $"{counters.FilesExcludedAsEcArtifact} EC backup/record file(s) not examined");
         }
 
         if (counters.DirectoriesExcludedByAttribute > 0)

--- a/sources/EncodingChecker/MainForm.Execution.cs
+++ b/sources/EncodingChecker/MainForm.Execution.cs
@@ -462,7 +462,15 @@ public partial class MainForm
 
             UpdateResultItem(item, entry, targetLabel, wasPreview);
 
-            tally.Count(entry.Result);
+            if (wasPreview || outcome?.Journal is null)
+                tally.Count(entry.Result);
+        }
+
+        // Completed runs use the journal's terminal outcomes, including interrupted files.
+        if (!wasPreview && outcome?.Journal is { } journal)
+        {
+            foreach (JournalEntry entry in journal.Entries)
+                tally.Count(entry.Status);
         }
 
         lstResults.Sort();
@@ -500,6 +508,9 @@ public partial class MainForm
         internal int Skipped { get; private set; }
         internal int Refused { get; private set; }
         internal int Failed { get; private set; }
+        internal int ConvertedWithWarning { get; private set; }
+        internal int InstallationUnknown { get; private set; }
+        internal int NotAttempted { get; private set; }
 
         internal void Count(ConversionRowResult result)
         {
@@ -519,20 +530,45 @@ public partial class MainForm
             }
         }
 
+        internal void Count(ConversionStatus status)
+        {
+            switch (status)
+            {
+                case ConversionStatus.Converted: Converted++; break;
+                case ConversionStatus.Unchanged: Unchanged++; break;
+                case ConversionStatus.Skipped: Skipped++; break;
+                case ConversionStatus.Refused: Refused++; break;
+                case ConversionStatus.Failed: Failed++; break;
+                case ConversionStatus.ConvertedWithWarning: ConvertedWithWarning++; break;
+                case ConversionStatus.InstallationUnknown: InstallationUnknown++; break;
+                case ConversionStatus.NotAttempted: NotAttempted++; break;
+            }
+        }
+
         internal string Describe(bool wasPreview, bool stopped)
         {
             string headline = (wasPreview, stopped) switch
             {
                 (true, true) => "Preview cancelled",
                 (true, false) => "Preview complete",
-                (false, true) => "Conversion cancelled",
+                (false, true) => "Conversion stopped",
                 (false, false) => "Conversion complete",
             };
 
             string verb = wasPreview ? "would be converted" : "converted";
 
+            string details = ConvertedWithWarning > 0
+                ? $", {ConvertedWithWarning} converted with warning"
+                : string.Empty;
+
+            if (InstallationUnknown > 0)
+                details += $", {InstallationUnknown} installation unknown";
+
+            if (NotAttempted > 0)
+                details += $", {NotAttempted} not attempted";
+
             return $"{headline}: {Converted} {verb}, {Unchanged} unchanged, "
-                   + $"{Skipped} skipped, {Refused} refused, {Failed} failed";
+                   + $"{Skipped} skipped, {Refused} refused, {Failed} failed{details}";
         }
     }
 

--- a/sources/EncodingChecker/MainForm.Execution.cs
+++ b/sources/EncodingChecker/MainForm.Execution.cs
@@ -412,10 +412,13 @@ public partial class MainForm
         _convertWasPreview = false;
         _convertArgs = null;
 
-        // These outcomes leave all files untouched, so there are no result rows to update.
+        // These outcomes leave all files untouched, so there are no result rows to
+        // update. Interrupted is deliberately not among them: it means writing had
+        // already begun, and reporting it here would tell the user nothing changed.
         if (e.Error is null && !e.Cancelled && outcome is not null &&
             outcome.Outcome is not (OrchestrationOutcome.Converted
-                                    or OrchestrationOutcome.Previewed))
+                                    or OrchestrationOutcome.Previewed
+                                    or OrchestrationOutcome.Interrupted))
         {
             // Starting conversion temporarily clears this control's visual state. A
             // cancelled review keeps all rows selected, so restore the matching state.
@@ -495,7 +498,7 @@ public partial class MainForm
                   $"{unchangedCount} unchanged, {refusedCount} refused, {errorCount} failed"
                 : $"Preview complete: {convertedCount} file(s) would be converted, " +
                   $"{unchangedCount} unchanged, {refusedCount} refused, {errorCount} failed")
-            : (e.Cancelled
+            : (e.Cancelled || outcome?.Outcome == OrchestrationOutcome.Interrupted
                 ? $"Conversion cancelled: {convertedCount} converted, " +
                   $"{unchangedCount} unchanged, {refusedCount} refused, {errorCount} failed"
                 : $"Conversion complete: {convertedCount} converted, " +

--- a/sources/EncodingChecker/MainForm.Execution.cs
+++ b/sources/EncodingChecker/MainForm.Execution.cs
@@ -445,10 +445,7 @@ public partial class MainForm
             return;
         }
 
-        int convertedCount = 0;
-        int unchangedCount = 0;
-        int refusedCount = 0;
-        int errorCount = 0;
+        var tally = new ConversionTally();
 
         // Update the UI only after all worker results are available.
         lstResults.BeginUpdate();
@@ -465,21 +462,7 @@ public partial class MainForm
 
             UpdateResultItem(item, entry, targetLabel, wasPreview);
 
-            switch (entry.Result)
-            {
-                case ConversionRowResult.Converted:
-                    convertedCount++;
-                    break;
-                case ConversionRowResult.Error:
-                    errorCount++;
-                    break;
-                case ConversionRowResult.Refused:
-                    refusedCount++;
-                    break;
-                default:
-                    unchangedCount++;
-                    break;
-            }
+            tally.Count(entry.Result);
         }
 
         lstResults.Sort();
@@ -491,20 +474,66 @@ public partial class MainForm
 
         btnExportReport.Visible = lstResults.Items.Count > 0;
 
-        // A preview reports intended changes, not completed conversions.
-        string statusMessage = wasPreview
-            ? (e.Cancelled
-                ? $"Preview cancelled: {convertedCount} file(s) would be converted, " +
-                  $"{unchangedCount} unchanged, {refusedCount} refused, {errorCount} failed"
-                : $"Preview complete: {convertedCount} file(s) would be converted, " +
-                  $"{unchangedCount} unchanged, {refusedCount} refused, {errorCount} failed")
-            : (e.Cancelled || outcome?.Outcome == OrchestrationOutcome.Interrupted
-                ? $"Conversion cancelled: {convertedCount} converted, " +
-                  $"{unchangedCount} unchanged, {refusedCount} refused, {errorCount} failed"
-                : $"Conversion complete: {convertedCount} converted, " +
-                  $"{unchangedCount} unchanged, {refusedCount} refused, {errorCount} failed");
+        UpdateControlsOnActionDone(
+            tally.Describe(
+                wasPreview,
+                stopped: e.Cancelled ||
+                         outcome?.Outcome == OrchestrationOutcome.Interrupted));
+    }
 
-        UpdateControlsOnActionDone(statusMessage);
+    /// <summary>
+    /// Counts what a conversion did, and says it.
+    /// </summary>
+    /// <remarks>
+    /// Skipped and Invalid used to fall into an "everything else" arm and be reported as
+    /// unchanged, so files whose encoding EC could not identify were counted as already
+    /// being in the target. The CLI has always listed them separately; this brings the
+    /// window into line with it.
+    /// <para>
+    /// Kept out of the form so the wording can be tested without one.
+    /// </para>
+    /// </remarks>
+    internal sealed class ConversionTally
+    {
+        internal int Converted { get; private set; }
+        internal int Unchanged { get; private set; }
+        internal int Skipped { get; private set; }
+        internal int Refused { get; private set; }
+        internal int Failed { get; private set; }
+
+        internal void Count(ConversionRowResult result)
+        {
+            switch (result)
+            {
+                case ConversionRowResult.Converted: Converted++; break;
+                case ConversionRowResult.Unchanged: Unchanged++; break;
+                case ConversionRowResult.Refused: Refused++; break;
+                case ConversionRowResult.Error: Failed++; break;
+
+                // Invalid belongs here rather than with Unchanged: it is a file the run
+                // did not convert, not one that needed no conversion.
+                case ConversionRowResult.Skipped:
+                case ConversionRowResult.Invalid:
+                    Skipped++;
+                    break;
+            }
+        }
+
+        internal string Describe(bool wasPreview, bool stopped)
+        {
+            string headline = (wasPreview, stopped) switch
+            {
+                (true, true) => "Preview cancelled",
+                (true, false) => "Preview complete",
+                (false, true) => "Conversion cancelled",
+                (false, false) => "Conversion complete",
+            };
+
+            string verb = wasPreview ? "would be converted" : "converted";
+
+            return $"{headline}: {Converted} {verb}, {Unchanged} unchanged, "
+                   + $"{Skipped} skipped, {Refused} refused, {Failed} failed";
+        }
     }
 
     // Kept separate so row presentation can be tested without creating the form.

--- a/sources/EncodingChecker/MainForm.Export.cs
+++ b/sources/EncodingChecker/MainForm.Export.cs
@@ -16,7 +16,7 @@ public partial class MainForm
             return;
         }
 
-        var saveFileDialog = new SaveFileDialog
+        using var saveFileDialog = new SaveFileDialog
         {
             Title = @"Export to a Text File",
             Filter = @"Text files (*.txt)|*.txt",
@@ -75,7 +75,7 @@ public partial class MainForm
             return;
         }
 
-        var saveFileDialog = new SaveFileDialog
+        using var saveFileDialog = new SaveFileDialog
         {
             Title = @"Export Results as CSV",
             Filter = @"CSV files (*.csv)|*.csv",
@@ -103,7 +103,7 @@ public partial class MainForm
         if (_lastConversionJournal is null)
             return;
 
-        var saveFileDialog = new SaveFileDialog
+        using var saveFileDialog = new SaveFileDialog
         {
             Title = @"Export Conversion Journal",
             Filter = @"JSON files (*.json)|*.json",

--- a/sources/EncodingChecker/MainForm.Settings.cs
+++ b/sources/EncodingChecker/MainForm.Settings.cs
@@ -8,24 +8,28 @@ public partial class MainForm
 {
     private void LoadSettings()
     {
-        string settingsFileName = GetSettingsFileName();
         Settings settings = new();
-
-        if (!File.Exists(settingsFileName))
-        {
-            ApplySettings(settings);
-            return;
-        }
 
         try
         {
-            using var settingsFile = new FileStream(
-                settingsFileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var serializer = new XmlSerializer(typeof(Settings));
-            settings = serializer.Deserialize(settingsFile) as Settings ?? new Settings();
+            // Inside the try: this creates the settings directory, which fails on a
+            // profile that forbids it. Outside, that exception escaped OnFormLoad and
+            // the window would not open at all - over preferences EC can do without.
+            string settingsFileName = GetSettingsFileName();
+
+            if (File.Exists(settingsFileName))
+            {
+                using var settingsFile = new FileStream(
+                    settingsFileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+                var serializer = new XmlSerializer(typeof(Settings));
+
+                settings = serializer.Deserialize(settingsFile) as Settings
+                           ?? new Settings();
+            }
         }
         catch (Exception ex) when (
-            ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            ex is IOException or UnauthorizedAccessException or InvalidOperationException
+                or ArgumentException or NotSupportedException)
         {
             // Settings are optional; defaults keep the application usable.
             settings = new Settings();

--- a/sources/EncodingChecker/MainForm.Settings.cs
+++ b/sources/EncodingChecker/MainForm.Settings.cs
@@ -35,6 +35,7 @@ public partial class MainForm
             settings = new Settings();
         }
 
+        settings.NormalizeAfterLoad();
         ApplySettings(settings);
     }
 
@@ -101,7 +102,8 @@ public partial class MainForm
             settingsFile.Flush();
         }
         catch (Exception ex) when (
-            ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            ex is IOException or UnauthorizedAccessException or InvalidOperationException
+                or ArgumentException or NotSupportedException)
         {
             // Closing the application must not depend on saving preferences.
         }

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -27,6 +27,24 @@ internal static partial class Program
             return 3;
         }
 
+        // -BasePath refuses a reparse-point root, so a plan can never have been made
+        // through one. Checking only that the directory still exists let the same input
+        // be rejected when planning and followed when applying: rename the root away,
+        // put a junction in its place, and the writes land in a tree the reviewer never
+        // saw. FindStaleFiles repeats this per path; naming the root here says which
+        // one thing changed instead of listing every file under it.
+        if (DirectoryTraversal.IsReparsePointDirectory(plan.BaseDirectory))
+        {
+            Console.Error.WriteLine(
+                $"The plan's directory is now a symbolic link or other reparse point, " +
+                $"so it may no longer be the directory that was reviewed: " +
+                $"{plan.BaseDirectory}");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(
+                "Re-run -Plan against the real directory you intend to convert.");
+            return 3;
+        }
+
         // Apply the reviewed plan; do not re-detect and silently change its decisions.
         IReadOnlyList<string> stale = plan.FindStaleFiles();
 

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -72,6 +72,18 @@ internal static partial class Program
                     ReasonCode = f.ReasonCode,
                     Diagnostic = f.Reason,
 
+                    // A policy input, not provenance: without it the explicit-source
+                    // veto cannot fire when the plan is applied.
+                    HasReliableUnicodeDetection = f.HasReliableUnicodeDetection,
+
+                    // The reviewed decision, kept intact so re-deciding below can only
+                    // refuse more than the review did, never less.
+                    Approved = new ApprovedDecision(
+                        f.Action,
+                        f.SourceInterpretation,
+                        f.ReasonCode,
+                        f.Reason),
+
                     // Rechecked at installation so a long conversion cannot install over
                     // bytes that changed after the initial stale-file check.
                     ExpectedSourceSha256 = f.Sha256,

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -105,11 +105,18 @@ internal static partial class Program
         ];
 
         using var cancellation = new CancellationTokenSource();
-        Console.CancelKeyPress += (_, e) =>
+
+        // Unsubscribed below, as the scan path already does. Left attached, the handler
+        // outlives the token source it captured, and a Ctrl+C after this method returns
+        // calls Cancel on a disposed one - an ObjectDisposedException raised on the
+        // console's own thread, where nothing is waiting to catch it.
+        ConsoleCancelEventHandler cancelHandler = (_, e) =>
         {
             e.Cancel = true;
             cancellation.Cancel();
         };
+
+        Console.CancelKeyPress += cancelHandler;
 
         try
         {
@@ -127,6 +134,10 @@ internal static partial class Program
         {
             Console.Error.WriteLine("Cancelled.");
             return 4;
+        }
+        finally
+        {
+            Console.CancelKeyPress -= cancelHandler;
         }
 
         List<ConversionReportEntry> completed =

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -347,6 +347,13 @@ internal static partial class Program
                 + "(hidden, system, or reparse point).");
         }
 
+        if (traversalCounters.FilesExcludedAsEcArtifact > 0)
+        {
+            Console.Error.WriteLine(
+                $"{traversalCounters.FilesExcludedAsEcArtifact} matching file(s) not examined "
+                + "(EC backup, recovery record, or temporary file).");
+        }
+
         if (traversalCounters.DirectoriesExcludedByAttribute > 0)
         {
             Console.Error.WriteLine(

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -354,6 +354,15 @@ internal static partial class Program
                 + "(hidden, system, or reparse point); their contents were not counted.");
         }
 
+        // Unconditional, and on stderr, matching -Apply. A file that could not be read
+        // is why the run exits 3, so suppressing the reason under -Quiet leaves the
+        // caller with a failure and nothing to act on.
+        foreach (ConversionReportEntry entry in entries
+                     .Where(e => e.Result == ConversionRowResult.Error))
+        {
+            Console.Error.WriteLine($"Error: {entry.FilePath}: {entry.Diagnostic}");
+        }
+
         if (options.Verbose)
             PrintVerboseSummary(entries);
 
@@ -431,7 +440,15 @@ internal static partial class Program
                 Console.Out.WriteLine(plan.Summarize());
             }
 
-            // A refusal is an expected preflight result, not a failed preflight.
+            // A file the scan could not read is a failed preflight, and the published
+            // precedence puts 3 ahead of 2. Returning before this check let a plan run
+            // report success over files it never opened; the plan is still written and
+            // summarized first so the caller can see which ones.
+            if (entries.Any(e => e.Result == ConversionRowResult.Error))
+                return 3;
+
+            // A refusal, unlike an error, is an expected preflight result. Exit 5 is
+            // deliberately not returned here.
             if (options.FailOnChanges &&
                 plan.Files.Any(f => f.Action == PlannedAction.Convert))
             {

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -27,8 +27,7 @@ internal static partial class Program
             return 3;
         }
 
-        // A reparse point can redirect the approved path to an unreviewed tree while all
-        // file hashes still match. FindStaleFiles repeats this check for each entry.
+        // A matching hash cannot reveal that a link redirected the reviewed path.
         if (DirectoryTraversal.IsReparsePointDirectory(plan.BaseDirectory))
         {
             Console.Error.WriteLine(
@@ -39,6 +38,23 @@ internal static partial class Program
             Console.Error.WriteLine(
                 "Re-run -Plan against the real directory you intend to convert.");
             return 3;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.JournalPath))
+        {
+            string journalPath = Path.GetFullPath(options.JournalPath);
+            PlannedFile? collision = plan.Files.FirstOrDefault(file =>
+                string.Equals(
+                    plan.ResolvePath(file), journalPath,
+                    StringComparison.OrdinalIgnoreCase));
+
+            if (collision is not null)
+            {
+                Console.Error.WriteLine(
+                    $"The journal path is also a planned source file: {collision.RelativePath}");
+                Console.Error.WriteLine("Choose another -Journal path; nothing was converted.");
+                return 1;
+            }
         }
 
         // Apply the reviewed plan; do not re-detect and silently change its decisions.
@@ -86,12 +102,10 @@ internal static partial class Program
                     ReasonCode = f.ReasonCode,
                     Diagnostic = f.Reason,
 
-                    // A policy input, not provenance: without it the explicit-source
-                    // veto cannot fire when the plan is applied.
+                    // Preserve the Unicode-veto input used by the reviewed decision.
                     HasReliableUnicodeDetection = f.HasReliableUnicodeDetection,
 
-                    // The reviewed decision, kept intact so re-deciding below can only
-                    // refuse more than the review did, never less.
+                    // Revalidation may tighten this decision, never broaden it.
                     Approved = new ApprovedDecision(
                         f.Action,
                         f.SourceInterpretation,
@@ -106,10 +120,7 @@ internal static partial class Program
 
         using var cancellation = new CancellationTokenSource();
 
-        // Unsubscribed below, as the scan path already does. Left attached, the handler
-        // outlives the token source it captured, and a Ctrl+C after this method returns
-        // calls Cancel on a disposed one - an ObjectDisposedException raised on the
-        // console's own thread, where nothing is waiting to catch it.
+        // Detach this handler before its token source is disposed.
         ConsoleCancelEventHandler cancelHandler = (_, e) =>
         {
             e.Cancel = true;
@@ -348,9 +359,7 @@ internal static partial class Program
             ConversionReport.WriteCsv(entries, Console.Out);
         }
 
-        // Coverage, not a result: a caller reading only the rows cannot tell a clean
-        // folder from one holding files the scan never opened. Written to stderr so it
-        // survives -Quiet and stays out of the machine-readable report on stdout.
+        // Keep coverage warnings on stderr and outside the CSV stream.
         if (traversalCounters.FilesExcludedByAttribute > 0)
         {
             Console.Error.WriteLine(
@@ -372,9 +381,7 @@ internal static partial class Program
                 + "(hidden, system, or reparse point); their contents were not counted.");
         }
 
-        // Unconditional, and on stderr, matching -Apply. A file that could not be read
-        // is why the run exits 3, so suppressing the reason under -Quiet leaves the
-        // caller with a failure and nothing to act on.
+        // Quiet mode must not hide the reason for exit code 3.
         foreach (ConversionReportEntry entry in entries
                      .Where(e => e.Result == ConversionRowResult.Error))
         {

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -27,12 +27,8 @@ internal static partial class Program
             return 3;
         }
 
-        // -BasePath refuses a reparse-point root, so a plan can never have been made
-        // through one. Checking only that the directory still exists let the same input
-        // be rejected when planning and followed when applying: rename the root away,
-        // put a junction in its place, and the writes land in a tree the reviewer never
-        // saw. FindStaleFiles repeats this per path; naming the root here says which
-        // one thing changed instead of listing every file under it.
+        // A reparse point can redirect the approved path to an unreviewed tree while all
+        // file hashes still match. FindStaleFiles repeats this check for each entry.
         if (DirectoryTraversal.IsReparsePointDirectory(plan.BaseDirectory))
         {
             Console.Error.WriteLine(

--- a/sources/EncodingChecker/Program.CliParsing.cs
+++ b/sources/EncodingChecker/Program.CliParsing.cs
@@ -258,6 +258,15 @@ internal static partial class Program
             return false;
         }
 
+        // Silently letting one win means the caller who asked for detail gets a summary
+        // and no indication that the request was dropped.
+        if (options is { Quiet: true, Verbose: true })
+        {
+            error = "-Quiet and -Verbose ask for opposite amounts of output; "
+                    + "supply only one.";
+            return false;
+        }
+
         if (!string.IsNullOrWhiteSpace(options.PlanPath) &&
             !string.IsNullOrWhiteSpace(options.ApplyPath))
         {
@@ -375,6 +384,27 @@ internal static partial class Program
             error =
                 "-Validate cannot be combined with -Target.";
             return false;
+        }
+
+        // The read-only modes write nothing, so an option that only affects writing
+        // cannot be honoured. Accepting and ignoring it lets a script that meant to
+        // convert read a clean detect run as though the conversion had happened.
+        if (options.DetectOnly || options.ValidateCharsets is not null)
+        {
+            string mode = options.DetectOnly ? "-DetectOnly" : "-Validate";
+
+            string? ignored =
+                options.Target is not null ? "-Target"
+                : options.WhatIf ? "-WhatIf"
+                : options.Backup ? "-Backup"
+                : null;
+
+            if (ignored is not null)
+            {
+                error = $"{mode} cannot be combined with {ignored}; it reports what the "
+                        + "detector finds and changes nothing.";
+                return false;
+            }
         }
 
         if (options.ValidateCharsets is not null &&

--- a/sources/EncodingChecker/Program.CliParsing.cs
+++ b/sources/EncodingChecker/Program.CliParsing.cs
@@ -240,31 +240,22 @@ internal static partial class Program
         CliOptions options,
         [NotNullWhen(false)] out string? error)
     {
-        // A filter that fails to parse must not widen the scan. -Include "" and
-        // -Include ",,," both leave no usable pattern, which would otherwise mean
-        // every file - the opposite of what the caller asked for, and dangerous
-        // when the value came from an unset variable in a script.
-        if (options.IncludeSpecified && options.Include.Count == 0)
+        switch (options)
         {
-            error = "-Include was given but contains no usable pattern. Omit "
-                    + "-Include to process every file.";
-            return false;
-        }
-
-        if (options.ExcludeSpecified && options.Exclude.Count == 0)
-        {
-            error = "-Exclude was given but contains no usable pattern. Omit "
-                    + "-Exclude to process every file.";
-            return false;
-        }
-
-        // Silently letting one win means the caller who asked for detail gets a summary
-        // and no indication that the request was dropped.
-        if (options is { Quiet: true, Verbose: true })
-        {
-            error = "-Quiet and -Verbose ask for opposite amounts of output; "
-                    + "supply only one.";
-            return false;
+            // An empty filter must not widen a scripted scan to every file.
+            case { IncludeSpecified: true, Include.Count: 0 }:
+                error = "-Include was given but contains no usable pattern. Omit "
+                        + "-Include to process every file.";
+                return false;
+            case { ExcludeSpecified: true, Exclude.Count: 0 }:
+                error = "-Exclude was given but contains no usable pattern. Omit "
+                        + "-Exclude to process every file.";
+                return false;
+            // Neither output mode may silently override the other.
+            case { Quiet: true, Verbose: true }:
+                error = "-Quiet and -Verbose ask for opposite amounts of output; "
+                        + "supply only one.";
+                return false;
         }
 
         if (!string.IsNullOrWhiteSpace(options.PlanPath) &&
@@ -274,6 +265,12 @@ internal static partial class Program
                     + "separate runs so the plan can be reviewed in between.";
             return false;
         }
+
+        if (!TryValidateDistinctCommandPaths(options, out error))
+            return false;
+
+        if (!TryValidateOutputSuffixes(options, out error))
+            return false;
 
         if (!string.IsNullOrWhiteSpace(options.ApplyPath))
         {
@@ -386,9 +383,7 @@ internal static partial class Program
             return false;
         }
 
-        // The read-only modes write nothing, so an option that only affects writing
-        // cannot be honoured. Accepting and ignoring it lets a script that meant to
-        // convert read a clean detect run as though the conversion had happened.
+        // Reject ignored write options so scripts cannot mistake inspection for conversion.
         if (options.DetectOnly || options.ValidateCharsets is not null)
         {
             string mode = options.DetectOnly ? "-DetectOnly" : "-Validate";
@@ -401,8 +396,8 @@ internal static partial class Program
 
             if (ignored is not null)
             {
-                error = $"{mode} cannot be combined with {ignored}; it reports what the "
-                        + "detector finds and changes nothing.";
+                error = $"{ignored} only affects conversion and cannot be used with "
+                        + $"{mode}, which does not modify files.";
                 return false;
             }
         }
@@ -449,6 +444,86 @@ internal static partial class Program
                     : $"'{options.Target}' is not a recognized encoding.";
                 return false;
             }
+        }
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>Prevents command files from silently overwriting one another.</summary>
+    private static bool TryValidateDistinctCommandPaths(
+        CliOptions options,
+        [NotNullWhen(false)] out string? error)
+    {
+        (string Name, string? Path)[] candidates =
+        [
+            ("-Plan", options.PlanPath),
+            ("-Apply", options.ApplyPath),
+            ("-Journal", options.JournalPath),
+            ("-Report", options.ReportPath),
+        ];
+
+        var seen = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach ((string name, string? path) in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+
+            string fullPath;
+
+            try
+            {
+                fullPath = Path.GetFullPath(path);
+            }
+            catch (Exception ex) when (
+                ex is IOException or ArgumentException or NotSupportedException)
+            {
+                error = $"{name} contains an invalid path: {ex.Message}";
+                return false;
+            }
+
+            if (seen.TryGetValue(fullPath, out string? first))
+            {
+                error = $"{first} and {name} resolve to the same file. Use separate paths.";
+                return false;
+            }
+
+            seen.Add(fullPath, name);
+        }
+
+        error = null;
+        return true;
+    }
+
+    /// <summary>Prevents command output from replacing EC recovery artifacts.</summary>
+    private static bool TryValidateOutputSuffixes(
+        CliOptions options,
+        [NotNullWhen(false)] out string? error)
+    {
+        (string Name, string? Path)[] outputs =
+        [
+            ("-Plan", options.PlanPath),
+            ("-Journal", options.JournalPath),
+            ("-Report", options.ReportPath),
+        ];
+
+        foreach ((string name, string? path) in outputs)
+        {
+            if (path is null)
+                continue;
+
+            // Windows removes trailing spaces and periods from ordinary file paths.
+            // Check the resolved name so "file.bak." cannot alias "file.bak".
+            string fullPath = Path.GetFullPath(path);
+
+            if (!DirectoryTraversal.HasReservedArtifactSuffix(fullPath))
+                continue;
+
+            error = $"{name} uses an EC-reserved artifact suffix. "
+                    + "Choose a path that cannot be mistaken for a backup, recovery "
+                    + "record, or temporary conversion file.";
+            return false;
         }
 
         error = null;

--- a/sources/EncodingChecker/Program.CliParsing.cs
+++ b/sources/EncodingChecker/Program.CliParsing.cs
@@ -215,12 +215,8 @@ internal static partial class Program
             return false;
         }
 
-        // An option that arrives with nothing in it is a missing value, not an absent
-        // option. Every later test uses IsNullOrWhiteSpace, so an empty string read as
-        // "not supplied" and fell through to the most permissive behaviour: -Plan ""
-        // skipped the preview flag and converted for real, and -From "" silently
-        // reverted to automatic detection. Rejecting it here covers every value-taking
-        // option, including ones added later, rather than one validation rule each.
+        // Later validation treats blank strings as absent. Reject them here so safety
+        // options such as -Plan and -Apply cannot fall through to direct conversion.
         if (string.IsNullOrWhiteSpace(candidate))
         {
             value = null;

--- a/sources/EncodingChecker/Program.CliParsing.cs
+++ b/sources/EncodingChecker/Program.CliParsing.cs
@@ -215,6 +215,18 @@ internal static partial class Program
             return false;
         }
 
+        // An option that arrives with nothing in it is a missing value, not an absent
+        // option. Every later test uses IsNullOrWhiteSpace, so an empty string read as
+        // "not supplied" and fell through to the most permissive behaviour: -Plan ""
+        // skipped the preview flag and converted for real, and -From "" silently
+        // reverted to automatic detection. Rejecting it here covers every value-taking
+        // option, including ones added later, rather than one validation rule each.
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            value = null;
+            return false;
+        }
+
         value = args[++i];
         return true;
     }

--- a/sources/EncodingChecker/Program.CliReporting.cs
+++ b/sources/EncodingChecker/Program.CliReporting.cs
@@ -9,16 +9,8 @@ internal static partial class Program
     private static void PrintVerboseSummary(
         List<ConversionReportEntry> entries)
     {
-        foreach (ConversionReportEntry entry in entries)
-        {
-            if (entry.Result == ConversionRowResult.Error &&
-                !string.IsNullOrEmpty(entry.Diagnostic))
-            {
-                Console.Error.WriteLine(
-                    $"Error: {entry.FilePath}: {entry.Diagnostic}");
-            }
-        }
-
+        // Errors are reported unconditionally by the caller, so -Verbose adds only the
+        // breakdown rather than repeating them.
         var byResult =
             entries
                 .GroupBy(e => e.Result)

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -218,8 +218,15 @@ internal static partial class Program
         Directories named .git, .svn, .hg, .vs, .idea, bin, obj, node_modules,
         packages, dist, build, and target are always skipped. Matching hidden,
         system, and reparse-point files are not examined. Hidden, system, and
-        reparse-point folders are not entered. Both counts are reported on stderr
-        and are informational; they do not change the exit code.
+        reparse-point folders are not entered.
+
+        EC's own .bak, .ecmeta.json, and .unicodechecker.tmp files are always
+        skipped, as are this command's own -Plan, -Journal, and -Report outputs.
+        Plans, journals, and reports from earlier runs are not recognized and are
+        scanned like any other file; keep them outside the folder you scan.
+
+        Every count above is reported on stderr for files your patterns selected,
+        and is informational; none of them change the exit code.
 
         Help: -?, /?, -h, /h, or --help. Version: --version.
 

--- a/sources/EncodingChecker/Program.cs
+++ b/sources/EncodingChecker/Program.cs
@@ -195,11 +195,14 @@ internal static partial class Program
           -Report <path>                Also write the UTF-8-with-BOM CSV report to a file.
           -Journal <path>               Write a JSON record of the conversion decision and
                                       result for every file. Convert mode only.
-          -Quiet                        Print only the final summary on standard output.
+          -Quiet                        Suppress per-file CSV and normal summaries.
+                                      Errors and coverage warnings still go to stderr.
           -Verbose                      Include error details and a result breakdown.
           -MaxParallelism <N>           Maximum simultaneous files; default is min(CPU count, 4).
           -FailOnChanges                Return exit code 2 if files need conversion (or fail
                                       validation). Useful for CI.
+
+        Plan, apply, report, and journal paths must name different files.
 
         Examples:
 
@@ -220,13 +223,14 @@ internal static partial class Program
         system, and reparse-point files are not examined. Hidden, system, and
         reparse-point folders are not entered.
 
-        EC's own .bak, .ecmeta.json, and .unicodechecker.tmp files are always
-        skipped, as are this command's own -Plan, -Journal, and -Report outputs.
+        Files ending in .bak, .ecmeta.json, or .unicodechecker.tmp are always
+        skipped, as are this command's -Plan, -Journal, and -Report outputs.
+        Those output options cannot use one of the reserved suffixes above.
         Plans, journals, and reports from earlier runs are not recognized and are
         scanned like any other file; keep them outside the folder you scan.
 
-        Every count above is reported on stderr for files your patterns selected,
-        and is informational; none of them change the exit code.
+        Skipped-file and skipped-folder counts are written to stderr for items your
+        patterns selected. These coverage counts do not change the exit code.
 
         Help: -?, /?, -h, /h, or --help. Version: --version.
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.10.1.0")]
-[assembly: AssemblyFileVersion("3.10.1.0")]
+[assembly: AssemblyVersion("3.11.0.0")]
+[assembly: AssemblyFileVersion("3.11.0.0")]

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -252,14 +252,17 @@ internal static class ScanEngine
             getPath: entry => entry.FilePath,
             processItem: entry =>
             {
-                // A failed planning snapshot is already a terminal refusal. Do not let a
-                // later pass reinterpret it as an ordinary unknown-encoding skip.
+                entry.ResetAttemptEvidence();
+
+                // A failed planning snapshot is already a terminal error.
                 if (entry is
                     {
                         Action: PlannedAction.Refuse,
                         ReasonCode: ConversionReasonCodes.SourceSnapshotFailed
                     })
                 {
+                    entry.Result = ConversionRowResult.Error;
+                    entry.ReplacementCommitted = false;
                     return entry;
                 }
 
@@ -374,7 +377,8 @@ internal static class ScanEngine
                 {
                     entry.Action = PlannedAction.Refuse;
                     entry.SourceInterpretation = SourceInterpretation.NotApplicable;
-                    entry.Result = ConversionRowResult.Refused;
+                    entry.Result = ConversionRowResult.Error;
+                    entry.ReplacementCommitted = false;
                     entry.ReasonCode = ConversionReasonCodes.SourceSnapshotFailed;
                     entry.Diagnostic =
                         $"The source could not be read consistently for planning: {ex.Message}";
@@ -469,10 +473,7 @@ internal static class ScanEngine
             detected = TextEncoding.DetectFromFile(path);
             hasBom = detected != null && HasPreamble(path, detected);
 
-            // The byte order is a fact about the file, so the read-only modes need it
-            // too; a mode that reports an unprovable order as settled contradicts the
-            // one that refuses it. Not computed for an explicit source: there `detected`
-            // is the answer being supplied, not evidence, so asking it always answers no.
+            // Read-only modes must disclose the same unprovable byte order conversion refuses.
             snapshotHasAmbiguousBomlessUtf16 =
                 detected is not null && IsAmbiguousBomlessUtf16(path, detected, hasBom);
         }
@@ -796,16 +797,7 @@ internal static class ScanEngine
         if (entry.Action is null)
             DetectionCounters.RecordClassification();
 
-        // Whether this file's byte order can be established from its bytes is a fact
-        // about the file, not a decision about what to do. Folding the two together
-        // erased the fact whenever a source was supplied: the entry then reached the
-        // advisory below with nothing left to consult but detection's own estimate,
-        // which is the very thing an ambiguous file proves nothing about.
-        //
-        // Source snapshots normally carry this in. Recheck for callers of ConvertFiles
-        // that supply entries directly, testing what detection saw - with an explicit
-        // source, sourceEncoding is the answer being offered, not evidence about the
-        // file, and asking it would always answer no.
+        // With an explicit source, test detection's estimate rather than the supplied answer.
         Encoding? bomlessCandidate = entry.SourceEncodingWasSpecified
             ? automaticallyDetected
             : sourceEncoding;
@@ -872,10 +864,7 @@ internal static class ScanEngine
         // The optional BOM-less Unicode advisory below is added back for this pass.
         entry.Diagnostic = null;
 
-        // Reported whether or not the choice matches detection's estimate. Matching an
-        // estimate EC cannot prove is not corroboration, and staying silent for it left
-        // the one case most likely to be wrong - the caller repeating a wrong guess -
-        // indistinguishable from an ordinary conversion.
+        // Matching an unprovable estimate still means the byte order was taken on trust.
         if (action == PlannedAction.Convert &&
             entry.SourceEncodingWasSpecified &&
             automaticallyDetected is not null &&
@@ -926,6 +915,9 @@ internal static class ScanEngine
             entry.Result = ConversionRowResult.Converted; // "would be converted"
             return;
         }
+
+        // No replacement has happened yet; failures before the converter are known safe.
+        entry.ReplacementCommitted = false;
 
         if (backup)
         {
@@ -1018,9 +1010,7 @@ internal static class ScanEngine
             entry.CurrentCharsetLabel = UnknownCharset;
         }
 
-        // Kept rather than consumed for the charset label alone: a failure after the
-        // file was replaced still changed it, and the journal must not call that
-        // untouched.
+        // The journal needs the installation state even when a later step failed.
         entry.ReplacementCommitted = result.ReplacementCommitted;
 
         entry.Result =
@@ -1072,8 +1062,7 @@ internal static class ScanEngine
         if (hashError is not null)
             return hashError;
 
-        // The hash of the bytes verification passed, so the journal can record what this
-        // run installed rather than whatever is on disk when it is written.
+        // Record the verified output rather than a later reread of the path.
         entry.OutputSha256 = record.OutputSha256;
 
         var prepared = new ConversionMetadata
@@ -1194,8 +1183,7 @@ internal static class ScanEngine
                 destination.Flush(flushToDisk: true);
             }
 
-            // Remove the old record at the last safe moment. A crash may leave a backup
-            // without metadata, but never metadata describing a different backup.
+            // Never leave old metadata describing a newly replaced backup.
             ConversionMetadataStore.RemoveBeforeBackupReplacement(path);
 
             EncodingConverter.AtomicReplaceForBackup(tempPath, path + ".bak");
@@ -1258,17 +1246,32 @@ internal static class ScanEngine
                     ArgumentException or
                     NotSupportedException)
                 {
-                    entry = new ConversionReportEntry
+                    if (item is ConversionReportEntry existing)
                     {
-                        FilePath = getPath(item),
-                        SourceEncoding = "(Error)",
-                        TargetEncoding = "(Error)",
-                        Result = ConversionRowResult.Error,
-                        Action = PlannedAction.Refuse,
-                        SourceInterpretation = SourceInterpretation.NotApplicable,
-                        ReasonCode = ConversionReasonCodes.ScanFailed,
-                        Diagnostic = ex.Message,
-                    };
+                        // Keep the caller's entry authoritative when conversion fails.
+                        existing.Result = ConversionRowResult.Error;
+                        existing.Action = PlannedAction.Refuse;
+                        existing.SourceInterpretation = SourceInterpretation.NotApplicable;
+                        existing.ReplacementCommitted = false;
+                        existing.ReasonCode = ConversionReasonCodes.ScanFailed;
+                        existing.Diagnostic = ex.Message;
+                        entry = existing;
+                    }
+                    else
+                    {
+                        entry = new ConversionReportEntry
+                        {
+                            FilePath = getPath(item),
+                            SourceEncoding = "(Error)",
+                            TargetEncoding = "(Error)",
+                            Result = ConversionRowResult.Error,
+                            Action = PlannedAction.Refuse,
+                            SourceInterpretation = SourceInterpretation.NotApplicable,
+                            ReplacementCommitted = false,
+                            ReasonCode = ConversionReasonCodes.ScanFailed,
+                            Diagnostic = ex.Message,
+                        };
+                    }
                 }
 
                 if (entry is not null)

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -809,12 +809,8 @@ internal static class ScanEngine
             out SourceInterpretation sourceInterpretation,
             out string? policyReason);
 
-        // A reviewed decision is a ceiling. Applying a plan re-decides rather than
-        // replays it, so a file that became unsafe after review is still refused - that
-        // direction is the point. The opposite direction never is: whatever the plan
-        // could not carry is simply absent here, and the policy then answers a question
-        // it has no evidence for. HasReliableUnicodeDetection is why this exists; the
-        // ceiling is what stops the next missing input from doing the same thing.
+        // Revalidation may make an applied plan stricter, never broader. Preserve a
+        // reviewed non-writing action if the current policy would convert the file.
         if (entry.Approved is { } approved &&
             approved.Action is not PlannedAction.Convert &&
             action is PlannedAction.Convert)
@@ -1159,12 +1155,9 @@ internal static class ScanEngine
                 destination.Flush(flushToDisk: true);
             }
 
-            // Drop the previous record before its backup stops existing. Done in this
-            // order - after the replacement copy is safely on disk, immediately before
-            // it takes the .bak name - the worst interruption leaves a valid backup
-            // with no record, which can be inspected. The other order leaves a record
-            // insisting on a hash and a source codec for bytes that are gone.
-            ConversionMetadataStore.Invalidate(path);
+            // Remove the old record at the last safe moment. A crash may leave a backup
+            // without metadata, but never metadata describing a different backup.
+            ConversionMetadataStore.RemoveBeforeBackupReplacement(path);
 
             EncodingConverter.AtomicReplaceForBackup(tempPath, path + ".bak");
         }

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -468,6 +468,13 @@ internal static class ScanEngine
             DetectionCounters.RecordDetection();
             detected = TextEncoding.DetectFromFile(path);
             hasBom = detected != null && HasPreamble(path, detected);
+
+            // The byte order is a fact about the file, so the read-only modes need it
+            // too; a mode that reports an unprovable order as settled contradicts the
+            // one that refuses it. Not computed for an explicit source: there `detected`
+            // is the answer being supplied, not evidence, so asking it always answers no.
+            snapshotHasAmbiguousBomlessUtf16 =
+                detected is not null && IsAmbiguousBomlessUtf16(path, detected, hasBom);
         }
 
         string sourceCharset =
@@ -490,8 +497,9 @@ internal static class ScanEngine
                 hasReliableUnicodeDetection,
             DetectedEncodingHasBom = options.Action == ScanAction.Convert &&
                 snapshotDetectedHasBom,
-            HasAmbiguousBomlessUtf16 = options.Action == ScanAction.Convert &&
-                snapshotHasAmbiguousBomlessUtf16,
+            // Not gated on Convert like the two above: those are policy inputs, this
+            // states what the bytes do and holds in every mode.
+            HasAmbiguousBomlessUtf16 = snapshotHasAmbiguousBomlessUtf16,
         };
 
         if (options.Action == ScanAction.Convert)
@@ -508,6 +516,14 @@ internal static class ScanEngine
                     entry.ReasonCode = ConversionReasonCodes.UnknownEncoding;
                     entry.Diagnostic =
                         "The file's encoding could not be identified from its contents.";
+                }
+                else if (entry.HasAmbiguousBomlessUtf16)
+                {
+                    // Detection found an estimate, not a reading. Nothing failed, so
+                    // the result stays Unchanged; the row must still say which it is.
+                    entry.ReasonCode = ConversionReasonCodes.AmbiguousBomlessUtf16;
+                    entry.Diagnostic =
+                        BomlessUnicodeSafety.DescribeUnprovableByteOrder(detected!);
                 }
 
                 break;
@@ -535,6 +551,20 @@ internal static class ScanEngine
                 {
                     entry.ReasonCode = ConversionReasonCodes.StrictValidationFailed;
                     entry.Diagnostic = validationDiagnostic;
+                }
+                else if (entry.Result == ConversionRowResult.Unchanged &&
+                         entry.HasAmbiguousBomlessUtf16)
+                {
+                    // The two byte orders are separate entries in the allowed set; the
+                    // label matched only because .NET names both "utf-16". Passing the
+                    // file would assert an identity EC cannot establish, and conversion
+                    // refuses that same file later.
+                    entry.Result = ConversionRowResult.Invalid;
+                    entry.ReasonCode = ConversionReasonCodes.AmbiguousBomlessUtf16;
+                    entry.Diagnostic =
+                        BomlessUnicodeSafety.DescribeUnprovableByteOrder(detected!)
+                        + $" The label '{label}' is in the allowed list, but EC cannot"
+                        + " confirm this file belongs to it.";
                 }
 
                 break;

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -1159,6 +1159,13 @@ internal static class ScanEngine
                 destination.Flush(flushToDisk: true);
             }
 
+            // Drop the previous record before its backup stops existing. Done in this
+            // order - after the replacement copy is safely on disk, immediately before
+            // it takes the .bak name - the worst interruption leaves a valid backup
+            // with no record, which can be inspected. The other order leaves a record
+            // insisting on a hash and a source codec for bytes that are gone.
+            ConversionMetadataStore.Invalidate(path);
+
             EncodingConverter.AtomicReplaceForBackup(tempPath, path + ".bak");
         }
         finally

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -1018,6 +1018,11 @@ internal static class ScanEngine
             entry.CurrentCharsetLabel = UnknownCharset;
         }
 
+        // Kept rather than consumed for the charset label alone: a failure after the
+        // file was replaced still changed it, and the journal must not call that
+        // untouched.
+        entry.ReplacementCommitted = result.ReplacementCommitted;
+
         entry.Result =
             result.Success
                 ? ConversionRowResult.Converted
@@ -1066,6 +1071,10 @@ internal static class ScanEngine
 
         if (hashError is not null)
             return hashError;
+
+        // The hash of the bytes verification passed, so the journal can record what this
+        // run installed rather than whatever is on disk when it is written.
+        entry.OutputSha256 = record.OutputSha256;
 
         var prepared = new ConversionMetadata
         {

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -809,6 +809,24 @@ internal static class ScanEngine
             out SourceInterpretation sourceInterpretation,
             out string? policyReason);
 
+        // A reviewed decision is a ceiling. Applying a plan re-decides rather than
+        // replays it, so a file that became unsafe after review is still refused - that
+        // direction is the point. The opposite direction never is: whatever the plan
+        // could not carry is simply absent here, and the policy then answers a question
+        // it has no evidence for. HasReliableUnicodeDetection is why this exists; the
+        // ceiling is what stops the next missing input from doing the same thing.
+        if (entry.Approved is { } approved &&
+            approved.Action is not PlannedAction.Convert &&
+            action is PlannedAction.Convert)
+        {
+            entry.Action = approved.Action;
+            entry.SourceInterpretation = approved.SourceInterpretation;
+            entry.Result = ConversionPolicy.ToRowResult(approved.Action);
+            entry.ReasonCode = approved.ReasonCode;
+            entry.Diagnostic = approved.Diagnostic;
+            return;
+        }
+
         entry.Action = action;
         entry.SourceInterpretation = sourceInterpretation;
         entry.ReasonCode = action switch

--- a/sources/EncodingChecker/Settings.cs
+++ b/sources/EncodingChecker/Settings.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace EncodingChecker;
@@ -50,9 +52,58 @@ public sealed class WindowPosition
     public int Width = -1;
     public int Height = -1;
 
-    public void ApplyTo(Form form)
+    public void ApplyTo(Form form) =>
+        ApplyTo(form, Screen.AllScreens.Select(s => s.WorkingArea));
+
+    /// <summary>
+    /// Restores the saved bounds, but only onto a monitor that is actually there.
+    /// </summary>
+    /// <remarks>
+    /// The monitor list is a parameter so the decision can be tested against layouts
+    /// this machine does not have - a saved position is only ever wrong on a desktop
+    /// other than the one that saved it.
+    /// </remarks>
+    internal void ApplyTo(Form form, IEnumerable<Rectangle> workingAreas)
     {
-        if (Left >= 0 && Top >= 0 && Width > 0 && Height > 0)
-            form.SetBounds(Left, Top, Width, Height);
+        ArgumentNullException.ThrowIfNull(form);
+
+        if (Width <= 0 || Height <= 0)
+            return;
+
+        if (!IsReachable(new Rectangle(Left, Top, Width, Height), workingAreas))
+            return;
+
+        form.SetBounds(Left, Top, Width, Height);
+    }
+
+    /// <summary>
+    /// Whether enough of the window would land on a monitor to be usable.
+    /// </summary>
+    /// <remarks>
+    /// A position saved on a monitor that is no longer attached restores the window
+    /// where nothing can reach it, and there is no way back from inside the app.
+    /// <para>
+    /// Testing the screens is also what allows negative coordinates. Rejecting those
+    /// outright, as this used to, discarded perfectly good positions on any setup with
+    /// a monitor placed left of or above the primary one.
+    /// </para>
+    /// </remarks>
+    internal static bool IsReachable(Rectangle bounds, IEnumerable<Rectangle> workingAreas)
+    {
+        // Enough of the title bar to grab, rather than a single pixel of overlap.
+        const int MinimumVisible = 80;
+
+        foreach (Rectangle area in workingAreas)
+        {
+            Rectangle overlap = Rectangle.Intersect(area, bounds);
+
+            if (overlap.Width >= Math.Min(MinimumVisible, bounds.Width) &&
+                overlap.Height >= Math.Min(MinimumVisible, bounds.Height))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/sources/EncodingChecker/Settings.cs
+++ b/sources/EncodingChecker/Settings.cs
@@ -26,6 +26,18 @@ public sealed class Settings
     public string FileMasks = string.Empty;
     public string[] ValidCharsets = [];
 
+    /// <summary>Repairs nullable values accepted by XML deserialization.</summary>
+    internal void NormalizeAfterLoad()
+    {
+        WindowPosition ??= new WindowPosition();
+        RecentDirectories ??= [];
+        RecentDirectories.RemoveAll(string.IsNullOrWhiteSpace);
+        FileMasks ??= string.Empty;
+        ValidCharsets = ValidCharsets?
+            .Where(static charset => !string.IsNullOrWhiteSpace(charset))
+            .ToArray() ?? [];
+    }
+
     /// <summary>
     /// Adds a directory to the front of the most-recently-used list, removing any existing
     /// occurrence and trimming the list to the 10 most recent entries.
@@ -76,29 +88,25 @@ public sealed class WindowPosition
         form.SetBounds(Left, Top, Width, Height);
     }
 
-    /// <summary>
-    /// Whether enough of the window would land on a monitor to be usable.
-    /// </summary>
-    /// <remarks>
-    /// A position saved on a monitor that is no longer attached restores the window
-    /// where nothing can reach it, and there is no way back from inside the app.
-    /// <para>
-    /// Testing the screens is also what allows negative coordinates. Rejecting those
-    /// outright, as this used to, discarded perfectly good positions on any setup with
-    /// a monitor placed left of or above the primary one.
-    /// </para>
-    /// </remarks>
+    /// <summary>Whether enough of the title bar remains reachable on a monitor.</summary>
     internal static bool IsReachable(Rectangle bounds, IEnumerable<Rectangle> workingAreas)
     {
-        // Enough of the title bar to grab, rather than a single pixel of overlap.
-        const int MinimumVisible = 80;
+        const int titleBarHeight = 32;
+        const int minimumVisibleWidth = 80;
+        const int minimumVisibleHeight = 8;
+
+        var titleBar = new Rectangle(
+            bounds.Left,
+            bounds.Top,
+            bounds.Width,
+            Math.Min(titleBarHeight, bounds.Height));
 
         foreach (Rectangle area in workingAreas)
         {
-            Rectangle overlap = Rectangle.Intersect(area, bounds);
+            Rectangle overlap = Rectangle.Intersect(area, titleBar);
 
-            if (overlap.Width >= Math.Min(MinimumVisible, bounds.Width) &&
-                overlap.Height >= Math.Min(MinimumVisible, bounds.Height))
+            if (overlap.Width >= Math.Min(minimumVisibleWidth, titleBar.Width) &&
+                overlap.Height >= Math.Min(minimumVisibleHeight, titleBar.Height))
             {
                 return true;
             }


### PR DESCRIPTION
Twenty commits taking EncodingChecker to v3.11.0. Two independent reviews of
v3.10.1 found thirty-five defects between them, overlapping on only two, and
neither found the other's most severe. Everything raised is either fixed here or
explicitly closed.

## The headline

Applying a saved plan converted a file the plan had recorded as `Refuse`. Measured
on a UTF-8 file with `-From windows-1252`, which a direct run refuses because the
explicit source contradicts a proven Unicode reading:

```
-Plan   ->  Action = Refuse, ReasonCode = ExplicitSourceConflictsWithDetection
-Apply  ->  1 converted, exit 0

before  63 61 66 c3a9 ...        café naïve — déjà vu
after   63 61 66 c383 c2a9 ...   cafÃ© naÃ¯ve â€" dÃ©jÃ  vu
```

The output is valid UTF-8 holding characters nobody wrote, so content verification
cannot catch it: both sides decode through the same wrong codec. `PlannedFile`
carried the detected codec but not `HasReliableUnicodeDetection`, which is a policy
input rather than provenance, so the veto had nothing to fire on at apply time.

Two defences now, because either alone hides the loss of the other: the plan
records the input, and a reviewed decision is a ceiling — re-deciding may refuse
more than the review did, never less.

## Compatibility breaks

Six change an exit code; the seventh changes what a journal can contain.

- Plan schema 4 to 5, semantics 5 to 6. Plans from v3.10.1 or earlier are refused
  and must be regenerated — they record decisions this build cannot reproduce.
- `-Validate` reports an unprovable BOM-less UTF-16 byte order as `Invalid`, so
  `-FailOnChanges` returns 2 where it returned 0.
- `-Plan` returns 3 when a selected file could not be read. It returned 0.
- A blank value for `-Plan`, `-Apply`, `-From`, `-Journal`, `-Report`, `-Include`,
  `-Exclude` or `-Validate` is rejected. `-Plan ""` previously performed a live
  conversion.
- `-Plan`, `-Journal` and `-Report` reject EC's reserved `.bak`, `.ecmeta.json` and
  `.unicodechecker.tmp` suffixes. `-Backup -Journal <source>.bak` previously
  converted the file, verified the backup, replaced that backup with JSON, and
  exited 0.
- Six documented-invalid option combinations are rejected instead of silently
  ignored.
- Journal readers must accept `ConvertedWithWarning`, `InstallationUnknown` and
  `NotAttempted`.

## Also fixed

Applying a plan followed a root that had become a junction, writing into a tree the
reviewer never saw. A second conversion destroyed the first backup and left a
sidecar positively describing it. `-DetectOnly` and `-Validate` reported a byte
order with full confidence that `-Target` refused seconds later. The review dialog
warned about the safer of two source choices and stayed silent for the riskier. A
plan holding one unreadable file could never be applied. The journal called a file
EC never opened a policy refusal, and a file it had already replaced untouched.
EC's own backups were skipped without being counted, so `-Include "*.bak"` returned
an empty, successful report.

Detector parity now runs on pull requests and gates the release, and covers
`TextValidation.cs`, which the audit records name as shared but no workflow
compared.

## Verified

633 tests pass, none skipped. Clean build, zero warnings. All changed files CRLF
with their existing BOM choice. `UnicodeDetector.cs` and `TextValidation.cs` are
identical across EncodingChecker, LineEndingNormalizer and CorpusTesters.

Each fix was mutation-checked in isolation: the change is reverted, the intended
test must fail, and the file is restored byte-identical. Controls are included so a
check that always refuses cannot pass for the wrong reason.

## Not verified

Stated plainly rather than left to be discovered.

- **The workflow changes have never run.** The parity logic is exercised locally
  against all three repositories in both directions and the YAML parses with the
  expected triggers, but `workflow_call` from the release job proves out only on a
  tag. This PR is the first test of the `pull_request` trigger.
- `OutputTextSha256` cannot be tested by value: verification has already proven the
  two digests equal, so a mutation copying the source digest back passes the whole
  suite. Confirmed rather than assumed. The fallback was replaced with a throw so a
  silent revert is impossible.
- Two GUI fixes have no test — one needs a real Ctrl+C inside a few instructions,
  the other a finalizer observation.
- Post-installation journal cases are asserted at the journal boundary, since both
  triggers need an I/O failure within a few instructions of `File.Replace`
  returning.

Still outstanding before release: manual GUI smoke test, the four-corpus audit, and
`tools/check_audit_integrity.py`. The corpus supplies each file's codec explicitly
on files that are not ambiguous, so it will likely not reach most of what changed
here — a `changed=0` result would establish that nothing was disturbed and nothing
about whether the fixes work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
