### PR TITLE
Record the v3.13.0 audited build, and file the missing evidence hash

### DIFF
--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=61 fixed=46 open=11 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
+<!-- backlog-counts total=62 fixed=46 open=12 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
 
-**Derived count: 61 findings — 46 fixed, 11 open, 1 not reproduced,
+**Derived count: 62 findings — 46 fixed, 12 open, 1 not reproduced,
 1 withdrawn, 1 not a defect, and 1 design decision.** Recompute and validate
 these figures with:
 
@@ -61,6 +61,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | BL-19 | NUL-heavy ASCII can be reported as BOM-less UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
 | BL-20 | Hard-linked paths are processed independently | Open | Low | Rare | [BL-20](#bl-20) |
 | BL-21 | Detection can accept a truncated trailing sequence that conversion rejects | Open | Low | Rare | [BL-21](#bl-21) |
+| BL-27 | Release evidence records no managed-assembly hash | Open | Low | Common | [BL-27](#bl-27) |
 
 ### Closed and other findings
 
@@ -593,6 +594,31 @@ proposal was rejected after it broke four existing tests and would have blocked
 an ordinary “wrong target, convert again” workflow until the user manually
 deleted recovery files. CX-02 instead ensures stale metadata cannot describe a
 new backup.
+
+### BL-27
+
+**The GUI smoke report names a managed-assembly hash it does not contain.**
+`RELEASE-CHECKLIST.md` states that the report carries "the executable and
+managed-assembly hashes", and several records in `SAFETY-AUDIT.md` repeat it.
+Checked against the v3.13.0 release evidence: `gui-smoke-report.json` has no
+`EcManagedAssemblySha256` key at all, and `gui-smoke-report.md` renders an empty
+pair of backticks — while both still print the `EncodingChecker.dll` path as
+though the value followed.
+
+The cause is that a single-file publish leaves no loose DLL at the path the
+suite looks for. That has held since single-file publishing began, so **v3.12.0
+and v3.12.1 carry the same empty field**, and the claim in their records is
+wrong the same way.
+
+Impact is low: the executable hash is present and real, and for v3.13.0 the
+published executable was reproduced byte-for-byte from the tagged commit, which
+is a stronger provenance link than the missing field would have provided. Reach
+is common, because it affects every release that ships a single-file build.
+
+The fix is a choice, not an omission to close blindly: either hash the publish
+intermediate `win-x64/EncodingChecker.dll`, or drop the field and the sentences
+that promise it. Recording the executable hash alone would be honest; promising
+two and delivering one is not.
 
 ### BL-22
 

--- a/docs/SAFETY-AUDIT.md
+++ b/docs/SAFETY-AUDIT.md
@@ -502,6 +502,136 @@ The rule this file already states about the product applies to the things that c
 - **Three backlog findings remain only partly reproducible** and are recorded as such: one needs force-close timing too precise to trigger, one needs a filesystem where `File.Replace` is unsupported, and the historical performance figures were not re-measured.
 - **No accessibility spot check is recorded** for this release. The checklist's scaling, keyboard-only, and high-contrast checks have no automated substitute, and nothing in the release job stands in for them.
 
+### v3.13.0 audited build
+
+The first release since v3.11.0 measured against the four corpora, and the first that had
+to be: it changes conversion policy, so the exemption v3.11.2, v3.12.0 and v3.12.1 claimed
+does not apply. Audited from a clean detached checkout of the commit it is tagged at.
+
+```
+commit    08858a68b31cbe769d476e605b2573c4a048a79b   (annotated tag v3.13.0)
+worktree  clean
+platform  .NET 10.0.400 - Windows 11 10.0.26200
+assembly  EncodingChecker.dll
+          b5761523da3af57072f735be93f369c2c3a6445cb25106d3328d219c4329869f
+run       v3130tag, compared against rel3110 in audit/reports/v3130tag-vs-rel3110
+```
+
+**No file changed outcome.** All four metrics are unchanged from v3.11.0, with zero
+implementation defects, zero strict-decode throws and zero backup-integrity mismatches per
+corpus.
+
+| | v3.11.0 | v3.13.0 |
+|---|---|---|
+| Detection accuracy | 4640/4646 (99.87%) | 4639/4645 (99.87%) |
+| Strict decoding | 4694/4694 (100.00%) | 4693/4693 (100.00%) |
+| Codec conformance | 4591/4694 (97.81%) | 4590/4693 (97.81%) |
+| Text preservation | 4520/4623 (97.77%) | 4519/4622 (97.77%) |
+
+`compare.py` reports `regressed=1`, and it is not one. A UTF-8 fixture present when
+v3.11.0 was audited is **absent from the corpus copy on disk**, so it joins as `(absent)`
+rather than as a changed outcome. The local UnicodeTestSuite holds 1,366 files where the
+published v3.0 holds 1,367. Every file present in both reached the same outcome.
+
+`check_audit_integrity.py` was run **with `CORPUS_ROOT` set** — the failure the v3.11.0
+record describes, where coverage and independent-hash checks are skipped and the run still
+prints that all invariants hold. Coverage 3166 / 478 / 67 / 1366, ground truth
+729 / 47 / 41 / 35, independent hashes 150 / 150 / 64 / 150: 514 files decoded and
+compared from scratch, outside the audit's own code path. All invariants hold across
+5,077 rows.
+
+**The source corpora were not modified.** Verified after the run by re-hashing all 5,077
+source files against the inventory captured before it: zero modified, zero missing.
+
+#### The audited build and the shipped build
+
+This release links the two by measurement rather than by assertion, which no earlier record
+does.
+
+The published single-file executable was **reproduced byte-for-byte** from the same clean
+checkout, on a different machine from the one that built it:
+
+```
+shipped by the release workflow  76f68a876b3385a711fe967b2243ade80109bb204d9d851f885912727e2760cc
+rebuilt locally from 08858a6     76f68a876b3385a711fe967b2243ade80109bb204d9d851f885912727e2760cc
+```
+
+The distinction that remains, and that every audited-build record here shares: **the audit
+measures the plain Release build, not the published one.** The harness invokes
+`bin/Release/net10.0-windows/EncodingChecker.exe`, while the release ships a `win-x64`
+single-file publish whose bundled managed assembly is
+`ba66a3438883963caaa083400ee10e0aa4599074dedb22e6978503c9a7f3f1b4`. Same commit, same SDK,
+different packaging. The reproduced executable hash is what ties the audited source to the
+shipped artifact; the assembly hash above identifies what the corpora were actually run
+against.
+
+#### What this audit cannot establish
+
+**It does not exercise the change this release makes.** The harness runs with a forced
+reference, supplying `-From` for every file, and v3.13.0 refuses BOM-less UTF-32 only when
+detection is *automatic*. `UnprovableBomlessUtf32` appears **zero times across 5,077
+files**.
+
+That belongs in the same breath as the clean result. A green audit on the first release in
+this line to change conversion policy reads as confirmation of the change, and it is not.
+It confirms that nothing else broke. What the change does rests on the unit and end-to-end
+tests, which drive the automatic path directly.
+
+The audit does measure the way out: 847 files carrying the BOM-less-doubt advisory were
+converted with an explicit source and **all 847 preserved their text exactly**. The escape
+hatch this release directs users to is measured at scale; the refusal that sends them there
+is not.
+
+**Detection is unchanged, and was checked rather than assumed.** Both detection testers
+produced reports byte-identical to the committed ones — 1,358 UnicodeTestSuite files and
+3,137 chardet files. Their headline accuracy is scored through an "also valid as"
+equivalence, so those percentages are used here only as a before-and-after identity check,
+never as ground truth.
+
+#### The GUI smoke evidence records no managed-assembly hash
+
+`RELEASE-CHECKLIST.md` states that the report carries "the executable and managed-assembly
+hashes", and several records above repeat it. The executable hash is real. The managed one
+is **absent**: `gui-smoke-report.json` has no `EcManagedAssemblySha256` key, and the
+Markdown renders an empty pair of backticks, while both still name the
+`EncodingChecker.dll` path as though the value were there.
+
+It is absent because a single-file publish leaves no loose DLL at that path. That has been
+true since single-file publishing began, so **v3.12.0 and v3.12.1 carry the same empty
+field** and the claim in their records is wrong in the same way. Filed rather than fixed
+here; this release changes no release tooling.
+
+#### What changed in v3.13.0
+
+| | |
+|---|---|
+| A BOM-less UTF-16 file that also decodes as UTF-32 | Was converted, rewriting U+0041 U+000A as U+A0041 with exit 0. Output verification could not notice: both sides of its comparison used the same wrong codec. Refused now. |
+| BOM-less UTF-32 valid under both byte orders | Detection preferred little-endian without saying so. Refused now. |
+| Ordinary BOM-less UTF-32 | Refused as well. Nothing in the bytes separates it from the first row, so no test admits one and rejects the other. A BOM or `-From` still converts it. |
+| Conversion semantics | 6 to 7. Plans written by v3.12.1 or earlier are refused rather than applied. |
+
+Widening the guard that protects BOM-less UTF-16 would not have closed the first row: those
+bytes are invalid under the opposite UTF-32 order, so an opposite-order test passes them
+through. What the bytes fail to establish is the codec, not merely its byte order.
+
+No scalar classification changed. Rejecting unassigned or private-use scalars would have
+been the smaller-looking fix and would have broken icon fonts, which put private-use
+characters in ordinary text files. `TextValidation.cs` and `UnicodeDetector.cs` are
+untouched.
+
+#### Known limits specific to this release
+
+- **The audit cannot reach the changed path**, as described above.
+- **Code signing did not run.** The signing secrets are still not configured, so the
+  archives are unsigned and the GUI suite drove an unsigned executable. Fourth release
+  running.
+- **The GUI evidence carries no managed-assembly hash**, as described above.
+- **The corpus copy is one file short** of the published UnicodeTestSuite v3.0.
+- **No accessibility spot check** is recorded for this release.
+- **The v3.12.0 gap is not closed by this release.** That build changed `ConversionPolicy`
+  and shipped without a corpus run; nothing here re-audits it. Its record stands as
+  written.
+
 ## Known limits
 
 - No detector can recover an author's historical legacy encoding when the same bytes admit multiple plausible readings. EC refuses automatic legacy conversion instead of guessing.


### PR DESCRIPTION
The `docs/SAFETY-AUDIT.md` record for [v3.13.0](https://github.com/amrali-eg/EncodingChecker/releases/tag/v3.13.0), plus one finding the audit turned up about the release evidence itself. Two files, +158/−2.

It arrives after its own tag for the reason this file documents: committing it changes the assembly through the PDB checksum, so recording it first would publish artifacts naming a hash they do not contain. That effect was measured on this release rather than assumed — two documentation commits moved the assembly hash with no code change, which is why the audit was re-run against the tagged commit rather than the branch tip that first produced it.

## The first audited build since v3.11.0

This is the first release in this line that had to have one: it changes conversion policy, so the exemption v3.11.2, v3.12.0 and v3.12.1 claimed does not apply.

Audited from a clean detached checkout of `08858a6`, the commit the tag points at. All four metrics unchanged from v3.11.0, zero implementation defects, zero strict-decode throws, zero backup-integrity mismatches.

`check_audit_integrity.py` was run **with `CORPUS_ROOT` set** — the failure mode the v3.11.0 record describes, where coverage and independent-hash checks are silently skipped and the run still prints that all invariants hold. Real figures recorded, including 514 files decoded and compared from scratch outside the audit's own code path. Source corpora re-hashed afterwards: zero modified.

## Two things stated beside the clean result, not after it

**`compare.py` reports one regression that is not one.** A UTF-8 fixture present when v3.11.0 was audited is absent from the corpus copy on disk, so it joins as `(absent)` rather than as a changed outcome.

**The audit cannot reach the path this release changes.** The harness supplies `-From` for every file, and the refusal only fires on automatic detection, so the new reason code appears **zero times in 5,077 files**. A green audit on a release that changed conversion policy reads as confirmation of that change, and it is not. What the audit does measure is the escape hatch: 847 files carrying the BOM-less-doubt advisory converted with an explicit source, all 847 text-identical.

## Audited build vs shipped build, measured

The published single-file executable was **reproduced byte-for-byte** from the same clean checkout, on a different machine from the one that built it:

```
shipped by the release workflow  76f68a876b3385a711fe967b2243ade80109bb204d9d851f885912727e2760cc
rebuilt locally from 08858a6     76f68a876b3385a711fe967b2243ade80109bb204d9d851f885912727e2760cc
```

No earlier record links the two this way. The distinction that remains is kept rather than blurred: the audit measures the plain Release build, the release ships a `win-x64` single-file publish. Same commit, same SDK, different packaging.

## BL-27 — the release evidence names a hash it does not contain

`RELEASE-CHECKLIST.md` states the GUI smoke report carries "the executable and managed-assembly hashes", and several records repeat it. The executable hash is real; the managed one is **absent**. `gui-smoke-report.json` has no `EcManagedAssemblySha256` key, and the Markdown renders an empty pair of backticks — while both still print the `EncodingChecker.dll` path as though a value followed.

A single-file publish leaves no loose DLL where the suite looks, so this has held since single-file publishing began: **v3.12.0 and v3.12.1 carry the same empty field**, and the claim in their records is wrong the same way.

Filed as open (Low impact, Common reach) rather than fixed, because this release changes no release tooling, and because the fix is a choice: hash the publish intermediate, or stop promising the field. Recording the executable hash alone would be honest; promising two and delivering one is not.

## Verification

Documentation only — no code, no tests, no behaviour. CRLF and both files' no-BOM choice preserved. The ledger checker passes at 62 findings, 46 fixed, 12 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
