### PR TITLE
Refuse BOM-less UTF-32 that detection cannot establish, and release v3.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.12.1
+# EncodingChecker v3.13.0
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -79,6 +79,11 @@ byte order. If both UTF-16LE and UTF-16BE strictly decode the complete file,
 EC refuses the automatic conversion. Choose `-From utf-16le` or
 `-From utf-16be` if you know the original order.
 
+BOM-less UTF-32 is never converted automatically, and is reported with reason
+code `UnprovableBomlessUtf32`. The bytes cannot establish the codec: UTF-16 text
+with one character per line also decodes as valid UTF-32. Add a byte-order mark,
+or pass `-From utf-32` or `-From utf-32BE`.
+
 `-Apply` uses the decisions and hashes stored in the plan; it does not detect
 the files again. Only `-Journal`, `-Quiet`, and `-MaxParallelism` may accompany
 it. `-WhatIf`, `-Target`, `-From`, `-Backup`, and file-selection options are

--- a/docs/CONVERSION-WORKFLOW.md
+++ b/docs/CONVERSION-WORKFLOW.md
@@ -37,6 +37,14 @@ If both orders work, the file is reported as `Refused` with reason code
 `AmbiguousBomlessUtf16`; no preview says it would convert, and no backup, sidecar, or output
 file is created. Choose the source encoding explicitly if you know it.
 
+### BOM-less UTF-32
+
+Refused outright, with reason code `UnprovableBomlessUtf32`. Without a marker EC cannot
+establish that the file is UTF-32 at all: UTF-16 text with one character per line decodes
+as valid UTF-32 and would be rewritten as different text. Ordinary BOM-less UTF-32 is
+refused for the same reason, because nothing in the bytes tells the two apart. Add a BOM,
+or name the source.
+
 ## What EC does
 
 ```mermaid

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=61 fixed=44 open=13 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
+<!-- backlog-counts total=61 fixed=46 open=11 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
 
-**Derived count: 61 findings — 44 fixed, 13 open, 1 not reproduced,
+**Derived count: 61 findings — 46 fixed, 11 open, 1 not reproduced,
 1 withdrawn, 1 not a defect, and 1 design decision.** Recompute and validate
 these figures with:
 
@@ -57,9 +57,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-20 | Detection permits concurrent writes and deletes | Open | Low | Rare | [EC-20](#ec-20) |
 | EC-23 | Plan application relies on a null-forgiving path dereference | Open | Low | Rare | [EC-23](#ec-23) |
 | CX-06 | The entropy gate runs before BOM detection | Open | Medium | Occasional | [CX-06](#cx-06) |
-| BL-01 | Ambiguous BOM-less UTF-32 can be converted under the wrong byte order | Open | Critical | Theoretical | [BL-01](#bl-01) |
 | BL-05 | Force-closing during a run can race UI callbacks | Open | Low | Rare | [BL-05](#bl-05) |
-| BL-18 | BOM-less UTF-16 can be detected and converted as UTF-32 | Open | Critical | Rare | [BL-18](#bl-18) |
 | BL-19 | NUL-heavy ASCII can be reported as BOM-less UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
 | BL-20 | Hard-linked paths are processed independently | Open | Low | Rare | [BL-20](#bl-20) |
 | BL-21 | Detection can accept a truncated trailing sequence that conversion rejects | Open | Low | Rare | [BL-21](#bl-21) |
@@ -72,6 +70,8 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-02 | Read-only validation disagreed with the BOM-less Unicode safety policy | Fixed | — | — | [EC-02](#ec-02) |
 | EC-03 | The GUI omitted the source-choice advisory | Fixed | — | — | [EC-03](#ec-03) |
 | EC-04 | `-Plan` could exit successfully after scan failures | Fixed | — | — | [EC-04](#ec-04) |
+| BL-01 | Ambiguous BOM-less UTF-32 can be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
+| BL-18 | BOM-less UTF-16 can be detected and converted as UTF-32 | Fixed | — | — | [BL-18](#bl-18) |
 | EC-05 | An unreadable non-conversion plan entry made a plan unusable | Fixed | — | — | [EC-05](#ec-05) |
 | EC-06 | A drive-root base path made every plan unusable | Fixed | — | — | [EC-06](#ec-06) |
 | EC-07 | A refusal advised the same ambiguous encoding it rejected | Fixed | — | — | [EC-07](#ec-07) |
@@ -199,12 +199,20 @@ what EC reports; it is not evidence that conversion writes the file.
 
 ### BL-01
 
-**BOM-less UTF-32 byte order can be guessed and then treated as proven.** The
-ambiguity guard covers code pages 1200 and 1201, not 12000 and 12001. A current
-end-to-end fixture containing UTF-32BE `00 00 01 00` units was detected as
-little-endian UTF-32 and converted from U+0100 to U+10000 with exit 0. Reaching
-the case requires every scalar to have the special byte shape, so ordinary text
-is unlikely to do it; its consequence is nevertheless silent text change.
+**Fixed.** BOM-less UTF-32 is no longer converted automatically in any mode; it
+is refused with reason code `UnprovableBomlessUtf32`, and `-DetectOnly` and
+`-Validate` report the same code. `ConversionSemantics` moved from 6 to 7,
+because a plan approved under the previous behaviour may list files this build
+refuses.
+
+Was: the ambiguity guard covered code pages 1200 and 1201, not 12000 and 12001.
+A fixture of UTF-32BE `00 00 01 00` units was detected as little-endian and
+converted from U+0100 to U+10000 with exit 0.
+
+Widening the opposite-order test would not have been enough on its own — see
+[BL-18](#bl-18), whose bytes are *invalid* under the opposite UTF-32 order. Both
+are closed by refusing BOM-less UTF-32 outright, at the cost of refusing
+ordinary BOM-less UTF-32 as well; nothing in the bytes separates the two.
 
 ### BL-05
 
@@ -218,15 +226,25 @@ content. The timing-dependent path was source-confirmed but not reproduced.
 
 ### BL-18
 
-**A degenerate BOM-less UTF-16 stream can look like UTF-32.** A current fixture
-containing UTF-16LE `00 01 0A 00` units was detected as BOM-less UTF-32 and
-rewritten to different Unicode with exit 0. Output verification cannot expose a
-wrong source interpretation because both sides use that same interpretation.
+**Fixed** by the same rule as [BL-01](#bl-01): BOM-less UTF-32 is refused
+rather than converted, so a UTF-16 file that happens to decode as UTF-32 is left
+alone instead of rewritten as different text.
 
-The original measurement used nineteen realistic shapes: 41 of 44 detections
-were right, and all three misses had the same constructed shape—one character
-per line, with every other UTF-16 code unit a C0 control. The reach is low; the
-impact when reached is silent text change.
+Was: a BOM-less UTF-16 file with one character per LF-terminated line puts a C0
+control in every second code unit, so each four-byte group is an in-range
+unassigned scalar and the file decodes as valid UTF-32. Converting it wrote
+different text, and output verification could not notice, because both sides of
+its comparison used the same wrong codec.
+
+This is the case an opposite-order test cannot catch: those bytes are *invalid*
+as UTF-32BE, so the check that protects BOM-less UTF-16 returns false. What the
+bytes fail to establish is the codec, not merely its byte order — which is why
+the fix refuses on the absence of a BOM rather than on ambiguity.
+
+No scalar classification changed. Private-use characters are what icon fonts put
+in ordinary text files, so rejecting unassigned or private-use scalars would have
+broken real sources; a test converts U+E000, U+F8FF, U+E0B0, U+F00C and U+F0000
+and checks all five survive.
 
 ### BL-19
 

--- a/docs/DETECTION.md
+++ b/docs/DETECTION.md
@@ -26,11 +26,15 @@ that a destructive conversion should proceed.
 - BOM-less UTF-16 is converted automatically only when the complete file is
   invalid under the opposite byte order. Otherwise EC reports
   `AmbiguousBomlessUtf16` and leaves it unchanged.
+- BOM-less UTF-32 is never converted automatically. EC reports
+  `UnprovableBomlessUtf32` and leaves it unchanged. An opposite-order test
+  cannot rescue it: UTF-16 text with one character per line decodes as valid
+  UTF-32, so what the bytes fail to establish is the codec, not just its order.
 - Detected legacy text requires an explicit source choice before EC rewrites it.
 - Unknown input is skipped and left unchanged.
 
 Use `-From <encoding>` or the GUI source selector when you know a legacy or
-BOM-less UTF-16 source. This selects how EC reads the bytes; it does not turn
+BOM-less Unicode source. This selects how EC reads the bytes; it does not turn
 off strict decoding, output verification, backup verification, or safe install.
 
 ## Supported text

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -20,6 +20,8 @@ cannot answer.
       and line-ending differences.
 - [ ] Ambiguous BOM-less UTF-16 is refused without changing bytes or creating a backup.
 - [ ] Structurally provable BOM-less UTF-16 still converts correctly.
+- [ ] BOM-less UTF-32 is refused in every mode, with `UnprovableBomlessUtf32`, and
+      converts when given a BOM or an explicit source.
 - [ ] Explicit source selection still receives strict decoding and output verification.
 - [ ] A stale reviewed plan leaves every selected source unchanged.
 - [ ] Backup and recovery-sidecar hashes match the source bytes used for conversion.

--- a/docs/RELEASE-NOTES-v3.13.0.md
+++ b/docs/RELEASE-NOTES-v3.13.0.md
@@ -1,0 +1,154 @@
+# EncodingChecker v3.13.0
+
+Two silent-corruption paths closed by one rule: BOM-less UTF-32 is no longer converted on
+detection alone. This is the first release since v3.12.0 that changes conversion policy, the first in
+this line to advance the conversion semantics version, and the first since v3.11.0
+measured against the four corpora.
+
+## BOM-less UTF-32 is refused rather than guessed
+
+Two findings, one cause.
+
+**A BOM-less UTF-16 file could be converted as UTF-32.** Text with one character per
+LF-terminated line puts a C0 control in every second code unit, so each four-byte group is
+an in-range unassigned scalar and the whole file decodes as valid UTF-32. EC converted it
+and wrote **different text** — U+0041 U+000A became U+A0041 — with exit 0 and no warning.
+Output verification could not notice, because it decodes the source with the codec EC
+chose and the output with the target codec, so both sides of its comparison used the same
+wrong codec.
+
+**Genuine BOM-less UTF-32 could be valid under both byte orders.** Bytes whose scalars are
+all multiples of 0x100 read equally well either way, and detection preferred little-endian
+without saying so.
+
+The rule that closes both: **without a byte-order mark, EC does not accept UTF-32 on
+detection alone.** It reports `Refused` with reason code `UnprovableBomlessUtf32` and
+leaves the bytes alone, in every mode.
+
+**Why the existing UTF-16 guard could not be widened to cover it.** That guard refuses
+BOM-less UTF-16 when the *opposite* byte order also decodes the file. The UTF-16 file
+above is **invalid** as UTF-32BE, so the same test returns false and would have passed it
+straight through. What the bytes fail to establish is the codec, not merely its byte
+order — so the refusal rests on the absence of a BOM, not on ambiguity.
+
+## The cost
+
+**Ordinary BOM-less UTF-32 is refused too**, even when its content is unremarkable.
+Nothing in the bytes separates it from the UTF-16 file above, so there is no test that
+admits one and rejects the other. Two rows moved out of the conversion matrix's
+valid-conversion set to say so.
+
+Two ways through, both unchanged and both tested: add a byte-order mark, or name the
+source with `-From utf-32` or `-From utf-32BE`. A BOM settles the codec, so UTF-32 with
+one still converts automatically.
+
+## What did not change
+
+**No scalar classification.** The misdetection is possible because the text heuristic
+accepts unassigned scalars, and the tempting fix is to reject unassigned or private-use
+ones. That would be wrong: private-use characters are what icon fonts put in ordinary text
+files, so it would break real sources. A test converts U+E000, U+F8FF, U+E0B0, U+F00C and
+U+F0000 and checks all five survive.
+
+`TextValidation.cs` and `UnicodeDetector.cs` are untouched. Both are held byte-identical
+across three repositories by the parity workflow, and a fix that needed to change them
+would have been a synchronised change in all three.
+
+## Compatibility
+
+**Conversion semantics move from 6 to 7. Plans written by v3.12.1 or earlier are
+refused.** Re-run `-Plan` and review the result. This is the point of the version: such a
+plan can list files this build will not convert, and applying it would extend approval
+given for one behaviour to another.
+
+The plan schema stays at **5** and the journal schema at **4**.
+
+| Situation | Before | After |
+|---|---|---|
+| BOM-less UTF-32, any mode | `utf-32`, converted, 0 | `Refused`, `UnprovableBomlessUtf32`, 5 |
+| BOM-less UTF-16 that decodes as UTF-32 | converted to different text, 0 | `Refused`, 5 |
+| A plan from v3.12.1 or earlier | applied | refused, 1 |
+
+`UnprovableBomlessUtf32` is a **new reason code**, separate from
+`AmbiguousBomlessUtf16` rather than reusing it: the doubt and the remedy differ, and a
+script filtering on the UTF-16 code would otherwise start matching a condition it was
+never written for.
+
+Everything else is unchanged — UTF-16 behaviour, legacy refusals, exit codes for every
+other outcome, and every other report column and journal field.
+
+## Verification
+
+- 751 tests pass, none skipped (was 746); release build with no warnings
+- Verified end to end against the built executable in Detect, Validate and Convert: the
+  same reason code in all three, refused sources byte-identical before and after, and all
+  five private-use scalars preserved through a conversion
+- Mutation-checked: removing the UTF-32 arm fails 3 of the 6 core tests, and the file
+  restores byte-identical by hash
+- The defect ledger records BL-01 and BL-18 as fixed with this evidence;
+  `docs/Test-DefectBacklog.ps1` passes at 46 fixed and 11 open
+- The four-corpus audit was run against this commit from a clean tree. Its results, and
+  the one thing it cannot establish, are below.
+
+## The four-corpus audit
+
+Run from a clean tree over UnicodeTestSuite v3.0, chardet `test-data`,
+charset-normalizer `char-dataset`, and the UTF.unknown 2.6 tests — 5,077 files. The exact
+commit and assembly hash are recorded in `docs/SAFETY-AUDIT.md`, which is written after
+this release is tagged: committing it changes the assembly through the PDB checksum, so a
+hash quoted here would describe a build this file is part of.
+
+Four metrics, reported separately because one number would hide which question failed:
+
+| | v3.11.0 | v3.13.0 |
+|---|---|---|
+| Detection accuracy | 4640/4646 (99.87%) | 4639/4645 (99.87%) |
+| Strict decoding | 4694/4694 (100.00%) | 4693/4693 (100.00%) |
+| Codec conformance | 4591/4694 (97.81%) | 4590/4693 (97.81%) |
+| Text preservation | 4520/4623 (97.77%) | 4519/4622 (97.77%) |
+
+Per corpus, and unchanged: **zero implementation defects, zero strict-decode throws, zero
+backup-integrity mismatches.** The comparison is joined per file rather than by totals.
+One file differs, and it is not a behaviour change: a UTF-8 fixture present when v3.11.0
+was audited is **absent from the local corpus copy now**, so it appears as `(absent)`
+rather than as a changed outcome. Every other file reached the same outcome as before.
+
+The remaining divergences are the long-standing ones, unrelated to this release: 145
+UTF-7 files EC has no codec for, and 103 legacy mapping differences dominated by
+`U+301C → U+FF5E` and `U+2212 → U+FF0D` in shift_jis and euc_jp.
+
+**Source corpora were not modified.** Each is copied into a working directory and only the
+copy is converted. Verified afterwards by re-hashing all 5,077 source files against the
+inventory captured before the run: zero modified, zero missing.
+
+### What this audit cannot establish
+
+**It does not exercise the change.** The harness runs with a forced reference, supplying
+`-From` for every file, and this release only refuses BOM-less UTF-32 when detection is
+*automatic*. `UnprovableBomlessUtf32` therefore appears **zero times** across all 5,077
+files. The audit is evidence that the change broke nothing; it is not evidence that the
+change works. That comes from the unit and end-to-end tests, which drive the automatic
+path directly.
+
+What the audit does exercise is the way out: 847 files carrying the BOM-less-doubt
+advisory were converted with an explicit source, and **all 847 preserved their text
+exactly**. The escape hatch this release tells users to reach for is measured at scale,
+even though the refusal that sends them there is not.
+
+**Detection is provably unchanged.** Both detection testers produced reports
+byte-identical to the committed ones — 1,358 UnicodeTestSuite files and 3,137 chardet
+files — which is the expected result for a change that touches no detector file.
+
+Those testers print an overall accuracy scored through an "also valid as" equivalence
+relation. That relation is not used here to establish ground truth; the figures are used
+only as a before-and-after identity check, which is what they can support.
+
+### One defect found during review, worth recording
+
+The first version of this change reported the correct reason code from conversion and the
+**wrong one** from `-DetectOnly` and `-Validate`: both branches held the UTF-16 code as a
+literal while the condition reaching them had widened. All 746 unit tests passed while the
+three modes disagreed about the same file. A CLI run found it.
+
+That is the mode-asymmetry class this project already knows about, reproduced by the fix
+for it. The three now read one mapping, and a test covers the read-only modes.

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -11,7 +11,7 @@ For each file EC is allowed to convert:
 1. Scans the source and decides whether automatic conversion is permitted.
 2. For a reviewed plan, verifies that every approved source hash still matches.
 3. Rejects malformed input, unsafe source choices, repeated leading BOMs, and
-   ambiguous BOM-less UTF-16 before writing output.
+   ambiguous BOM-less UTF-16 and all BOM-less UTF-32 before writing output.
 4. If backups are enabled, creates `<file>.bak` before conversion begins.
 5. Strictly decodes the source and strictly encodes the target into a sibling
    temporary file.
@@ -50,6 +50,20 @@ code `AmbiguousBomlessUtf16` and leaves the source unchanged.
 This is intentionally conservative: most ordinary BOM-less UTF-16 files are
 expected to be refused. It costs a second full read, which is deliberate because
 rewriting a file must not rest on a sample-based byte-order guess.
+
+### BOM-less UTF-32
+
+EC never converts it automatically. It reports `Refused` with reason code
+`UnprovableBomlessUtf32` and leaves the source unchanged.
+
+The doubt is larger than a byte order. UTF-16 text with one character per line
+puts a C0 control in every second code unit, so each four-byte group is an
+in-range unassigned scalar and the whole file decodes as valid UTF-32 — while
+the *opposite* UTF-32 order rejects it, so the test that protects UTF-16 would
+pass it through. Separately, genuine UTF-32 can be valid under both orders.
+
+The cost is that ordinary BOM-less UTF-32 is refused too. Nothing in the bytes
+separates it from the UTF-16 file above. Add a BOM, or name the source.
 
 Choose `-From utf-16le` or `-From utf-16be` if you know the source order. That
 chooses the source interpretation only; it does not bypass any other safeguard.

--- a/sources/EncodingChecker.Tests/BomlessUtf32RefusalTests.cs
+++ b/sources/EncodingChecker.Tests/BomlessUtf32RefusalTests.cs
@@ -1,0 +1,162 @@
+using System.Text;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// BOM-less UTF-32 is an estimate detection cannot establish, so it is refused.
+/// </summary>
+/// <remarks>
+/// Two silent-corruption paths closed by one rule. A BOM-less UTF-16 file with one
+/// character per line puts a C0 control in every second code unit, so each four-byte group
+/// is an in-range unassigned scalar and the file decodes as UTF-32 — converting it rewrites
+/// different text. Separately, genuine BOM-less UTF-32 can be valid under both byte orders,
+/// and detection preferred little-endian without saying so.
+///
+/// An opposite-order test cannot close the first: the UTF-16 file's bytes are *not* valid
+/// under the opposite UTF-32 order, so the ambiguity check that protects UTF-16 returns
+/// false. What cannot be proven is the codec, not just its byte order.
+///
+/// The cost is that BOM-less UTF-32 no longer converts automatically even when its content
+/// is unambiguous. That is deliberate: nothing in the bytes distinguishes it from the
+/// UTF-16 file above.
+/// </remarks>
+public sealed class BomlessUtf32RefusalTests : IDisposable
+{
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_utf32_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private string Write(string name, byte[] bytes)
+    {
+        string path = Path.Combine(_root, name);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private ConversionReportEntry Convert(string? from = null)
+    {
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = ScanAction.Convert,
+            TargetCharset = "utf-8",
+            TargetWriteBom = false,
+            SourceCharset = from,
+        };
+
+        var entries = new EntrySink();
+        ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
+        return Assert.Single(entries);
+    }
+
+    /// <summary>Finding 1: UTF-16 that also decodes as UTF-32 must not be converted.</summary>
+    [Fact]
+    public void Utf16ThatAlsoDecodesAsUtf32IsRefusedRatherThanRewritten()
+    {
+        // One ASCII character per LF-terminated line, UTF-16LE, no BOM.
+        string text = string.Concat(
+            Enumerable.Range(0, 200).Select(i => $"{(char)('a' + (i % 26))}\n"));
+
+        string path = Write("perline.txt", Encoding.Unicode.GetBytes(text));
+        byte[] before = File.ReadAllBytes(path);
+
+        ConversionReportEntry entry = Convert();
+
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(ConversionReasonCodes.UnprovableBomlessUtf32, entry.ReasonCode);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    /// <summary>Finding 2: UTF-32 valid under both byte orders must not be converted.</summary>
+    [Fact]
+    public void Utf32ValidUnderBothByteOrdersIsRefusedRatherThanGuessed()
+    {
+        // Every scalar a multiple of 0x100, so the bytes read equally well either way.
+        byte[] bytes = [.. Enumerable.Range(1, 60)
+            .SelectMany(i => new byte[] { 0x00, (byte)i, 0x00, 0x00 })];
+
+        string path = Write("bothways.txt", bytes);
+        byte[] before = File.ReadAllBytes(path);
+
+        ConversionReportEntry entry = Convert();
+
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(ConversionReasonCodes.UnprovableBomlessUtf32, entry.ReasonCode);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    /// <summary>
+    /// The cost, stated as a test: ordinary BOM-less UTF-32 is refused too.
+    /// </summary>
+    [Fact]
+    public void OrdinaryBomlessUtf32IsRefusedAsWell()
+    {
+        string path = Write(
+            "plain.txt", new UTF32Encoding(false, false).GetBytes("Hello world\n"));
+
+        ConversionReportEntry entry = Convert();
+
+        Assert.Equal(PlannedAction.Refuse, entry.Action);
+        Assert.Equal(ConversionReasonCodes.UnprovableBomlessUtf32, entry.ReasonCode);
+    }
+
+    /// <summary>Naming the source is the documented way through, so it must work.</summary>
+    [Fact]
+    public void AnExplicitSourceStillConvertsBomlessUtf32()
+    {
+        const string text = "Hello world\n";
+        Write("plain.txt", new UTF32Encoding(false, false).GetBytes(text));
+
+        ConversionReportEntry entry = Convert(from: "utf-32");
+
+        Assert.Equal(PlannedAction.Convert, entry.Action);
+        Assert.Equal(
+            text,
+            File.ReadAllText(Path.Combine(_root, "plain.txt"), new UTF8Encoding(false)));
+    }
+
+    /// <summary>A BOM settles the codec, so UTF-32 with one still converts.</summary>
+    [Fact]
+    public void Utf32WithABomStillConverts()
+    {
+        const string text = "Hello world\n";
+        var utf32 = new UTF32Encoding(false, true);
+        Write("bom.txt", [.. utf32.GetPreamble(), .. utf32.GetBytes(text)]);
+
+        ConversionReportEntry entry = Convert();
+
+        Assert.Equal(PlannedAction.Convert, entry.Action);
+    }
+
+    /// <summary>
+    /// Private-use characters must keep converting: icon fonts put them in ordinary text
+    /// files, so a rule that rejected unassigned or private-use scalars would break real
+    /// sources. This fix deliberately changes no scalar classification.
+    /// </summary>
+    [Fact]
+    public void PrivateUseCharactersStillConvert()
+    {
+        // U+E000 and U+F8FF bracket the BMP private use area; U+F0000 is plane 15.
+        string text = "icon   " + char.ConvertFromUtf32(0xF0000) + "\n";
+        var utf16 = new UnicodeEncoding(false, true);
+        Write("icons.txt", [.. utf16.GetPreamble(), .. utf16.GetBytes(text)]);
+
+        ConversionReportEntry entry = Convert();
+
+        Assert.Equal(PlannedAction.Convert, entry.Action);
+        Assert.Equal(
+            text,
+            File.ReadAllText(Path.Combine(_root, "icons.txt"), new UTF8Encoding(false)));
+    }
+}

--- a/sources/EncodingChecker.Tests/BomlessUtf32RefusalTests.cs
+++ b/sources/EncodingChecker.Tests/BomlessUtf32RefusalTests.cs
@@ -44,6 +44,20 @@ public sealed class BomlessUtf32RefusalTests : IDisposable
         return path;
     }
 
+    private ConversionReportEntry Scan(ScanAction action, string? validate = null)
+    {
+        var options = new ScanDirectoryOptions
+        {
+            BaseDirectory = _root,
+            Action = action,
+            ValidCharsets = validate is null ? null : [validate],
+        };
+
+        var entries = new EntrySink();
+        ScanEngine.ScanDirectory(options, entries.Add, CancellationToken.None);
+        return Assert.Single(entries);
+    }
+
     private ConversionReportEntry Convert(string? from = null)
     {
         var options = new ScanDirectoryOptions
@@ -147,8 +161,10 @@ public sealed class BomlessUtf32RefusalTests : IDisposable
     [Fact]
     public void PrivateUseCharactersStillConvert()
     {
-        // U+E000 and U+F8FF bracket the BMP private use area; U+F0000 is plane 15.
-        string text = "icon   " + char.ConvertFromUtf32(0xF0000) + "\n";
+        // U+E000 and U+F8FF bracket the BMP private use area, U+E0B0 and U+F00C are
+        // what Powerline and Font Awesome actually use, and U+F0000 is plane 15.
+        string text = "icon     "
+            + char.ConvertFromUtf32(0xF0000) + "\n";
         var utf16 = new UnicodeEncoding(false, true);
         Write("icons.txt", [.. utf16.GetPreamble(), .. utf16.GetBytes(text)]);
 
@@ -158,5 +174,66 @@ public sealed class BomlessUtf32RefusalTests : IDisposable
         Assert.Equal(
             text,
             File.ReadAllText(Path.Combine(_root, "icons.txt"), new UTF8Encoding(false)));
+    }
+
+    /// <summary>Read-only modes must name the same reason conversion does.</summary>
+    /// <remarks>
+    /// Both branches held the UTF-16 code as a literal while the condition reaching them
+    /// had widened, so a UTF-32 file was reported as an ambiguous UTF-16 byte order. The
+    /// unit suite did not notice; a CLI run did. They now read the same mapping.
+    /// </remarks>
+    [Fact]
+    public void ReadOnlyModesNameTheUtf32Reason()
+    {
+        // A fact rather than a theory because ScanAction is internal, so an InlineData
+        // parameter would have to be public.
+        Write("plain.txt", new UTF32Encoding(false, false).GetBytes("Hello world\n"));
+
+        Assert.Equal(
+            ConversionReasonCodes.UnprovableBomlessUtf32,
+            Scan(ScanAction.Detect).ReasonCode);
+
+        Assert.Equal(
+            ConversionReasonCodes.UnprovableBomlessUtf32,
+            Scan(ScanAction.Validate, validate: "utf-32").ReasonCode);
+    }
+
+    /// <summary>Big-endian is refused and overridable, exactly as little-endian is.</summary>
+    [Fact]
+    public void BigEndianBehavesTheSameWayAsLittleEndian()
+    {
+        const string text = "Hello world\n";
+        string path = Write("be.txt", new UTF32Encoding(true, false).GetBytes(text));
+        byte[] before = File.ReadAllBytes(path);
+
+        ConversionReportEntry refused = Convert();
+        Assert.Equal(PlannedAction.Refuse, refused.Action);
+        Assert.Equal(ConversionReasonCodes.UnprovableBomlessUtf32, refused.ReasonCode);
+        Assert.Equal(before, File.ReadAllBytes(path));
+
+        ConversionReportEntry overridden = Convert(from: "utf-32BE");
+        Assert.Equal(PlannedAction.Convert, overridden.Action);
+        Assert.Equal(text, File.ReadAllText(path, new UTF8Encoding(false)));
+    }
+
+    /// <summary>A big-endian BOM settles the codec, so the file converts.</summary>
+    [Fact]
+    public void BigEndianWithABomStillConverts()
+    {
+        var utf32 = new UTF32Encoding(true, true);
+        Write("bebom.txt", [.. utf32.GetPreamble(), .. utf32.GetBytes("Hello\n")]);
+
+        Assert.Equal(PlannedAction.Convert, Convert().Action);
+    }
+
+    /// <summary>
+    /// The GUI offers a source chooser for refusals the user can resolve, and this is one.
+    /// </summary>
+    [Fact]
+    public void TheSourceChooserIsOfferedForAnUnprovableUtf32Refusal()
+    {
+        Assert.True(ConversionPolicy.RequiresExplicitSourceChoice(
+            SourceInterpretation.AutomaticUnicodeOrAscii,
+            ConversionReasonCodes.UnprovableBomlessUtf32));
     }
 }

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -601,6 +601,29 @@ public sealed class ConversionPlanTests : IDisposable
     }
 
     [Fact]
+    public void APlanFromAnEarlierSemanticsVersionIsRefused()
+    {
+        // The direction that matters when semantics advance rather than a plan being
+        // tampered with: a plan approved under the previous version. Refusing BOM-less
+        // UTF-32 took semantics from 6 to 7, so a plan written by the release before it
+        // can list a file this build will not convert. Accepting it would apply approval
+        // given for one behaviour to another.
+        string path = Write("jp.txt", "こんにちは世界。テキスト", "shift_jis");
+        byte[] original = File.ReadAllBytes(path);
+
+        Assert.Equal(0, Plan());
+        Rewrite(fields =>
+            fields["SemanticsVersion"] =
+                JsonSerializer.SerializeToElement(ConversionSemantics.Current - 1));
+
+        Assert.Equal(1, Run("-Apply", PlanPath));
+        Assert.Equal(original, File.ReadAllBytes(path));
+
+        Assert.Null(ConversionPlan.Load(PlanPath, out string? error));
+        Assert.Contains("different conversion behaviour", error);
+    }
+
+    [Fact]
     public void APlanAppliedFromACopyStillConvertsTheTreeItWasApprovedFor()
     {
         // A plan carrying absolute paths that is copied alongside its tree still names

--- a/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPolicyTests.cs
@@ -144,7 +144,7 @@ public sealed class ConversionPolicyTests : IDisposable
             "utf-16le", targetCodePage: 1200, targetHasBom: false,
             sourceWasSpecified: false, isUnicodeOrAscii: false,
             explicitSourceConflictsWithReliableDetection: false,
-            automaticBomlessUtf16IsAmbiguous: false,
+            automaticBomlessUnicodeDoubt: BomlessUnicodeKind.None,
             out SourceInterpretation interpretation, out string? reason);
 
         Assert.Equal(PlannedAction.Refuse, action);
@@ -162,7 +162,7 @@ public sealed class ConversionPolicyTests : IDisposable
             "utf-16le", targetCodePage: 1200, targetHasBom: false,
             sourceWasSpecified: false, isUnicodeOrAscii: true,
             explicitSourceConflictsWithReliableDetection: false,
-            automaticBomlessUtf16IsAmbiguous: false,
+            automaticBomlessUnicodeDoubt: BomlessUnicodeKind.None,
             out SourceInterpretation automatic, out _));
         Assert.Equal(SourceInterpretation.AutomaticUnicodeOrAscii, automatic);
 
@@ -173,7 +173,7 @@ public sealed class ConversionPolicyTests : IDisposable
             "utf-8", targetCodePage: 65001, targetHasBom: false,
             sourceWasSpecified: true, isUnicodeOrAscii: false,
             explicitSourceConflictsWithReliableDetection: false,
-            automaticBomlessUtf16IsAmbiguous: false,
+            automaticBomlessUnicodeDoubt: BomlessUnicodeKind.None,
             out SourceInterpretation explicitSource, out _));
         Assert.Equal(SourceInterpretation.ExplicitSource, explicitSource);
     }
@@ -190,7 +190,7 @@ public sealed class ConversionPolicyTests : IDisposable
                 "utf-8", targetCodePage: 65001, targetHasBom: false,
                 sourceWasSpecified: false, isUnicodeOrAscii: true,
                 explicitSourceConflictsWithReliableDetection: false,
-                automaticBomlessUtf16IsAmbiguous: false,
+                automaticBomlessUnicodeDoubt: BomlessUnicodeKind.None,
                 out SourceInterpretation interpretation, out _));
         Assert.Equal(SourceInterpretation.NotApplicable, interpretation);
     }
@@ -207,7 +207,7 @@ public sealed class ConversionPolicyTests : IDisposable
                 "utf-8", targetCodePage: 65001, targetHasBom: false,
                 sourceWasSpecified: false, isUnicodeOrAscii: false,
                 explicitSourceConflictsWithReliableDetection: false,
-                automaticBomlessUtf16IsAmbiguous: false,
+                automaticBomlessUnicodeDoubt: BomlessUnicodeKind.None,
                 out SourceInterpretation interpretation, out _));
         Assert.Equal(SourceInterpretation.NotApplicable, interpretation);
 

--- a/sources/EncodingChecker.Tests/EncodingConversionMatrixTests.cs
+++ b/sources/EncodingChecker.Tests/EncodingConversionMatrixTests.cs
@@ -44,9 +44,8 @@ public sealed class EncodingConversionMatrixTests : IDisposable
         yield return [new UnicodeEncoding(true, false), false, "utf-8", false, TestContent.Multilingual];
         yield return [new UnicodeEncoding(true, true), true, "utf-8-bom", true, TestContent.Multilingual];
 
-        yield return [new UTF32Encoding(false, false), false, "utf-8", false, TestContent.Multilingual];
+        // BOM-less UTF-32 is refused, not converted: see BomlessUtf32RefusalTests.
         yield return [new UTF32Encoding(false, true), true, "utf-8-bom", true, TestContent.Multilingual];
-        yield return [new UTF32Encoding(true, false), false, "utf-8", false, TestContent.Multilingual];
         yield return [new UTF32Encoding(true, true), true, "utf-8-bom", true, TestContent.Multilingual];
 
         yield return [new UTF8Encoding(false), false, "utf-32-bom", true, TestContent.Multilingual];

--- a/sources/EncodingChecker.Tests/ReadOnlyModeAmbiguityTests.cs
+++ b/sources/EncodingChecker.Tests/ReadOnlyModeAmbiguityTests.cs
@@ -169,7 +169,7 @@ public sealed class ReadOnlyModeAmbiguityTests : IDisposable
 
         Assert.Equal("utf-16", detected.SourceEncoding);
         Assert.Null(detected.ReasonCode);
-        Assert.False(detected.HasAmbiguousBomlessUtf16);
+        Assert.False(detected.HasBomlessUnicodeDoubt);
 
         ConversionReportEntry validated =
             Assert.Single(Scan(ScanAction.Validate, "utf-16"));
@@ -201,7 +201,7 @@ public sealed class ReadOnlyModeAmbiguityTests : IDisposable
 
         ConversionReportEntry entry = Assert.Single(Scan(ScanAction.Detect));
 
-        Assert.False(entry.HasAmbiguousBomlessUtf16);
+        Assert.False(entry.HasBomlessUnicodeDoubt);
         Assert.Null(entry.ReasonCode);
     }
 
@@ -215,7 +215,7 @@ public sealed class ReadOnlyModeAmbiguityTests : IDisposable
         ConversionReportEntry entry = Assert.Single(Scan(ScanAction.Detect));
 
         Assert.Equal("us-ascii", entry.SourceEncoding);
-        Assert.False(entry.HasAmbiguousBomlessUtf16);
+        Assert.False(entry.HasBomlessUnicodeDoubt);
         Assert.Null(entry.ReasonCode);
     }
 }

--- a/sources/EncodingChecker.Tests/RefusalReasonCodeTests.cs
+++ b/sources/EncodingChecker.Tests/RefusalReasonCodeTests.cs
@@ -33,11 +33,11 @@ public sealed class RefusalReasonCodeTests
     /// produce, with the decision it reaches.
     /// </summary>
     /// <remarks>
-    /// The two flags are mutually exclusive by construction at the call site: a conflict
-    /// needs an explicit source, and the automatic ambiguity needs the absence of one.
+    /// A conflict needs an explicit source and the automatic doubt needs the absence of
+    /// one, so the two are mutually exclusive by construction at the call site.
     /// </remarks>
     private static IEnumerable<(PlannedAction Action, SourceInterpretation Interpretation,
-        bool Ambiguous, bool Conflict)> Reachable()
+        BomlessUnicodeKind Doubt, bool Conflict)> Reachable()
     {
         foreach ((string sc, int scp) in Sources)
         foreach ((string tc, int tcp) in Targets)
@@ -46,26 +46,29 @@ public sealed class RefusalReasonCodeTests
         foreach (bool specified in new[] { false, true })
         foreach (bool unicodeOrAscii in new[] { false, true })
         foreach (bool conflict in new[] { false, true })
-        foreach (bool ambiguous in new[] { false, true })
+        foreach (BomlessUnicodeKind doubt in Enum.GetValues<BomlessUnicodeKind>())
         {
             if (conflict && !specified) continue;
-            if (ambiguous && specified) continue;
+            if (doubt != BomlessUnicodeKind.None && specified) continue;
 
             PlannedAction action = ConversionPolicy.Decide(
                 sc, scp, sourceHasBom, tc, tcp, targetHasBom,
-                specified, unicodeOrAscii, conflict, ambiguous,
+                specified, unicodeOrAscii, conflict, doubt,
                 out SourceInterpretation interpretation, out _);
 
-            yield return (action, interpretation, ambiguous, conflict);
+            yield return (action, interpretation, doubt, conflict);
         }
     }
 
     /// <summary>The formula this replaced, kept as the oracle for the change itself.</summary>
     private static string? PreviousFormula(
-        PlannedAction action, bool ambiguous, bool conflict) => action switch
+        PlannedAction action, BomlessUnicodeKind doubt, bool conflict) => action switch
     {
         PlannedAction.Skip => ConversionReasonCodes.UnknownEncoding,
-        PlannedAction.Refuse when ambiguous => ConversionReasonCodes.AmbiguousBomlessUtf16,
+        PlannedAction.Refuse when doubt == BomlessUnicodeKind.Utf32NotProvable =>
+            ConversionReasonCodes.UnprovableBomlessUtf32,
+        PlannedAction.Refuse when doubt != BomlessUnicodeKind.None =>
+            ConversionReasonCodes.AmbiguousBomlessUtf16,
         PlannedAction.Refuse => conflict
             ? ConversionReasonCodes.ExplicitSourceConflictsWithDetection
             : ConversionReasonCodes.LegacySourceRequired,
@@ -78,17 +81,17 @@ public sealed class RefusalReasonCodeTests
         var checkedCombinations = 0;
 
         foreach ((PlannedAction action, SourceInterpretation interpretation,
-                  bool ambiguous, bool conflict) in Reachable())
+                  BomlessUnicodeKind doubt, bool conflict) in Reachable())
         {
             checkedCombinations++;
 
             Assert.Equal(
-                PreviousFormula(action, ambiguous, conflict),
-                ConversionPolicy.ReasonCodeFor(action, interpretation));
+                PreviousFormula(action, doubt, conflict),
+                ConversionPolicy.ReasonCodeFor(action, interpretation, doubt));
         }
 
         // A rule that silently matched nothing would look identical to one that passed.
-        Assert.Equal(256, checkedCombinations);
+        Assert.Equal(320, checkedCombinations);
     }
 
     [Fact]
@@ -96,33 +99,41 @@ public sealed class RefusalReasonCodeTests
     {
         // The guard that matters for the next refusal reason someone adds: a decision not
         // to convert has to explain itself, and an unmapped interpretation returns null.
-        foreach ((PlannedAction action, SourceInterpretation interpretation, _, _) in Reachable())
+        foreach ((PlannedAction action, SourceInterpretation interpretation,
+                  BomlessUnicodeKind doubt, _) in Reachable())
         {
             if (action is not (PlannedAction.Refuse or PlannedAction.Skip))
                 continue;
 
             Assert.False(
-                string.IsNullOrEmpty(ConversionPolicy.ReasonCodeFor(action, interpretation)),
-                $"{action}/{interpretation} produced no reason code");
+                string.IsNullOrEmpty(
+                    ConversionPolicy.ReasonCodeFor(action, interpretation, doubt)),
+                $"{action}/{interpretation}/{doubt} produced no reason code");
         }
     }
 
     [Fact]
     public void EachRefusalPathHasItsOwnReason()
     {
-        // Three ways to refuse, three distinct codes: collapsing any two would tell a user
+        // Four ways to refuse, four distinct codes: collapsing any two would tell a user
         // to do something that cannot resolve their case.
         string?[] codes =
         [
             ConversionPolicy.ReasonCodeFor(
-                PlannedAction.Refuse, SourceInterpretation.ExplicitSource),
+                PlannedAction.Refuse, SourceInterpretation.ExplicitSource,
+                BomlessUnicodeKind.None),
             ConversionPolicy.ReasonCodeFor(
-                PlannedAction.Refuse, SourceInterpretation.AutomaticUnicodeOrAscii),
+                PlannedAction.Refuse, SourceInterpretation.AutomaticUnicodeOrAscii,
+                BomlessUnicodeKind.Utf16ByteOrderAmbiguous),
             ConversionPolicy.ReasonCodeFor(
-                PlannedAction.Refuse, SourceInterpretation.LegacyNeedsSourceChoice),
+                PlannedAction.Refuse, SourceInterpretation.AutomaticUnicodeOrAscii,
+                BomlessUnicodeKind.Utf32NotProvable),
+            ConversionPolicy.ReasonCodeFor(
+                PlannedAction.Refuse, SourceInterpretation.LegacyNeedsSourceChoice,
+                BomlessUnicodeKind.None),
         ];
 
-        Assert.Equal(3, codes.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(4, codes.Distinct(StringComparer.Ordinal).Count());
         Assert.All(codes, code => Assert.False(string.IsNullOrEmpty(code)));
     }
 
@@ -137,7 +148,8 @@ public sealed class RefusalReasonCodeTests
         foreach (SourceInterpretation interpretation in
                  Enum.GetValues<SourceInterpretation>())
         {
-            Assert.Null(ConversionPolicy.ReasonCodeFor(action, interpretation));
+            Assert.Null(ConversionPolicy.ReasonCodeFor(
+                action, interpretation, BomlessUnicodeKind.None));
         }
     }
 }

--- a/sources/EncodingChecker.Tests/TargetAliasIdentityTests.cs
+++ b/sources/EncodingChecker.Tests/TargetAliasIdentityTests.cs
@@ -149,7 +149,7 @@ public sealed class TargetAliasIdentityTests : IDisposable
                 "mystery", targetCodePage: 0, targetHasBom: false,
                 sourceWasSpecified: false, isUnicodeOrAscii: false,
                 explicitSourceConflictsWithReliableDetection: false,
-                automaticBomlessUtf16IsAmbiguous: false,
+                automaticBomlessUnicodeDoubt: BomlessUnicodeKind.None,
                 out _, out _));
     }
 

--- a/sources/EncodingChecker/BomlessUnicodeSafety.cs
+++ b/sources/EncodingChecker/BomlessUnicodeSafety.cs
@@ -5,73 +5,120 @@ using System.Text;
 namespace EncodingChecker;
 
 /// <summary>
-/// Prevents automatic conversion when BOM-less UTF-16 byte order cannot be
-/// established from the bytes alone.
+/// Why a BOM-less Unicode file cannot be converted on detection alone.
+/// </summary>
+/// <remarks>
+/// Not persisted. Plans record <see cref="SourceInterpretation"/>, which is unchanged.
+/// </remarks>
+internal enum BomlessUnicodeKind
+{
+    /// <summary>The bytes establish the codec, or a BOM does.</summary>
+    None,
+
+    /// <summary>UTF-16 whose bytes decode equally well under either byte order.</summary>
+    Utf16ByteOrderAmbiguous,
+
+    /// <summary>UTF-32 without a BOM, which detection cannot establish at all.</summary>
+    Utf32NotProvable,
+}
+
+/// <summary>
+/// Prevents automatic conversion when BOM-less Unicode cannot be established from the
+/// bytes alone.
 /// </summary>
 internal static class BomlessUnicodeSafety
 {
     internal const string AmbiguousReasonCode = "AmbiguousBomlessUtf16";
+    internal const string UnprovableUtf32ReasonCode = "UnprovableBomlessUtf32";
 
     /// <summary>
-    /// Returns true when the detected BOM-less UTF-16 bytes also strictly
-    /// decode under the opposite byte order.
+    /// Classifies what detection failed to establish about a BOM-less Unicode file.
     /// </summary>
     /// <remarks>
-    /// Detection may prefer one order, but that preference is not enough to
-    /// justify rewriting a file when both orders accept the complete source.
+    /// UTF-16 is refused only when the opposite byte order also decodes the whole file,
+    /// because otherwise the bytes do establish the order.
+    ///
+    /// UTF-32 is refused whenever no BOM is present, and an opposite-order test would not
+    /// do: UTF-16 text with one character per line puts a C0 control in every second code
+    /// unit, and each resulting four-byte group is an in-range unassigned scalar, so it
+    /// decodes as UTF-32LE while the *opposite* UTF-32 order rejects it. The unprovable
+    /// thing is the codec, not merely its byte order.
     /// </remarks>
-    internal static bool IsAmbiguous(
+    internal static BomlessUnicodeKind Classify(
         Stream source,
         Encoding? detectedEncoding,
         bool detectedHasBom)
     {
         ArgumentNullException.ThrowIfNull(source);
 
-        if (detectedHasBom || detectedEncoding?.CodePage is not (1200 or 1201))
-            return false;
+        if (detectedHasBom || detectedEncoding is null)
+            return BomlessUnicodeKind.None;
 
-        int oppositeCodePage = detectedEncoding.CodePage == 1200 ? 1201 : 1200;
-        Encoding opposite = Encoding.GetEncoding(
-            oppositeCodePage,
-            EncoderFallback.ExceptionFallback,
-            DecoderFallback.ExceptionFallback);
+        switch (detectedEncoding.CodePage)
+        {
+            case 12000 or 12001:
+                return BomlessUnicodeKind.Utf32NotProvable;
 
-        return StrictFileValidation.TryValidateStream(source, opposite, out _);
+            case 1200 or 1201:
+                int opposite = detectedEncoding.CodePage == 1200 ? 1201 : 1200;
+
+                return StrictFileValidation.TryValidateStream(source, Strict(opposite), out _)
+                    ? BomlessUnicodeKind.Utf16ByteOrderAmbiguous
+                    : BomlessUnicodeKind.None;
+
+            default:
+                return BomlessUnicodeKind.None;
+        }
     }
+
+    /// <summary>The machine-readable reason for a <paramref name="kind"/>.</summary>
+    internal static string? ReasonCodeFor(BomlessUnicodeKind kind) => kind switch
+    {
+        BomlessUnicodeKind.Utf16ByteOrderAmbiguous => AmbiguousReasonCode,
+        BomlessUnicodeKind.Utf32NotProvable => UnprovableUtf32ReasonCode,
+        _ => null,
+    };
 
     /// <summary>Builds the actionable explanation shared by reports and the GUI.</summary>
-    internal static string DescribeRefusal(Encoding detectedEncoding)
+    internal static string DescribeRefusal(Encoding detectedEncoding) =>
+        Describe(detectedEncoding, conversionRefused: true);
+
+    /// <summary>Describes the doubt without implying that conversion was attempted.</summary>
+    internal static string DescribeUnprovableByteOrder(Encoding detectedEncoding) =>
+        Describe(detectedEncoding, conversionRefused: false);
+
+    private static string Describe(Encoding detectedEncoding, bool conversionRefused)
     {
         ArgumentNullException.ThrowIfNull(detectedEncoding);
 
-        (string detectedName, string oppositeName) = Names(detectedEncoding);
+        if (detectedEncoding.CodePage is 12000 or 12001)
+        {
+            string detected = detectedEncoding.CodePage == 12000 ? "UTF-32LE" : "UTF-32BE";
 
-        return Describe(detectedName, oppositeName, conversionRefused: true);
-    }
+            return $"EC estimates BOM-less {detected}, which it cannot establish from the "
+                + "bytes: UTF-16 text can decode as valid UTF-32, and a BOM-less UTF-32 "
+                + "byte order cannot be proven either. "
+                + (conversionRefused
+                    ? "No conversion was performed. Add a byte-order mark, or specify "
+                      + "-From with the codec the file was written in."
+                    : "Add a byte-order mark to identify it.");
+        }
 
-    /// <summary>Describes the ambiguity without implying that conversion was attempted.</summary>
-    internal static string DescribeUnprovableByteOrder(Encoding detectedEncoding)
-    {
-        ArgumentNullException.ThrowIfNull(detectedEncoding);
-
-        (string detectedName, string oppositeName) = Names(detectedEncoding);
-
-        return Describe(detectedName, oppositeName, conversionRefused: false);
-    }
-
-    private static string Describe(
-        string detectedName,
-        string oppositeName,
-        bool conversionRefused) =>
-        $"EC estimates BOM-less {detectedName}, but these bytes are also valid "
-        + $"{oppositeName}. The byte order cannot be proven from the file. "
-        + (conversionRefused
-            ? "No conversion was performed. Add a byte-order mark, or specify "
-              + "-From utf-16le or -From utf-16be."
-            : "Add a byte-order mark to identify it.");
-
-    private static (string Detected, string Opposite) Names(Encoding detectedEncoding) =>
-        detectedEncoding.CodePage == 1200
+        (string detectedName, string oppositeName) = detectedEncoding.CodePage == 1200
             ? ("UTF-16LE", "UTF-16BE")
             : ("UTF-16BE", "UTF-16LE");
+
+        return $"EC estimates BOM-less {detectedName}, but these bytes are also valid "
+            + $"{oppositeName}. The byte order cannot be proven from the file. "
+            + (conversionRefused
+                ? "No conversion was performed. Add a byte-order mark, or specify "
+                  + "-From utf-16le or -From utf-16be."
+                : "Add a byte-order mark to identify it.");
+    }
+
+    private static Encoding Strict(int codePage) =>
+        Encoding.GetEncoding(
+            codePage,
+            EncoderFallback.ExceptionFallback,
+            DecoderFallback.ExceptionFallback);
 }

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -39,11 +39,11 @@ internal sealed record ConversionSemantics
     /// <summary>
     /// Changes only when the meaning of an existing plan's decisions changes.
     /// </summary>
-    internal const int Current = 6;
+    internal const int Current = 7;
 
     /// <summary>The guarantees of <see cref="Current"/> shown to the reader.</summary>
     internal const string Describes =
-        "source-bound detection, strict codecs, verified output, atomic install, explicit source required for legacy text, proven BOM-less UTF-16 byte order, a reviewed refusal is binding";
+        "source-bound detection, strict codecs, verified output, atomic install, explicit source required for legacy text, proven BOM-less UTF-16 byte order, BOM or explicit source required for UTF-32, a reviewed refusal is binding";
 
     /// <summary>Malformed input is rejected rather than replaced.</summary>
     public bool StrictDecoding { get; init; } = true;

--- a/sources/EncodingChecker/ConversionPolicy.cs
+++ b/sources/EncodingChecker/ConversionPolicy.cs
@@ -45,7 +45,7 @@ internal static class ConversionPolicy
         bool sourceWasSpecified,
         bool isUnicodeOrAscii,
         bool explicitSourceConflictsWithReliableDetection,
-        bool automaticBomlessUtf16IsAmbiguous,
+        BomlessUnicodeKind automaticBomlessUnicodeDoubt,
         out SourceInterpretation sourceInterpretation,
         out string? reason)
     {
@@ -82,11 +82,17 @@ internal static class ConversionPolicy
             return PlannedAction.Refuse;
         }
 
-        if (!sourceWasSpecified && automaticBomlessUtf16IsAmbiguous)
+        if (!sourceWasSpecified &&
+            automaticBomlessUnicodeDoubt != BomlessUnicodeKind.None)
         {
             sourceInterpretation = SourceInterpretation.AutomaticUnicodeOrAscii;
-            reason = "BOM-less UTF-16 needs a byte order that the bytes do not prove. "
-                     + "Choose the original source encoding explicitly before converting.";
+
+            reason = automaticBomlessUnicodeDoubt == BomlessUnicodeKind.Utf32NotProvable
+                ? "BOM-less UTF-32 is an estimate the bytes do not establish. Choose the "
+                  + "original source encoding explicitly before converting."
+                : "BOM-less UTF-16 needs a byte order that the bytes do not prove. "
+                  + "Choose the original source encoding explicitly before converting.";
+
             return PlannedAction.Refuse;
         }
 
@@ -134,12 +140,15 @@ internal static class ConversionPolicy
     /// </remarks>
     internal static string? ReasonCodeFor(
         PlannedAction action,
-        SourceInterpretation sourceInterpretation) => (action, sourceInterpretation) switch
+        SourceInterpretation sourceInterpretation,
+        BomlessUnicodeKind bomlessUnicodeDoubt) => (action, sourceInterpretation) switch
     {
         (PlannedAction.Skip, _) => ConversionReasonCodes.UnknownEncoding,
 
+        // Reads the same input Decide read, rather than working the kind out again.
         (PlannedAction.Refuse, SourceInterpretation.AutomaticUnicodeOrAscii) =>
-            ConversionReasonCodes.AmbiguousBomlessUtf16,
+            BomlessUnicodeSafety.ReasonCodeFor(bomlessUnicodeDoubt)
+            ?? ConversionReasonCodes.AmbiguousBomlessUtf16,
 
         (PlannedAction.Refuse, SourceInterpretation.ExplicitSource) =>
             ConversionReasonCodes.ExplicitSourceConflictsWithDetection,
@@ -161,5 +170,9 @@ internal static class ConversionPolicy
         string.Equals(
             reasonCode,
             ConversionReasonCodes.AmbiguousBomlessUtf16,
+            StringComparison.Ordinal) ||
+        string.Equals(
+            reasonCode,
+            ConversionReasonCodes.UnprovableBomlessUtf32,
             StringComparison.Ordinal);
 }

--- a/sources/EncodingChecker/ConversionPolicy.cs
+++ b/sources/EncodingChecker/ConversionPolicy.cs
@@ -31,8 +31,9 @@ internal static class ConversionPolicy
     /// <param name="sourceWasSpecified">Whether the source encoding was explicitly specified by the user.</param>
     /// <param name="isUnicodeOrAscii">Whether the source encoding is Unicode or ASCII.</param>
     /// <param name="explicitSourceConflictsWithReliableDetection">Whether the explicitly specified source encoding conflicts with reliable detection.</param>
-    /// <param name="automaticBomlessUtf16IsAmbiguous">
-    /// Whether automatic BOM-less UTF-16 detection is valid under both byte orders.
+    /// <param name="automaticBomlessUnicodeDoubt">
+    /// What automatic detection could not establish about a BOM-less Unicode source:
+    /// a UTF-16 byte order the bytes leave open, or UTF-32 they cannot establish at all.
     /// </param>
     /// <returns>The planned action for the file.</returns>
     internal static PlannedAction Decide(
@@ -146,9 +147,16 @@ internal static class ConversionPolicy
         (PlannedAction.Skip, _) => ConversionReasonCodes.UnknownEncoding,
 
         // Reads the same input Decide read, rather than working the kind out again.
+        // Decide reaches this refusal only from a non-None doubt, so a None here is a
+        // caller that lost it. Defaulting to the UTF-16 code would rebuild the defect
+        // this mapping exists to prevent: a correct refusal carrying a wrong reason,
+        // with nothing to fail.
         (PlannedAction.Refuse, SourceInterpretation.AutomaticUnicodeOrAscii) =>
             BomlessUnicodeSafety.ReasonCodeFor(bomlessUnicodeDoubt)
-            ?? ConversionReasonCodes.AmbiguousBomlessUtf16,
+            ?? throw new ArgumentOutOfRangeException(
+                nameof(bomlessUnicodeDoubt),
+                bomlessUnicodeDoubt,
+                "An automatic Unicode refusal must carry the doubt that caused it."),
 
         (PlannedAction.Refuse, SourceInterpretation.ExplicitSource) =>
             ConversionReasonCodes.ExplicitSourceConflictsWithDetection,

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -70,10 +70,13 @@ internal sealed class ConversionReportEntry
     internal bool DetectedEncodingHasBom { get; set; }
 
     /// <summary>
-    /// Whether a detected BOM-less UTF-16 source also strictly decodes under the opposite
-    /// byte order. Internal planning state; not in CSV.
+    /// What detection could not establish about a BOM-less Unicode source. Internal
+    /// planning state; not in CSV.
     /// </summary>
-    internal bool HasAmbiguousBomlessUtf16 { get; set; }
+    internal BomlessUnicodeKind BomlessUnicodeDoubt { get; set; }
+
+    /// <summary>Whether that doubt exists at all.</summary>
+    internal bool HasBomlessUnicodeDoubt => BomlessUnicodeDoubt != BomlessUnicodeKind.None;
 
     /// <summary>
     /// The SHA-256 this file must still have when installed, or <see langword="null"/>
@@ -224,6 +227,18 @@ internal static class ConversionReasonCodes
     internal const string ExplicitSourceOnUnprovableBomlessUnicode =
         nameof(ExplicitSourceOnUnprovableBomlessUnicode);
     internal const string AmbiguousBomlessUtf16 = BomlessUnicodeSafety.AmbiguousReasonCode;
+
+    /// <summary>
+    /// A BOM-less UTF-32 source, which detection cannot establish from the bytes.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="AmbiguousBomlessUtf16"/> because the doubt and the remedy
+    /// differ: UTF-16 is a byte order the bytes leave open, while UTF-32 without a BOM
+    /// may not be UTF-32 at all. A script filtering on the UTF-16 code would otherwise
+    /// start matching a condition it was never written for.
+    /// </remarks>
+    internal const string UnprovableBomlessUtf32 =
+        BomlessUnicodeSafety.UnprovableUtf32ReasonCode;
     internal const string StrictValidationFailed = nameof(StrictValidationFailed);
 
     /// <summary>

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.12.1.0")]
-[assembly: AssemblyFileVersion("3.12.1.0")]
+[assembly: AssemblyVersion("3.13.0.0")]
+[assembly: AssemblyFileVersion("3.13.0.0")]

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -360,7 +360,7 @@ internal static class ScanEngine
                     entry.DetectedEncodingLabel = snapshot.DetectedEncoding?.WebName;
                     entry.DetectedEncodingHasBom = snapshot.DetectedEncodingHasBom;
                     entry.HasReliableUnicodeDetection = snapshot.HasReliableUnicodeDetection;
-                    entry.HasAmbiguousBomlessUtf16 = snapshot.HasAmbiguousBomlessUtf16;
+                    entry.BomlessUnicodeDoubt = snapshot.BomlessUnicodeDoubt;
                     entry.ExpectedSourceSha256 = snapshot.Sha256;
                     entry.ExpectedSourceSize = snapshot.Size;
                     entry.Action = snapshot.SourceEncoding is null
@@ -446,7 +446,7 @@ internal static class ScanEngine
         Encoding? automaticallyDetected = null;
         bool hasReliableUnicodeDetection = false;
         bool snapshotDetectedHasBom = false;
-        bool snapshotHasAmbiguousBomlessUtf16 = false;
+        BomlessUnicodeKind snapshotBomlessUnicodeDoubt = BomlessUnicodeKind.None;
         bool hasBom;
         string? sourceSha256 = null;
         long? sourceSize = null;
@@ -461,7 +461,7 @@ internal static class ScanEngine
             automaticallyDetected = snapshot.DetectedEncoding;
             hasReliableUnicodeDetection = snapshot.HasReliableUnicodeDetection;
             snapshotDetectedHasBom = snapshot.DetectedEncodingHasBom;
-            snapshotHasAmbiguousBomlessUtf16 = snapshot.HasAmbiguousBomlessUtf16;
+            snapshotBomlessUnicodeDoubt = snapshot.BomlessUnicodeDoubt;
             hasBom = snapshot.HasBom;
             sourceSha256 = snapshot.Sha256;
             sourceSize = snapshot.Size;
@@ -481,9 +481,10 @@ internal static class ScanEngine
             detected = TextEncoding.DetectFromFile(path);
             hasBom = detected != null && HasPreamble(path, detected);
 
-            // Read-only modes must disclose the same unprovable byte order conversion refuses.
-            snapshotHasAmbiguousBomlessUtf16 =
-                detected is not null && IsAmbiguousBomlessUtf16(path, detected, hasBom);
+            // Read-only modes must disclose the same doubt conversion refuses.
+            snapshotBomlessUnicodeDoubt = detected is null
+                ? BomlessUnicodeKind.None
+                : ClassifyBomlessUnicode(path, detected, hasBom);
         }
 
         string sourceCharset =
@@ -508,7 +509,7 @@ internal static class ScanEngine
                 snapshotDetectedHasBom,
             // Not gated on Convert like the two above: those are policy inputs, this
             // states what the bytes do and holds in every mode.
-            HasAmbiguousBomlessUtf16 = snapshotHasAmbiguousBomlessUtf16,
+            BomlessUnicodeDoubt = snapshotBomlessUnicodeDoubt,
         };
 
         if (options.Action == ScanAction.Convert)
@@ -526,7 +527,7 @@ internal static class ScanEngine
                     entry.Diagnostic =
                         "The file's encoding could not be identified from its contents.";
                 }
-                else if (entry.HasAmbiguousBomlessUtf16)
+                else if (entry.HasBomlessUnicodeDoubt)
                 {
                     // Detection found an estimate, not a reading. Nothing failed, so
                     // the result stays Unchanged; the row must still say which it is.
@@ -578,7 +579,7 @@ internal static class ScanEngine
                     entry.ReasonCode = ConversionReasonCodes.StrictValidationFailed;
                     entry.Diagnostic = validationDiagnostic;
                 }
-                else if (entry.HasAmbiguousBomlessUtf16)
+                else if (entry.HasBomlessUnicodeDoubt)
                 {
                     // The two byte orders are separate entries in the allowed set; the
                     // label matched only because .NET names both "utf-16". Passing the
@@ -633,7 +634,7 @@ internal static class ScanEngine
         Encoding? SourceEncoding,
         bool HasReliableUnicodeDetection,
         bool DetectedEncodingHasBom,
-        bool HasAmbiguousBomlessUtf16,
+        BomlessUnicodeKind BomlessUnicodeDoubt,
         bool HasBom,
         string Sha256,
         long Size);
@@ -675,7 +676,7 @@ internal static class ScanEngine
         bool detectedHasBom = detectedEncoding != null && HasPreamble(stream, detectedEncoding);
         bool hasReliableUnicodeDetection = IsReliablyDetectedUnicode(
             stream, detectedEncoding, detectedHasBom);
-        bool hasAmbiguousBomlessUtf16 = BomlessUnicodeSafety.IsAmbiguous(
+        BomlessUnicodeKind bomlessUnicodeDoubt = BomlessUnicodeSafety.Classify(
             stream, detectedEncoding, detectedHasBom);
 
         stream.Position = 0;
@@ -683,7 +684,7 @@ internal static class ScanEngine
 
         return new SourceSnapshot(
             detectedEncoding, sourceEncoding, hasReliableUnicodeDetection,
-            detectedHasBom, hasAmbiguousBomlessUtf16, hasBom, hash, stream.Length);
+            detectedHasBom, bomlessUnicodeDoubt, hasBom, hash, stream.Length);
     }
 
     private static bool IsReliablyDetectedUnicode(
@@ -710,13 +711,16 @@ internal static class ScanEngine
     /// Checks the whole current source before a direct conversion that did not receive
     /// a source-bound planning snapshot.
     /// </summary>
-    private static bool IsAmbiguousBomlessUtf16(
+    private static BomlessUnicodeKind ClassifyBomlessUnicode(
         string path,
         Encoding sourceEncoding,
         bool sourceHasBom)
     {
-        if (sourceHasBom || sourceEncoding.CodePage is not (1200 or 1201))
-            return false;
+        if (sourceHasBom ||
+            sourceEncoding.CodePage is not (1200 or 1201 or 12000 or 12001))
+        {
+            return BomlessUnicodeKind.None;
+        }
 
         using FileStream stream = new(
             path,
@@ -726,7 +730,7 @@ internal static class ScanEngine
             64 * 1024,
             FileOptions.SequentialScan);
 
-        return BomlessUnicodeSafety.IsAmbiguous(stream, sourceEncoding, sourceHasBom);
+        return BomlessUnicodeSafety.Classify(stream, sourceEncoding, sourceHasBom);
     }
 
     /// <summary>
@@ -830,16 +834,19 @@ internal static class ScanEngine
             ? entry.DetectedEncodingHasBom
             : sourceHasBom;
 
-        bool bomlessUtf16IsAmbiguous =
-            entry.HasAmbiguousBomlessUtf16 ||
-            (bomlessCandidate is not null && IsAmbiguousBomlessUtf16(
-                path, bomlessCandidate, candidateHasBom));
+        BomlessUnicodeKind bomlessUnicodeDoubt = entry.HasBomlessUnicodeDoubt
+            ? entry.BomlessUnicodeDoubt
+            : bomlessCandidate is null
+                ? BomlessUnicodeKind.None
+                : ClassifyBomlessUnicode(path, bomlessCandidate, candidateHasBom);
 
-        entry.HasAmbiguousBomlessUtf16 = bomlessUtf16IsAmbiguous;
+        entry.BomlessUnicodeDoubt = bomlessUnicodeDoubt;
 
         // The decision: refuse automatically only when nobody has supplied an answer.
-        bool automaticBomlessUtf16IsAmbiguous =
-            !entry.SourceEncodingWasSpecified && bomlessUtf16IsAmbiguous;
+        BomlessUnicodeKind automaticBomlessUnicodeDoubt =
+            entry.SourceEncodingWasSpecified
+                ? BomlessUnicodeKind.None
+                : bomlessUnicodeDoubt;
 
         PlannedAction action = ConversionPolicy.Decide(
             sourceCharset,
@@ -853,7 +860,7 @@ internal static class ScanEngine
             entry.SourceEncodingWasSpecified && entry.HasReliableUnicodeDetection &&
             automaticallyDetected is not null &&
             automaticallyDetected.CodePage != sourceEncoding.CodePage,
-            automaticBomlessUtf16IsAmbiguous,
+            automaticBomlessUnicodeDoubt,
             out SourceInterpretation sourceInterpretation,
             out string? policyReason);
 
@@ -873,7 +880,8 @@ internal static class ScanEngine
 
         entry.Action = action;
         entry.SourceInterpretation = sourceInterpretation;
-        entry.ReasonCode = ConversionPolicy.ReasonCodeFor(action, sourceInterpretation);
+        entry.ReasonCode = ConversionPolicy.ReasonCodeFor(
+            action, sourceInterpretation, automaticBomlessUnicodeDoubt);
 
         // A retry must not carry a diagnostic from an earlier failed attempt.
         // The optional BOM-less Unicode advisory below is added back for this pass.
@@ -885,7 +893,7 @@ internal static class ScanEngine
             automaticallyDetected is not null &&
             IsUtf16OrUtf32(automaticallyDetected) &&
             !entry.DetectedEncodingHasBom &&
-            (bomlessUtf16IsAmbiguous ||
+            (bomlessUnicodeDoubt != BomlessUnicodeKind.None ||
              automaticallyDetected.CodePage != sourceEncoding.CodePage))
         {
             bool matchesEstimate =
@@ -928,7 +936,7 @@ internal static class ScanEngine
         if (action != PlannedAction.Convert)
         {
             entry.Result = ConversionPolicy.ToRowResult(action);
-            entry.Diagnostic = automaticBomlessUtf16IsAmbiguous
+            entry.Diagnostic = automaticBomlessUnicodeDoubt != BomlessUnicodeKind.None
                 ? BomlessUnicodeSafety.DescribeRefusal(sourceEncoding)
                 : policyReason;
             return;

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -530,8 +530,10 @@ internal static class ScanEngine
                 else if (entry.HasBomlessUnicodeDoubt)
                 {
                     // Detection found an estimate, not a reading. Nothing failed, so
-                    // the result stays Unchanged; the row must still say which it is.
-                    entry.ReasonCode = ConversionReasonCodes.AmbiguousBomlessUtf16;
+                    // the result stays Unchanged; the row must still say which it is,
+                    // and say it with the same code conversion would use.
+                    entry.ReasonCode =
+                        BomlessUnicodeSafety.ReasonCodeFor(entry.BomlessUnicodeDoubt);
                     entry.Diagnostic =
                         BomlessUnicodeSafety.DescribeUnprovableByteOrder(detected!);
                 }
@@ -586,7 +588,8 @@ internal static class ScanEngine
                     // file would assert an identity EC cannot establish, and conversion
                     // refuses that same file later.
                     entry.Result = ConversionRowResult.Invalid;
-                    entry.ReasonCode = ConversionReasonCodes.AmbiguousBomlessUtf16;
+                    entry.ReasonCode =
+                        BomlessUnicodeSafety.ReasonCodeFor(entry.BomlessUnicodeDoubt);
                     entry.Diagnostic =
                         BomlessUnicodeSafety.DescribeUnprovableByteOrder(detected!)
                         + $" The label '{label}' is in the allowed list, but EC cannot"


### PR DESCRIPTION
Closes the two silent-corruption findings this project has carried longest, with one rule: **BOM-less UTF-32 is not accepted on detection alone.**

## The two findings

**A BOM-less UTF-16 file could be converted as UTF-32.** Text with one character per LF-terminated line puts a C0 control in every second code unit, so each four-byte group is an in-range unassigned scalar and the whole file decodes as valid UTF-32. EC converted it and wrote **different text** — U+0041 U+000A became U+A0041 — with exit 0. Output verification could not notice, because both sides of its comparison used the same wrong codec.

**Genuine BOM-less UTF-32 could be valid under both byte orders**, and detection preferred little-endian without saying so.

**Why the existing UTF-16 guard could not simply be widened.** That guard refuses BOM-less UTF-16 when the *opposite* byte order also decodes the file. The UTF-16 file above is **invalid** as UTF-32BE, so the same test returns false and would have passed it straight through. What the bytes fail to establish is the codec, not merely its byte order — so the refusal rests on the absence of a BOM.

## The cost, stated as a test

**Ordinary BOM-less UTF-32 is refused too.** Nothing in the bytes separates it from the corrupting case, so no test admits one and rejects the other. Two rows moved out of the conversion matrix's valid-conversion set to say so. A BOM or `-From` still converts it, both tested.

## What did not change

**No scalar classification.** The misdetection is possible because the text heuristic accepts unassigned scalars, and the tempting fix is to reject unassigned or private-use ones. That would break icon fonts, which put private-use characters in ordinary text files. A test converts U+E000, U+F8FF, U+E0B0, U+F00C and U+F0000 and checks all five survive.

`TextValidation.cs` and `UnicodeDetector.cs` are untouched — both are held byte-identical across three repositories by the parity workflow.

## Compatibility

**Conversion semantics move 6 → 7, so plans written by v3.12.1 or earlier are refused.** Re-run `-Plan`. That is the point of the version: such a plan can list files this build will not convert.

| Situation | Before | After |
|---|---|---|
| BOM-less UTF-32, any mode | converted, 0 | `Refused`, `UnprovableBomlessUtf32`, 5 |
| BOM-less UTF-16 that decodes as UTF-32 | converted to different text, 0 | `Refused`, 5 |
| A plan from v3.12.1 or earlier | applied | refused, 1 |

`UnprovableBomlessUtf32` is a new reason code rather than a reuse of the UTF-16 one: the doubt and the remedy differ.

## Verification

- **751 tests** pass, 0 skipped; Release build 0 warnings
- Verified end to end in Detect, Validate and Convert: same reason code in all three, refused sources byte-identical, all five private-use scalars preserved through a conversion
- Mutation-checked: removing the UTF-32 arm fails 3 of the 6 core tests, file restored byte-identical
- `BL-01` and `BL-18` marked fixed; the defect ledger checker passes at 46 fixed, 11 open

### The four-corpus audit

Run over all four corpora, 5,077 files. All four metrics unchanged from v3.11.0, with zero implementation defects, zero strict-decode throws and zero backup mismatches. Corpus integrity verified afterwards by re-hashing all 5,077 source files: zero modified. `check_audit_integrity.py` run **with `CORPUS_ROOT` set** — the failure mode the v3.11.0 record documents — passing coverage, ground truth, and 514 independently decoded files.

**It does not exercise this change.** The harness supplies `-From` for every file, and the refusal only fires on automatic detection, so `UnprovableBomlessUtf32` appears **zero times** in 5,077 files. The audit shows nothing else broke; it does not show the change works. What it does measure is the way out: 847 files carrying the BOM-less-doubt advisory converted with an explicit source, **all 847 text-identical**.

Detection is provably unchanged — both detection testers produced reports byte-identical to the committed ones.

### On the missing hash

The release notes quote no commit or assembly hash deliberately. Those belong in `docs/SAFETY-AUDIT.md`, which lands **after** the tag: committing it changes the assembly through the PDB checksum, so a hash quoted here would describe a build this branch is part of. Measured on this branch — two documentation commits moved the assembly hash with no code change.

The audit will be re-run against the tagged commit, and its record written afterwards naming that commit and its hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
