### PR TITLE
Make the release workflow rehearsable without publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+  # A rehearsal. Runs every step a real release runs except the publish, so a
+  # change to this file can be proven before a tag depends on it.
+  workflow_dispatch:
+
 permissions:
   contents: write
 
@@ -29,7 +33,39 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      # One step decides what version this run is for, so nothing later has to
+      # reason about whether a tag exists.
+      - name: Resolve the version under test
+        id: version
+        shell: pwsh
+        run: |
+          $isTag = "${{ github.ref }}".StartsWith("refs/tags/")
+
+          if ($isTag) {
+            $resolved = "${{ github.ref_name }}" -replace '^v', ''
+          }
+          else {
+            $assemblyInfo =
+              Get-Content "sources\EncodingChecker\Properties\AssemblyInfo.cs" -Raw
+            $pattern = '(?m)^\s*\[assembly:\s*AssemblyVersion\("(?<version>[^"]+)"\)\]'
+            $match = [regex]::Match($assemblyInfo, $pattern)
+
+            if (-not $match.Success) {
+              throw "Could not find [AssemblyVersion] in AssemblyInfo.cs."
+            }
+
+            $parsed = [Version]$match.Groups['version'].Value
+            $resolved = "$($parsed.Major).$($parsed.Minor).$([Math]::Max($parsed.Build, 0))"
+          }
+
+          "version=$resolved" >> $env:GITHUB_OUTPUT
+          "is_tag=$($isTag.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+          "version=$resolved  is_tag=$isTag"
+
+      # Exists only to catch a tag that disagrees with the source, so it has
+      # nothing to check when there is no tag.
       - name: Verify release version
+        if: steps.version.outputs.is_tag == 'true'
         shell: pwsh
         run: |
           $tagVersion = "${{ github.ref_name }}" -replace '^v', ''
@@ -60,7 +96,7 @@ jobs:
       - name: Verify built display version
         shell: pwsh
         run: |
-          $expected = "${{ github.ref_name }}" -replace '^v', ''
+          $expected = "${{ steps.version.outputs.version }}"
           $actual = (& dotnet "sources\EncodingChecker\bin\Release\net10.0-windows\EncodingChecker.dll" --version).Trim()
 
           if ($LASTEXITCODE -ne 0) {
@@ -133,11 +169,15 @@ jobs:
       - name: Package
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}" -replace '^v', ''
+          $version = "${{ steps.version.outputs.version }}"
           Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64\*" -DestinationPath "EncodingChecker-$version-framework-dependent.zip"
           Compress-Archive -Path "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64-selfcontained\*" -DestinationPath "EncodingChecker-$version-win-x64-self-contained.zip"
 
+      # The publish, and the only step a rehearsal must never reach. It requires a
+      # tag *push*, not merely a tag ref: workflow_dispatch can be pointed at a tag
+      # from the dropdown, and a run started by hand must never publish.
       - name: Create GitHub release
+        if: github.event_name == 'push' && steps.version.outputs.is_tag == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
@@ -145,3 +185,14 @@ jobs:
           EncodingChecker-*-framework-dependent.zip EncodingChecker-*-win-x64-self-contained.zip
           --title "${{ github.ref_name }}"
           --generate-notes
+
+      - name: Say plainly that nothing was published
+        if: github.event_name != 'push'
+        shell: pwsh
+        run: |
+          $summary = "REHEARSAL for version ${{ steps.version.outputs.version }} - " +
+                     "built, tested, signed, GUI-checked and packaged. No release was created."
+          $summary
+          "## Release rehearsal" >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          $summary >> $env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Every run of `release.yml` in this repository's history has been a real
release. The only trigger was a tag push, and the final step publishes:

```
ref=v3.11.1  event=push -> success      ref=v3.10.0  event=push -> success
ref=v3.11.0  event=push -> success      ref=v3.9.2   event=push -> success
ref=v3.10.1  event=push -> success      ref=v3.9.1   event=push -> success
```

Six runs, six publishes, no dry run ever. That means the nine-phase GUI gate
added in #74 — and every future edit to this file — would first execute during
a release somebody actually wanted to ship. The failure direction is safe (it
blocks publication rather than shipping a bad build), but the timing is the
worst available.

## What changes

`workflow_dispatch` runs the same job without publishing. Build, test, publish,
code-sign, all nine GUI phases and packaging happen exactly as they do for a
release. Only `gh release create` is skipped.

## A dispatch cannot publish, structurally

This is the part worth reviewing closely. `workflow_dispatch` lets the operator
choose any ref from a dropdown, **including a tag**. Gating the publish on "is
this a tag ref?" alone would mean a hand-started run against a tag publishes for
real. So the publish requires a tag *push*:

```yaml
if: github.event_name == 'push' && steps.version.outputs.is_tag == 'true'
```

| how it starts | publishes |
|---|---|
| tag push (a real release) | **yes** |
| dispatch on `master` | no |
| dispatch pointed at a tag | **no** |

## Real releases are unaffected

One new step resolves the version — from the tag when there is one, from
`AssemblyInfo.cs` otherwise — so no later step has to reason about whether a tag
exists. On a tag push it yields `3.11.2` from `v3.11.2`, which is exactly what
`Verify built display version` and `Package` computed inline before. The two
call sites now read that one value instead of re-deriving it.

`Verify release version` is gated to tags because its entire purpose is catching
a tag that disagrees with the source; there is nothing for it to check without
one.

## It fails safe

If the resolve step ever breaks, its outputs are empty, the publish condition
evaluates false, and nothing is released.

## It says what it did

A rehearsal writes `No release was created` into its own job summary, so a green
run can never be misread as a publish.

## Verification plan after merge

`workflow_dispatch` only becomes available once the file is on the default
branch, so this cannot be exercised from the branch. After merging: dispatch one
rehearsal on `master` and confirm the release list is unchanged against the 19
releases recorded before this work started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
