### PR TITLE
Refuse a build the smoke suite cannot drive, instead of blaming EC

### DIFF
--- a/docs/GUI-SMOKE-TEST.md
+++ b/docs/GUI-SMOKE-TEST.md
@@ -1,6 +1,6 @@
 # The GUI smoke test
 
-Nine phases that drive the built `EncodingChecker.exe` through Windows UI Automation
+Nine phases that drive a built `EncodingChecker.exe` through Windows UI Automation
 and check the bytes it leaves behind. Every phase creates its own disposable folder,
 performs a real sequence in the real window, and then verifies files — never status
 messages.
@@ -17,8 +17,8 @@ sources/EncodingChecker.GuiSmoke/bin/Release/net10.0-windows/EncodingChecker.Gui
 --keep-workspace      keep the fixtures even when the run passes
 ```
 
-Exit `0` when every phase passes, `1` when one fails, `2` for a usage or environment
-problem. Each run writes `gui-smoke-report.json` and `gui-smoke-report.md` carrying the
+Exit `0` when every phase passes, `1` when one fails, `2` for a usage, environment, or
+build-compatibility problem. Each run writes `gui-smoke-report.json` and `gui-smoke-report.md` carrying the
 EC version, the executable and managed-assembly SHA-256, the OS and .NET versions, and
 each phase's before and after file hashes.
 
@@ -87,6 +87,23 @@ could have gone red.
   layouts only, because it needs a real display change.
 - **The journal export dialog.** Phase I checks the status line and the bytes; the
   exported file's contents are reconciled by `InterruptedRunJournalTests` instead.
+
+## Which builds it can drive
+
+The driver finds the review dialog's controls by automation id, and those ids were
+added by the same change that added this suite. **No release up to and including
+v3.11.0 carries them**, so no published binary can be driven by it today; the first
+testable release is whatever ships next.
+
+A preflight check enforces this. It opens one review, looks for the five ids, and if
+none are present refuses with exit `2` and says so.
+
+This exists because the failure was worse than useless without it. Pointed at v3.11.0
+the suite ran every phase and reported, first line, that *the mixed review did not offer
+a source-encoding choice* — which reads as a conversion-safety regression in EC. The
+control was there; the suite could not see it. A harness that cannot tell "the control
+is absent" from "the behaviour is absent" reports the wrong defect, in the alarming
+direction, about the wrong component.
 
 ## Requirements
 

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -61,9 +61,10 @@ before and after file hashes.
 
 **[What each of the nine phases proves, and what it would catch →](GUI-SMOKE-TEST.md)**
 
-An interactive Windows desktop is required; the runner exits 2 rather than reporting a
-pass it did not earn. Whether a GitHub-hosted runner provides one is not yet
-established, so run this locally before tagging.
+Two prerequisites, each refused with exit 2 rather than reported as a pass: an
+interactive Windows desktop, and a build carrying the review dialog's automation ids
+— no release up to and including v3.11.0 has them. Whether a GitHub-hosted runner
+provides such a desktop is not yet established, so run this locally before tagging.
 
 Status messages are never evidence on their own. Every phase checks files, and phase I
 checks the status line *against* the bytes on disk rather than trusting it.

--- a/sources/EncodingChecker.GuiSmoke/Program.cs
+++ b/sources/EncodingChecker.GuiSmoke/Program.cs
@@ -61,6 +61,11 @@ internal static class Program
             Console.WriteLine($"Evidence: {options.Output}");
             return report.Passed ? 0 : 1;
         }
+        catch (IncompatibleBuildException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 2;
+        }
         catch (ArgumentException ex)
         {
             Console.Error.WriteLine(ex.Message);

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -5,6 +5,12 @@ using System.Text.Json;
 
 namespace EncodingChecker.GuiSmoke;
 
+/// <summary>
+/// The build under test predates the review dialog's automation ids, so the suite
+/// cannot drive it at all.
+/// </summary>
+internal sealed class IncompatibleBuildException(string message) : Exception(message);
+
 internal sealed record SmokePhaseResult(
     string Id,
     string Name,
@@ -49,6 +55,8 @@ internal sealed class SmokeSuite
     internal SmokeReport Run(string? onlyPhase = null)
     {
         string started = DateTime.UtcNow.ToString("O");
+
+        Preflight();
 
         RunIf("A", "Review cancellation changes nothing", PhaseA);
         RunIf("B", "Unicode and ASCII convert automatically", PhaseB);
@@ -107,6 +115,44 @@ internal sealed class SmokeSuite
 
         if (!passed)
             Console.Error.WriteLine(error);
+    }
+
+    /// <summary>Ids the review dialog has carried since they were introduced.</summary>
+    private static readonly string[] ReviewAutomationIds =
+    [
+        "btnProceedConversion",
+        "btnCancelConversionReview",
+        "btnConfirmSourceEncoding",
+        "lstSourceEncoding",
+        "lstRefusedFiles",
+    ];
+
+    /// <summary>
+    /// Refuses a build whose review dialog has no automation ids. Without this the
+    /// phases still run, and report the absence as a finding about EC: phase A says the
+    /// review offered no source-encoding choice, which reads as a conversion-safety
+    /// regression rather than a suite that cannot see the control. All five ids arrived
+    /// in one commit, so any one of them present means the build is drivable.
+    /// </summary>
+    private void Preflight()
+    {
+        string directory = Path.Combine(_workspace, "preflight");
+        Directory.CreateDirectory(directory);
+        Write(directory, "french.txt", "Prix: 100€ pour le café", CodePage("windows-1252"));
+
+        using var gui = new EcGuiDriver(_app);
+        System.Windows.Automation.AutomationElement review = gui.OpenReview(directory, 1);
+
+        if (!ReviewAutomationIds.Any(id => gui.ReviewContainsControl(review, id)))
+        {
+            throw new IncompatibleBuildException(
+                $"{_app} predates the review dialog's automation ids, so the suite "
+                + "cannot drive it. Run against a build that contains them; every "
+                + "release up to and including v3.11.0 does not.");
+        }
+
+        gui.CancelReview(review);
+        Directory.Delete(directory, recursive: true);
     }
 
     private void PhaseA(PhaseContext phase)


### PR DESCRIPTION
The review dialog's controls carry automation ids only from the commit that
added the smoke suite. Pointed at any earlier build — which is every published
release, v3.11.0 included — the driver cannot see them.

Without a check it ran all nine phases anyway and failed them. The first line
of output was:

```
[FAIL] A: Review cancellation changes nothing
System.InvalidOperationException: The mixed review did not offer a source-encoding choice.
```

That is a claim about conversion safety. The control was there; the suite
could not see it. Eight control-not-found timeouts followed and buried the one
fact that mattered. A harness that cannot distinguish an absent control from
absent behaviour reports the wrong defect, in the alarming direction, about
the wrong component — and this one reports it against the part of EC whose
whole job is refusing to convert without asking.

## The check

`Preflight()` opens one review, looks for the five ids, and refuses with exit
`2` if none are present. Any single id is enough: they arrived in one commit,
so this cannot misfire on a build that merely renames a control.

`Program` catches it and prints the message alone rather than a stack trace,
matching the existing interactive-desktop guard.

## Verified both ways

A guard that has only been seen to stay quiet has not been shown to work.

- Against the published v3.11.0 exe (SHA-256 of the archive matches GitHub's
  digest `b7fd266b…`): exit `2`, one line, no phases run.
- Against the current build: all nine phases pass, exit `0`. The check does
  not fire on a build it can drive.

634 unit tests pass, solution builds warning-free.

## Docs

`GUI-SMOKE-TEST.md` gains a section stating which builds can be driven, and
records why the guard exists. The old wording — "drives the built
`EncodingChecker.exe`" — is what invited pointing it at a release archive in
the first place; it now says a built executable and names the prerequisite.

`RELEASE-CHECKLIST.md` names both prerequisites together, each refused with
exit 2 rather than reported as a pass.

## Note

No published release can be driven by this suite. The first testable one is
whatever ships next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
