### PR TITLE
v3.11.1: keep recovery files readable, and correct what the About box claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.11.0
+# EncodingChecker v3.11.1
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 

--- a/docs/GUI-SMOKE-TEST.md
+++ b/docs/GUI-SMOKE-TEST.md
@@ -92,8 +92,8 @@ could have gone red.
 
 The driver finds the review dialog's controls by automation id, and those ids were
 added by the same change that added this suite. **No release up to and including
-v3.11.0 carries them**, so no published binary can be driven by it today; the first
-testable release is whatever ships next.
+v3.11.0 carries them**, so none of those can be driven by it. **v3.11.1 is the first
+release the suite can run against.**
 
 A preflight check enforces this. It opens one review, looks for the five ids, and if
 none are present refuses with exit `2` and says so.

--- a/docs/RELEASE-NOTES-v3.11.1.md
+++ b/docs/RELEASE-NOTES-v3.11.1.md
@@ -1,0 +1,41 @@
+# EncodingChecker v3.11.1
+
+A readability fix for the three files EC writes to be read by a person, plus a
+guard on the GUI smoke test.
+
+## Recovery files keep their names
+
+The conversion journal, the saved plan, and the recovery sidecar all used the
+default JSON encoder, which escapes every non-ASCII character. A recovery
+record for a Japanese or Arabic filename spelled it as a run of `\uXXXX`, and an
+ordinary apostrophe came out as `\u0027`.
+
+The text those files could not spell is exactly the text EC exists to convert,
+and they are what you read when a run has gone wrong. They now write the
+characters themselves:
+
+```json
+"RelativePath": "it's-a-file.txt",
+"RelativePath": "ملف-عربي.txt",
+"RelativePath": "日本語のファイル.txt",
+```
+
+Nothing about the format changes. The JSON was always valid and always
+round-tripped, which is why no test caught it; the schema versions are
+unchanged and files written by v3.11.0 are still read normally. Backslashes in
+Windows paths are still escaped, because JSON requires that.
+
+## The GUI smoke test refuses a build it cannot drive
+
+The suite drives the review dialog by automation id. Pointed at a build without
+those ids it ran every phase anyway and reported, first line, that the review
+had offered no source-encoding choice — a claim about conversion safety, when
+the real cause was a control it could not see.
+
+It now checks once, up front, and exits 2 saying so. **v3.11.1 is the first
+release the suite can run against**; no earlier one carries the ids.
+
+## Compatibility
+
+No conversion or classification behaviour changes. Conversion semantics stay at
+6, the plan schema at 5, and the journal schema at 4. Exit codes are unchanged.

--- a/docs/RELEASE-NOTES-v3.11.1.md
+++ b/docs/RELEASE-NOTES-v3.11.1.md
@@ -1,7 +1,7 @@
 # EncodingChecker v3.11.1
 
-A readability fix for the three files EC writes to be read by a person, plus a
-guard on the GUI smoke test.
+A readability fix for the three files EC writes to be read by a person, a guard on
+the GUI smoke test, and corrections to what the About box claims.
 
 ## Recovery files keep their names
 
@@ -34,6 +34,28 @@ the real cause was a control it could not see.
 
 It now checks once, up front, and exits 2 saying so. **v3.11.1 is the first
 release the suite can run against**; no earlier one carries the ids.
+
+## About box and attribution
+
+Four statements in the About box or the assembly were wrong or out of date.
+
+- **The licence.** It said Mozilla Public License **1.1**. The project ships
+  **2.0** — that is what `LICENSE` contains, what the README links, and what the
+  label's own click target already opened. Only the words a reader saw were wrong.
+- **The detector credit.** It named `ude` while linking to UtfUnknown, the
+  library actually in use. It now names UtfUnknown.
+- **The CodePlex link.** It pointed at `encodingchecker.codeplex.com`, which no
+  longer resolves — CodePlex shut down. It now points at the archive, as the
+  README does.
+- **Attribution.** `AssemblyCompany` names the current maintainer, and the About
+  box records both the original author and the maintainer. The copyright notice
+  adds the maintainer beside the original author rather than replacing him; MPL
+  2.0 section 3.4 forbids removing a copyright notice from covered source, and
+  permits altering a notice only to remedy a factual inaccuracy, which is what
+  the licence-version fix above is.
+
+`THIRD-PARTY-NOTICES.txt` still says MPL 1.1 and is correct: that describes
+UtfUnknown's own licence, not this project's.
 
 ## Compatibility
 

--- a/sources/EncodingChecker.Tests/ConversionJournalTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionJournalTests.cs
@@ -85,6 +85,29 @@ public sealed class ConversionJournalTests : IDisposable
         ]);
 
     [Fact]
+    public void TheJournalKeepsNonAsciiNamesAndApostrophesReadable()
+    {
+        Write("日本語のファイル.txt", "こんにちは世界。", "utf-8");
+        Write("ملف-عربي.txt", "مرحبا بالعالم", "utf-8");
+        Write("it's-a-file.txt", "plain ascii", "utf-8");
+
+        Assert.Equal(0, Convert("-From", "utf-8"));
+
+    // These files are read by a person recovering from a bad run, so the names have to
+    // survive as names. The default encoder escapes every non-ASCII character and the
+    // apostrophe too, turning the text EC exists to convert into \uXXXX.
+    //
+    // The assertion is on the raw bytes on disk, not on a deserialized value: the round
+    // trip succeeds either way, so only the file itself shows whether it is readable.
+        string json = File.ReadAllText(JournalPath);
+
+        Assert.Contains("日本語のファイル.txt", json, StringComparison.Ordinal);
+        Assert.Contains("ملف-عربي.txt", json, StringComparison.Ordinal);
+        Assert.Contains("it's-a-file.txt", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("\\u", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ItRecordsWhatWasBelievedDecidedAndWritten()
     {
         const string text = "こんにちは世界。日本語のテキストです。";

--- a/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionMetadataTests.cs
@@ -59,6 +59,24 @@ public sealed class ConversionMetadataTests : IDisposable
     }
 
     [Fact]
+    public void TheSidecarKeepsNonAsciiNamesAndApostrophesReadable()
+    {
+        string path = Convert(
+            "عربي-l'été.txt", "café — naïve", "windows-1252", "utf-8");
+
+    // These files are read by a person recovering from a bad run, so the names have to
+    // survive as names. The default encoder escapes every non-ASCII character and the
+    // apostrophe too, turning the text EC exists to convert into \uXXXX.
+    //
+    // The assertion is on the raw bytes on disk, not on a deserialized value: the round
+    // trip succeeds either way, so only the file itself shows whether it is readable.
+        string json = File.ReadAllText(ConversionMetadataStore.MetadataPathFor(path));
+
+        Assert.Contains("عربي-l'été.txt", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("\\u", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AConversionWithBackupWritesASidecarDescribingIt()
     {
         string path = Convert("described.txt", "café — naïve", "windows-1252", "utf-8");

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -120,6 +120,26 @@ public sealed class ConversionPlanTests : IDisposable
     }
 
     [Fact]
+    public void ThePlanKeepsNonAsciiNamesAndApostrophesReadable()
+    {
+        Write("日本語のファイル.txt", "こんにちは世界。", "shift_jis");
+        Write("ملف-عربي.txt", "مرحبا بالعالم", "utf-8");
+        Write("it's-a-file.txt", "plain ascii", "us-ascii");
+
+        Assert.Equal(0, Plan("-From", "shift_jis"));
+
+    // A plan is reviewed before it is applied, which is impossible if the paths in it
+    // are \uXXXX. Asserted on the file's own bytes, since deserializing hides the
+    // difference.
+        string json = File.ReadAllText(PlanPath);
+
+        Assert.Contains("日本語のファイル.txt", json, StringComparison.Ordinal);
+        Assert.Contains("ملف-عربي.txt", json, StringComparison.Ordinal);
+        Assert.Contains("it's-a-file.txt", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("\\u", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PlanningWritesNothing()
     {
         // The one thing a dry run must never do.

--- a/sources/EncodingChecker/AboutForm.Designer.cs
+++ b/sources/EncodingChecker/AboutForm.Designer.cs
@@ -127,13 +127,13 @@ partial class AboutForm
         // lblCreditsUde
         // 
         this.lblCreditsUde.AutoSize = true;
-        this.lblCreditsUde.LinkArea = new System.Windows.Forms.LinkArea(0, 3);
+        this.lblCreditsUde.LinkArea = new System.Windows.Forms.LinkArea(0, 10);
         this.lblCreditsUde.Location = new System.Drawing.Point(25, 148);
         this.lblCreditsUde.Name = "lblCreditsUde";
         this.lblCreditsUde.Size = new System.Drawing.Size(265, 18);
         this.lblCreditsUde.TabIndex = 6;
         this.lblCreditsUde.TabStop = true;
-        this.lblCreditsUde.Text = "ude, a C# port of Mozilla Universal Charset Detector";
+        this.lblCreditsUde.Text = "UtfUnknown, a C# port of uchardet";
         this.lblCreditsUde.UseCompatibleTextRendering = true;
         this.lblCreditsUde.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
         // 

--- a/sources/EncodingChecker/AboutForm.Designer.cs
+++ b/sources/EncodingChecker/AboutForm.Designer.cs
@@ -120,7 +120,7 @@ partial class AboutForm
         this.lblLicense.Size = new System.Drawing.Size(229, 18);
         this.lblLicense.TabIndex = 4;
         this.lblLicense.TabStop = true;
-        this.lblLicense.Text = "Licensed under the Mozilla Public License 1.1";
+        this.lblLicense.Text = "Licensed under the Mozilla Public License 2.0";
         this.lblLicense.UseCompatibleTextRendering = true;
         this.lblLicense.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
         // 

--- a/sources/EncodingChecker/AboutForm.Designer.cs
+++ b/sources/EncodingChecker/AboutForm.Designer.cs
@@ -107,7 +107,7 @@ partial class AboutForm
         this.lblAuthor.Size = new System.Drawing.Size(131, 18);
         this.lblAuthor.TabIndex = 3;
         this.lblAuthor.TabStop = true;
-        this.lblAuthor.Text = "Created by Jeevan James";
+        this.lblAuthor.Text = "Created by Jeevan James · Maintained by Amr Ali";
         this.lblAuthor.UseCompatibleTextRendering = true;
         this.lblAuthor.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.OnLinkClicked);
         // 

--- a/sources/EncodingChecker/AboutForm.cs
+++ b/sources/EncodingChecker/AboutForm.cs
@@ -22,7 +22,7 @@ public partial class AboutForm : Form
         lblAuthor.Links[0].LinkData = "https://github.com/JeevanJames";
         lblLicense.Links[0].LinkData = "https://www.mozilla.org/en-US/MPL/2.0/";
         lblCreditsUde.Links[0].LinkData = "https://github.com/CharsetDetector/UTF-unknown";
-        lblCreditsCodePlex.Links[0].LinkData = "http://encodingchecker.codeplex.com";
+        lblCreditsCodePlex.Links[0].LinkData = "https://archive.codeplex.com/?p=encodingchecker";
     }
 
     private void OnLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)

--- a/sources/EncodingChecker/ConversionJournal.cs
+++ b/sources/EncodingChecker/ConversionJournal.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -168,9 +169,14 @@ internal sealed record ConversionJournal
             .OrderBy(group => group.Key, StringComparer.Ordinal)
             .ToDictionary(group => group.Key, group => group.Count());
 
+    // These files exist to be read by a person recovering from a bad run. The
+    // default encoder escapes every non-ASCII character, which turns the text EC
+    // exists to handle into \uXXXX. Relaxed escaping is safe here because none of
+    // this JSON is ever embedded in HTML.
     private static readonly JsonSerializerOptions Options = new()
     {
         WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 
     /// <summary>Builds a journal from the results of one run.</summary>

--- a/sources/EncodingChecker/ConversionMetadata.cs
+++ b/sources/EncodingChecker/ConversionMetadata.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -142,9 +143,14 @@ internal static class ConversionMetadataStore
 {
     internal const string Suffix = ".ecmeta.json";
 
+    // These files exist to be read by a person recovering from a bad run. The
+    // default encoder escapes every non-ASCII character, which turns the text EC
+    // exists to handle into \uXXXX. Relaxed escaping is safe here because none of
+    // this JSON is ever embedded in HTML.
     private static readonly JsonSerializerOptions Options = new()
     {
         WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 
     internal static string MetadataPathFor(string filePath) => filePath + Suffix;

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -171,9 +172,14 @@ internal sealed record ConversionPlan
 
     internal ConversionPlanSummary Summary => ConversionPlanSummary.From(Files);
 
+    // These files exist to be read by a person recovering from a bad run. The
+    // default encoder escapes every non-ASCII character, which turns the text EC
+    // exists to handle into \uXXXX. Relaxed escaping is safe here because none of
+    // this JSON is ever embedded in HTML.
     private static readonly JsonSerializerOptions Options = new()
     {
         WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 
     internal static ConversionPlan FromEntries(

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -17,9 +17,9 @@ using System.Runtime.Versioning;
 [assembly: AssemblyTitle("File Encoding Checker")]
 [assembly: AssemblyDescription("GUI tool to check the encoding of a text file")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jeevan James")]
+[assembly: AssemblyCompany("Amr Ali")]
 [assembly: AssemblyProduct("File Encoding Checker")]
-[assembly: AssemblyCopyright("Copyright © Jeevan James 2020")]
+[assembly: AssemblyCopyright("Copyright © Jeevan James 2020, Amr Ali 2026")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.11.0.0")]
-[assembly: AssemblyFileVersion("3.11.0.0")]
+[assembly: AssemblyVersion("3.11.1.0")]
+[assembly: AssemblyFileVersion("3.11.1.0")]


### PR DESCRIPTION
v3.11.1. Three of the files EC writes for a person to read could not spell the
text EC exists to convert, and the About box made four claims that were wrong or
out of date.

## Recovery files keep their names

The journal, the saved plan, and the recovery sidecar all used the default JSON
encoder, which escapes every non-ASCII character and the apostrophe. A recovery
record for a Japanese or Arabic filename spelled it as a run of `\uXXXX`.

These are what you read when a run has gone wrong, so:

```json
"RelativePath": "it's-a-file.txt",
"RelativePath": "ملف-عربي.txt",
"RelativePath": "日本語のファイル.txt",
```

That is a real journal from the built exe, not a fixture: 0 escape sequences,
15 non-ASCII characters written literally. Backslashes in Windows paths are
still escaped, because JSON requires it.

`UnsafeRelaxedJsonEscaping` rather than `JavaScriptEncoder.Create(UnicodeRanges.All)`,
which still escapes the apostrophe. "Unsafe" refers to embedding JSON in HTML;
EC emits no HTML anywhere, checked before choosing.

**Why no test caught it.** The JSON was always valid and always round-tripped.
The three new tests assert on the file's raw text rather than a deserialized
value, because deserializing hides the difference — each covers CJK, Arabic, and
an apostrophe in a real filename. Mutation-checked: with the encoder line
removed all three fail, and the files were restored byte-identical.

## About box and attribution

- **Licence.** It said Mozilla Public License **1.1**. The project ships **2.0** —
  what `LICENSE` contains, what the README links, and what the label's own click
  target already opened. Only the words a reader saw were wrong.
- **Detector credit.** Named `ude` while linking UtfUnknown, the library actually
  in use. Now names UtfUnknown.
- **CodePlex link.** Pointed at a domain that stopped resolving when CodePlex
  shut down; now the archive, as the README uses.
- **Attribution.** `AssemblyCompany` names the current maintainer, and the About
  box records both author and maintainer. The copyright notice **adds** the
  maintainer beside the original author rather than replacing him: MPL 2.0 §3.4
  forbids removing a copyright notice from covered source, and permits altering
  one only to remedy a factual inaccuracy — which is what the licence fix is.

`THIRD-PARTY-NOTICES.txt` still says MPL 1.1 and is correct: that is UtfUnknown's
licence, not this project's.

Each of these is a `LinkLabel` whose clickable span is a character range, not a
word match, so text and span move together. `ude` to `UtfUnknown` needed
`LinkArea(0, 3)` to become `(0, 10)`; the others were unaffected because the
replacements were the same length or appended after the linked text.

## Compatibility

No conversion or classification behaviour changes. Conversion semantics stay at
6, the plan schema at 5, the journal schema at 4, exit codes unchanged, and
v3.11.0 artifacts still load.

## Verification

- 637 tests pass, 0 skipped, no test declared with a `Skip` attribute
- Release build, 0 warnings
- Nine-phase GUI smoke suite passes against this build, `EcVersion 3.11.1.0`
  recorded in the evidence; phase I converted 36 of 400 before the cancel, so
  the interrupted path was genuinely exercised
- `--version` and `--help` both report 3.11.1; assembly metadata verified from
  the built DLL rather than the source

The four-corpus audit was not run: by the checklist's own rule it is required
for a release changing detection or conversion policy, and this changes neither.

**v3.11.1 is the first release the GUI smoke suite can drive** — no earlier one
carries the automation ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
