### PR TITLE
Say what a plan's semantics version means, and release v3.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.13.0
+# EncodingChecker v3.14.0
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -56,7 +56,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-18 | A negative BOM-less UTF-16 ambiguity result is recomputed | Open | Low | Common | [EC-18](#ec-18) |
 | EC-20 | Detection permits concurrent writes and deletes | Open | Low | Rare | [EC-20](#ec-20) |
 | EC-23 | Plan application relies on a null-forgiving path dereference | Open | Low | Rare | [EC-23](#ec-23) |
-| CX-06 | The entropy gate runs before BOM detection | Open | Medium | Occasional | [CX-06](#cx-06) |
+| CX-06 | The entropy gate runs before BOM detection | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a run can race UI callbacks | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | NUL-heavy ASCII can be reported as BOM-less UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
 | BL-20 | Hard-linked paths are processed independently | Open | Low | Rare | [BL-20](#bl-20) |
@@ -192,11 +192,31 @@ why leaving that invariant implicit is fragile.
 
 ### CX-06
 
-**High entropy can hide an otherwise valid BOM.** At current
-`TextEncoding.cs:175`, the entropy guard returns before
-`UnicodeDetector.DetectFromBuffer` examines the BOM at line 182. The result can
-be an unknown or wrong encoding even when the file declares it. This changes
-what EC reports; it is not evidence that conversion writes the file.
+**High entropy can hide an otherwise valid BOM.** The entropy guard returns
+before `UnicodeDetector.DetectFromBuffer` examines the BOM. The result can be an
+unknown or wrong encoding even when the file declares it. This changes what EC
+reports; it is not evidence that conversion writes the file.
+
+**Re-scored Occasional to Theoretical on 2026-09-08, after measurement.** No
+text reaches the gate. Across all four corpora, 3,620 files are large enough to
+be gated (512 bytes) and 47 trip the 7.4-bit threshold — every one of them
+binary: 35 fixtures under `13_Binary/`, plus images and a spreadsheet in
+directories the corpora label `None`. The highest-entropy *text* file among 3,568
+candidates is dense Chinese XML in gb2312 at **6.8133**, a margin of 0.59 below
+the threshold, with UTF-16 Chinese just behind it. Base64 caps at 6.0 by
+construction. Reaching 7.4 needs a near-uniform byte distribution, which prose
+in any encoding does not produce.
+
+**A fix was written and then dropped**, which is the part worth recording. Making
+the guard yield to a byte-order mark works, and costs something measurable:
+`CheckBom` returns a codec from the marker bytes alone, so BOM-prefixed binary
+began detecting as `utf-16` instead of `(Unknown)`, and a scan containing one
+moved from exit 0 to exit 3. Strict validation still caught it and no bytes
+changed, so nothing was corrupted — but that is a measured behaviour change
+bought against a benefit no corpus file demonstrates.
+
+Reopen this on evidence of real text at or above the threshold, not on the
+mechanism, which is not in doubt.
 
 ### BL-01
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=62 fixed=47 open=11 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
+<!-- backlog-counts total=62 fixed=50 open=8 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
 
-**Derived count: 62 findings — 47 fixed, 11 open, 1 not reproduced,
+**Derived count: 62 findings — 50 fixed, 8 open, 1 not reproduced,
 1 withdrawn, 1 not a defect, and 1 design decision.** Recompute and validate
 these figures with:
 
@@ -52,15 +52,12 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 |---|---|---|---|---|---|
 | EC-08 | An include pattern can hang a scan indefinitely | Open | Medium | Theoretical | [EC-08](#ec-08) |
 | EC-17 | A text-validation comment contradicts the calculation | Open | Low | Common | [EC-17](#ec-17) |
-| EC-18 | A negative BOM-less UTF-16 ambiguity result is recomputed | Open | Low | Common | [EC-18](#ec-18) |
 | EC-20 | Detection permits concurrent writes and deletes | Open | Low | Rare | [EC-20](#ec-20) |
-| EC-23 | Plan application relies on a null-forgiving path dereference | Open | Low | Rare | [EC-23](#ec-23) |
 | CX-06 | The entropy gate runs before BOM detection | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a run can race UI callbacks | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | NUL-heavy ASCII can be reported as BOM-less UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
 | BL-20 | Hard-linked paths are processed independently | Open | Low | Rare | [BL-20](#bl-20) |
 | BL-21 | Detection can accept a truncated trailing sequence that conversion rejects | Open | Low | Rare | [BL-21](#bl-21) |
-| BL-27 | Release evidence records no managed-assembly hash | Open | Low | Common | [BL-27](#bl-27) |
 
 ### Closed and other findings
 
@@ -71,6 +68,9 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-03 | The GUI omitted the source-choice advisory | Fixed | — | — | [EC-03](#ec-03) |
 | EC-04 | `-Plan` could exit successfully after scan failures | Fixed | — | — | [EC-04](#ec-04) |
 | BL-01 | Ambiguous BOM-less UTF-32 can be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
+| EC-18 | A negative BOM-less UTF-16 ambiguity result is recomputed | Fixed | — | — | [EC-18](#ec-18) |
+| EC-23 | Plan application relies on a null-forgiving path dereference | Fixed | — | — | [EC-23](#ec-23) |
+| BL-27 | Release evidence records no managed-assembly hash | Fixed | — | — | [BL-27](#bl-27) |
 | EC-15 | Serialized conversion guarantees are not enforced individually | Fixed | — | — | [EC-15](#ec-15) |
 | BL-18 | BOM-less UTF-16 can be detected and converted as UTF-32 | Fixed | — | — | [BL-18](#bl-18) |
 | EC-05 | An unreadable non-conversion plan entry made a plan unusable | Fixed | — | — | [EC-05](#ec-05) |
@@ -179,12 +179,16 @@ CorpusTesters, so its correction must be synchronized.
 
 ### EC-18
 
-**Only a positive ambiguity result is cached.** In `ScanEngine`,
-`entry.HasAmbiguousBomlessUtf16 || IsAmbiguousBomlessUtf16(...)` short-circuits
-when the stored value is true. A stored false runs the full check again on each
-pass. Measurement found no meaningful cost because a provable file normally
-fails the opposite-order decode in its first buffer; the issue is redundant
-work and unclear state, not observed slowness.
+**Fixed.** The classification is cached as a nullable value, so null means not
+yet classified and `None` means classified with no doubt found. Both are stored,
+and the file is examined once.
+
+Was: only a positive result was kept, so an already-cleared file ran the full
+opposite-order check again on every pass. Measurement found no meaningful cost,
+because a provable file fails that decode in its first buffer; the defect was
+redundant work and a state that could not distinguish "no" from "not asked".
+
+No observable behaviour changes, so this carries no test of its own.
 
 ### EC-20
 
@@ -197,11 +201,14 @@ own bound snapshot before writing.
 
 ### EC-23
 
-**Plan application still depends on ordering to make a nullable path non-null.**
-At the current source location `Program.CliExecution.cs:90`, the code uses
-`plan.ResolvePath(f)!`. `FindStaleFiles` validates the same paths 29 lines
-earlier, so the dereference is safe under the present flow. EC-06 demonstrates
-why leaving that invariant implicit is fragile.
+**Fixed.** The null-forgiving dereference is now an explicit throw that names the
+invariant it rests on: `FindStaleFiles` rejects a plan whose paths resolve
+outside its directory, and reaching the dereference means that check did not
+run.
+
+Under the present flow nothing changes, which is why there is nothing new to
+assert and no test accompanies it. EC-06 is what happened when an invariant of
+this shape was left implicit.
 
 ### CX-06
 
@@ -630,28 +637,25 @@ new backup.
 
 ### BL-27
 
-**The GUI smoke report names a managed-assembly hash it does not contain.**
-`RELEASE-CHECKLIST.md` states that the report carries "the executable and
-managed-assembly hashes", and several records in `SAFETY-AUDIT.md` repeat it.
-Checked against the v3.13.0 release evidence: `gui-smoke-report.json` has no
-`EcManagedAssemblySha256` key at all, and `gui-smoke-report.md` renders an empty
-pair of backticks — while both still print the `EncodingChecker.dll` path as
-though the value followed.
+**Fixed by promising only what the build being driven can show.** The report
+hashes a loose managed assembly when one sits beside the executable, and says
+there is none when it does not, rather than printing a path with an empty hash
+after it. `RELEASE-CHECKLIST.md` and `GUI-SMOKE-TEST.md` describe both cases.
+The executable *is* the artifact, so its hash is the provenance that matters;
+v3.13.0 demonstrated the stronger form by reproducing that hash byte-for-byte
+from the tagged commit.
 
-The cause is that a single-file publish leaves no loose DLL at the path the
-suite looks for. That has held since single-file publishing began, so **v3.12.0
-and v3.12.1 carry the same empty field**, and the claim in their records is
-wrong the same way.
+Was: `gui-smoke-report.json` carried no `EcManagedAssemblySha256` key and the
+Markdown rendered an empty pair of backticks, while both printed the
+`EncodingChecker.dll` path as though a value followed — because a single-file
+publish leaves no loose DLL where the suite looked. That held since single-file
+publishing began, so the v3.12.0 and v3.12.1 evidence carries the same empty
+field.
 
-Impact is low: the executable hash is present and real, and for v3.13.0 the
-published executable was reproduced byte-for-byte from the tagged commit, which
-is a stronger provenance link than the missing field would have provided. Reach
-is common, because it affects every release that ships a single-file build.
-
-The fix is a choice, not an omission to close blindly: either hash the publish
-intermediate `win-x64/EncodingChecker.dll`, or drop the field and the sentences
-that promise it. Recording the executable hash alone would be honest; promising
-two and delivering one is not.
+The alternative, hashing the publish intermediate `win-x64/EncodingChecker.dll`,
+was rejected: it exists only during the build and no user ever receives it, so
+recording it would document a byproduct rather than the release. Nothing about
+conversion was involved either way; this is evidence hygiene.
 
 ### BL-22
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=62 fixed=46 open=12 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
+<!-- backlog-counts total=62 fixed=47 open=11 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
 
-**Derived count: 62 findings — 46 fixed, 12 open, 1 not reproduced,
+**Derived count: 62 findings — 47 fixed, 11 open, 1 not reproduced,
 1 withdrawn, 1 not a defect, and 1 design decision.** Recompute and validate
 these figures with:
 
@@ -51,7 +51,6 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | ID | Finding | Status | Impact | Reach | Details |
 |---|---|---|---|---|---|
 | EC-08 | An include pattern can hang a scan indefinitely | Open | Medium | Theoretical | [EC-08](#ec-08) |
-| EC-15 | Serialized conversion guarantees are not enforced individually | Open | Low | Common | [EC-15](#ec-15) |
 | EC-17 | A text-validation comment contradicts the calculation | Open | Low | Common | [EC-17](#ec-17) |
 | EC-18 | A negative BOM-less UTF-16 ambiguity result is recomputed | Open | Low | Common | [EC-18](#ec-18) |
 | EC-20 | Detection permits concurrent writes and deletes | Open | Low | Rare | [EC-20](#ec-20) |
@@ -72,6 +71,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-03 | The GUI omitted the source-choice advisory | Fixed | — | — | [EC-03](#ec-03) |
 | EC-04 | `-Plan` could exit successfully after scan failures | Fixed | — | — | [EC-04](#ec-04) |
 | BL-01 | Ambiguous BOM-less UTF-32 can be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
+| EC-15 | Serialized conversion guarantees are not enforced individually | Fixed | — | — | [EC-15](#ec-15) |
 | BL-18 | BOM-less UTF-16 can be detected and converted as UTF-32 | Fixed | — | — | [BL-18](#bl-18) |
 | EC-05 | An unreadable non-conversion plan entry made a plan unusable | Fixed | — | — | [EC-05](#ec-05) |
 | EC-06 | A drive-root base path made every plan unusable | Fixed | — | — | [EC-06](#ec-06) |
@@ -148,12 +148,25 @@ the intended `src/*.cs` directory behavior.
 
 ### EC-15
 
-**The five serialized guarantee flags look enforceable but are descriptive.**
-`ConversionSemantics` writes `StrictDecoding`, `StrictEncoding`,
-`OutputVerification`, `AtomicInstall`, and `LegacyRequiresExplicitSource`.
-`ConversionPlan.Load` enforces `SemanticsVersion` only. EC always executes its
-current strict behavior, so this cannot weaken conversion, but a reader may
-mistake a serialized `true` value for proof that the specific check ran.
+**Fixed as an artifact-clarity simplification, not a conversion-safety defect.**
+The five flags are gone. Plans and journals now carry `SemanticsDescription` -
+the sentence `ConversionSemantics.Describes` already held - beside the version
+number, so a reader gets what the version means instead of five constants.
+`SemanticsVersion` remains the only enforced compatibility value, and a test
+proves the description is never consulted: altering it in a plan file changes
+nothing about whether that plan loads.
+
+Was: `StrictDecoding`, `StrictEncoding`, `OutputVerification`, `AtomicInstall`
+and `LegacyRequiresExplicitSource` were serialized into every plan and journal,
+hardcoded `true`, and read by nothing. They could not disagree with the version,
+so they were a second encoding of it that a reader could mistake for evidence a
+particular check had run. EC always executed its strict behaviour; only the
+artifact implied otherwise.
+
+The artifacts changed shape, so their versions say so: plan schema 5 to 6,
+journal schema 4 to 5. That rejects plans written by v3.13.0 as well as older
+ones - semantics 7 shipped in that release, so this is not the free change it
+would have been a day earlier.
 
 ### EC-17
 

--- a/docs/GUI-SMOKE-TEST.md
+++ b/docs/GUI-SMOKE-TEST.md
@@ -19,8 +19,10 @@ sources/EncodingChecker.GuiSmoke/bin/Release/net10.0-windows/EncodingChecker.Gui
 
 Exit `0` when every phase passes, `1` when one fails, `2` for a usage, environment, or
 build-compatibility problem. Each run writes `gui-smoke-report.json` and `gui-smoke-report.md` carrying the
-EC version, the executable and managed-assembly SHA-256, the OS and .NET versions, and
-each phase's before and after file hashes.
+EC version, the executable SHA-256, the OS and .NET versions, and each phase's before and
+after file hashes. It also hashes the managed assembly beside the executable when there
+is one, as in an ordinary Release build. A single-file publish has none, and the report
+says so instead of naming a file it could not read.
 
 ## Why this is not an ordinary test
 

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -58,8 +58,11 @@ sources/EncodingChecker.GuiSmoke/bin/Release/net10.0-windows/EncodingChecker.Gui
 ```
 
 Exit 0 is a pass. Each run writes `gui-smoke-report.json` and `gui-smoke-report.md`
-carrying the EC version, the executable and managed-assembly hashes, and every phase's
-before and after file hashes.
+carrying the EC version, the executable hash, and every phase's before and after file
+hashes. Driven against an ordinary Release build it also hashes the managed assembly
+beside the executable; driven against a single-file publish there is none, and it says so.
+Either way the executable is the artifact, and reproducing its hash from the tagged commit
+is what ties a release to its source.
 
 **[What each of the ten phases proves, and what it would catch →](GUI-SMOKE-TEST.md)**
 
@@ -89,9 +92,9 @@ checks the status line *against* the bytes on disk rather than trusting it.
 ### Record
 
 The ten phases record themselves. `gui-smoke-report.md` and `gui-smoke-report.json`
-already carry the EC version, the executable and managed-assembly hashes, the OS and
-.NET versions, and every phase's before and after file hashes — better evidence than a
-transcribed letter, and not subject to a typo. Keep both files with the release.
+already carry the EC version, the executable hash, the OS and .NET versions, and every
+phase's before and after file hashes — better evidence than a transcribed letter, and not
+subject to a typo. Keep both files with the release.
 
 What still needs a person is the spot check above, because nobody has automated a
 judgement about whether text is readable. Fill this in and keep it alongside them.

--- a/docs/RELEASE-NOTES-v3.14.0.md
+++ b/docs/RELEASE-NOTES-v3.14.0.md
@@ -1,0 +1,148 @@
+# EncodingChecker v3.14.0
+
+Four backlog findings closed, one dropped after measurement, and a change to the shape of
+the plan and journal files. That last one is why this is a minor release: the artifacts
+changed, so their schema versions say so, and a plan written by v3.13.0 is refused.
+
+No detection or conversion policy changes. What EC converts, refuses and reports for any
+input is exactly what v3.13.0 did.
+
+## A plan says what its version means, instead of five constants that could not disagree
+
+Every plan and journal carried five booleans — `StrictDecoding`, `StrictEncoding`,
+`OutputVerification`, `AtomicInstall` and `LegacyRequiresExplicitSource` — hardcoded
+`true`, written on every run, and read back by nothing. The same build wrote the flags and
+the semantics version they sat beside, so they could never disagree with it. What they
+could do is invite a reader to take a serialized `true` as evidence that a particular check
+ran on that file.
+
+They are gone. In their place is `SemanticsDescription`: the sentence
+`ConversionSemantics.Describes` already held, written beside the version number, so whoever
+opens a plan reads what the version means rather than five constants to interpret.
+
+`SemanticsVersion` stays the only value `Load` enforces, and a test proves the description
+decides nothing — altering it inside a plan file changes nothing about whether that plan
+loads.
+
+**This is artifact clarity, not a conversion-safety fix.** EC always executed the strict
+behaviour those flags described. Only the file implied that the flags were the reason.
+
+### What it costs
+
+The artifacts changed shape, so their versions say so: plan schema 5 to 6, journal schema 4
+to 5. **A plan written by v3.13.0 or earlier is refused** and has to be re-planned and
+reviewed again — even though this build would make exactly the decisions that plan records,
+because conversion semantics are unchanged at 7.
+
+Landing a day earlier this would have cost nothing: semantics moved 6 to 7 in v3.13.0, so
+every plan older than that release was already refused. It did not land earlier. This is a
+real cost paid for a clearer artifact, and a reader deciding whether to upgrade should
+weigh it that way.
+
+## A file already cleared is not examined again
+
+`ScanEngine` cached only a *positive* BOM-less ambiguity result:
+`entry.HasAmbiguousBomlessUtf16 || IsAmbiguousBomlessUtf16(...)` short-circuits when the
+stored value is true, so a stored false ran the full opposite-order decode again on every
+pass.
+
+The classification is now stored as a nullable value — null means not yet classified,
+`None` means classified with nothing found. Both are kept, and a file is examined once.
+
+**This is not a performance fix.** Measurement found no meaningful cost in the old form,
+because a provable file fails the opposite-order decode inside its first buffer. The defect
+was a stored state that could not distinguish "no" from "not asked". Nothing observable
+changes, which is why it carries no test of its own.
+
+## Plan application names the invariant it rests on
+
+Applying a plan used `plan.ResolvePath(f)!`. The dereference was safe — `FindStaleFiles`
+rejects a plan whose paths resolve outside its directory, twenty-nine lines earlier. It was
+safe because of the order of two calls, and nothing said so.
+
+It is now an explicit throw naming that invariant: reaching it means the check did not run.
+Under the present flow nothing changes, so there is nothing new to assert and no test
+accompanies it. EC-06 is what happened the last time an invariant of this shape was left
+implicit.
+
+## Release evidence promises only what the build being driven can show
+
+`RELEASE-CHECKLIST.md` and `GUI-SMOKE-TEST.md` both stated that the smoke report carries
+"the executable and managed-assembly hashes". Checked against real release evidence:
+`gui-smoke-report.json` carried no managed-assembly hash and the Markdown rendered an empty
+pair of backticks, while both printed the `EncodingChecker.dll` path as though a value
+followed.
+
+The release workflow drives the *published* executable, and a single-file publish leaves no
+loose DLL beside it. That has held since single-file publishing began, so **the v3.12.0 and
+v3.12.1 evidence carries the same empty field**, and the claim in their records is wrong the
+same way.
+
+The report now records the assembly only when there is one to hash, and says there is none
+when there is not. Both documents describe both cases, because both happen: driven against
+an ordinary Release build the suite does find a loose assembly and hashes it; driven against
+the published single-file executable, as the release workflow does, it does not.
+
+Hashing the publish intermediate was considered and rejected: it exists only during the
+build and no user ever receives it, so recording it would document a byproduct rather than
+the release. The executable is the artifact — v3.13.0 showed the stronger form by
+reproducing its hash byte-for-byte from the tagged commit.
+
+Nothing about conversion was involved either way. This is evidence hygiene.
+
+## A fix that was written, measured, and dropped
+
+CX-06 records that the entropy guard returns before the byte-order mark is examined, so a
+high-entropy file can be reported as unknown even when it declares its encoding. It was
+scored Occasional. That score had never been measured.
+
+It has been now. Across all four corpora, 3,620 files are large enough to be gated at 512
+bytes and 47 trip the 7.4-bit threshold — every one of them binary: 35 fixtures under
+`13_Binary/`, plus images and a spreadsheet. The highest-entropy *text* file among 3,568
+candidates is dense Chinese XML in gb2312 at **6.8133**, a margin of 0.59 below the
+threshold. Base64 caps at 6.0 by construction. Reaching 7.4 needs a near-uniform byte
+distribution, which prose does not produce in any encoding.
+
+**The fix worked and was dropped anyway.** Making the guard yield to a byte-order mark is a
+few lines, and it costs something measurable: `CheckBom` returns a codec from the marker
+bytes alone, so BOM-prefixed binary began detecting as `utf-16` instead of `(Unknown)`, and
+a scan containing one moved from exit 0 to exit 3. Strict validation still caught it and no
+bytes changed. But that is a measured behaviour change bought against a benefit no file in
+3,568 demonstrates.
+
+The row is re-scored Occasional to Theoretical and stays open. Reopen it on evidence of real
+text at or above the threshold — not on the mechanism, which was never in doubt.
+
+## Compatibility
+
+**The plan schema moves from 5 to 6 and the journal schema from 4 to 5. A plan written by
+v3.13.0 or earlier is refused.** Re-run `-Plan` and review the result.
+
+Conversion semantics stay at **7**.
+
+| Situation | Before | After |
+|---|---|---|
+| A plan from v3.13.0 or earlier | applied | refused, 1 |
+| `Semantics` in a plan or journal | five `true` flags | `SemanticsDescription`, one sentence |
+
+Every exit code, reason code, report column and other journal field is unchanged, and
+detection and conversion behave exactly as they did in v3.13.0.
+
+## Verification
+
+- 755 tests pass, none skipped (was 751); release build with no warnings
+- The four new tests were mutation-checked one at a time. Each mutation built cleanly and
+  failed exactly the test aimed at it: the plan stops carrying the description, the removed
+  flags come back, the journal stops carrying the description, and `Load` starts consulting
+  the description. Both source files restored byte-identical, confirmed by SHA-256
+- The GUI smoke suite passes all ten phases against **both** builds — the ordinary Release
+  build, where it finds a loose managed assembly and hashes it, and the published
+  single-file executable, where it reports that there is none. That is the evidence fix in
+  both of its branches, checked rather than argued
+- `docs/Test-DefectBacklog.ps1` passes at **62 findings — 50 fixed, 8 open**
+- **EC-18 and EC-23 carry no tests, deliberately.** Neither changes observable behaviour, so
+  a test would pin the shape of the code rather than anything EC promises. The backlog
+  records that reasoning rather than leaving them to look untested by oversight
+- **No four-corpus audit was run.** This release changes no detection or conversion policy,
+  so the checklist does not require one. The CX-06 measurement above did read all four
+  corpora, but as measurement, not as an audit

--- a/docs/SAFETY-AUDIT.md
+++ b/docs/SAFETY-AUDIT.md
@@ -646,8 +646,9 @@ never as ground truth.
 
 #### The GUI smoke evidence records no managed-assembly hash
 
-`RELEASE-CHECKLIST.md` states that the report carries "the executable and managed-assembly
-hashes", and several records above repeat it. The executable hash is real. The managed one
+`RELEASE-CHECKLIST.md` said at this release that the report carries "the executable and
+managed-assembly hashes", as did `GUI-SMOKE-TEST.md` in its own phrasing; both were
+corrected afterwards. The executable hash is real. The managed one
 is **absent**: `gui-smoke-report.json` has no `EcManagedAssemblySha256` key, and the
 Markdown renders an empty pair of backticks, while both still name the
 `EncodingChecker.dll` path as though the value were there.

--- a/sources/EncodingChecker.GuiSmoke/Program.cs
+++ b/sources/EncodingChecker.GuiSmoke/Program.cs
@@ -40,13 +40,20 @@ internal static class Program
             string workspace = Path.Combine(options.Output, "workspace");
             Directory.CreateDirectory(workspace);
 
+            // Record the assembly path only when there is one to hash, so the report
+            // never names a file it could not read.
+            string? managedAssembly = ManagedAssemblyPath(options.App);
+            string? managedAssemblySha256 = HashIfPresent(managedAssembly);
+            if (managedAssemblySha256 is null)
+                managedAssembly = null;
+
             var suite = new SmokeSuite(options.App, workspace);
             SmokeReport report = suite.Run(options.Phase) with
             {
                 EcVersion = FileVersionInfo.GetVersionInfo(options.App).FileVersion
                             ?? "unknown",
-                EcManagedAssembly = ManagedAssemblyPath(options.App),
-                EcManagedAssemblySha256 = HashIfPresent(ManagedAssemblyPath(options.App)),
+                EcManagedAssembly = managedAssembly,
+                EcManagedAssemblySha256 = managedAssemblySha256,
             };
 
             WriteReports(options.Output, report);
@@ -117,9 +124,25 @@ internal static class Program
             .AppendLine()
             .AppendLine($"- Result: **{(report.Passed ? "PASS" : "FAIL")}**")
             .AppendLine($"- EC version: `{report.EcVersion}`")
-            .AppendLine($"- Executable SHA-256: `{report.EcSha256}`")
-            .AppendLine($"- Managed assembly: `{report.EcManagedAssembly}`")
-            .AppendLine($"- Managed assembly SHA-256: `{report.EcManagedAssemblySha256}`")
+            .AppendLine($"- Executable SHA-256: `{report.EcSha256}`");
+
+        // Two lines when a loose assembly is there to hash, one sentence when it is not.
+        // Never a path with an empty hash beside it, and never a blank line in the list.
+        if (report.EcManagedAssemblySha256 is { Length: > 0 })
+        {
+            markdown
+                .AppendLine($"- Managed assembly: `{report.EcManagedAssembly}`")
+                .AppendLine(
+                    $"- Managed assembly SHA-256: `{report.EcManagedAssemblySha256}`");
+        }
+        else
+        {
+            markdown.AppendLine(
+                "- Managed assembly: none; a single-file publish leaves no loose "
+                + "assembly, so only the executable above is hashed");
+        }
+
+        markdown
             .AppendLine($"- Started UTC: `{report.StartedUtc}`")
             .AppendLine($"- Completed UTC: `{report.CompletedUtc}`")
             .AppendLine($"- Windows: `{report.OS}`")

--- a/sources/EncodingChecker.Tests/ConversionJournalTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionJournalTests.cs
@@ -292,8 +292,7 @@ public sealed class ConversionJournalTests : IDisposable
 
         Assert.Equal(ConversionJournal.CurrentJournalVersion, journal.JournalVersion);
         Assert.Equal(ConversionSemantics.Current, journal.SemanticsVersion);
-        Assert.True(journal.Semantics.StrictDecoding);
-        Assert.True(journal.Semantics.LegacyRequiresExplicitSource);
+        Assert.Equal(ConversionSemantics.Describes, journal.SemanticsDescription);
         Assert.Equal("CommandLine", journal.Surface);
         Assert.Equal("utf-8", journal.TargetEncoding);
         Assert.False(journal.TargetHasBom);

--- a/sources/EncodingChecker.Tests/ConversionPlanTests.cs
+++ b/sources/EncodingChecker.Tests/ConversionPlanTests.cs
@@ -542,11 +542,7 @@ public sealed class ConversionPlanTests : IDisposable
         Assert.Equal(Path.GetFullPath(_root), plan.BaseDirectory);
         Assert.NotEmpty(plan.EcVersion);
 
-        Assert.True(plan.Semantics.StrictDecoding);
-        Assert.True(plan.Semantics.StrictEncoding);
-        Assert.True(plan.Semantics.OutputVerification);
-        Assert.True(plan.Semantics.AtomicInstall);
-        Assert.True(plan.Semantics.LegacyRequiresExplicitSource);
+        Assert.Equal(ConversionSemantics.Describes, plan.SemanticsDescription);
 
         PlannedFile file = Assert.Single(plan.Files);
         Assert.Equal("shift_jis", file.DetectedEncoding);

--- a/sources/EncodingChecker.Tests/SemanticsArtifactShapeTests.cs
+++ b/sources/EncodingChecker.Tests/SemanticsArtifactShapeTests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A plan and a journal say what their semantics version guarantees, and claim nothing
+/// they do not check.
+/// </summary>
+/// <remarks>
+/// EC-15. A guarantee flag that no build can vary is not evidence a check ran, so the
+/// artifacts name their semantics version and describe it, and claim nothing else.
+/// </remarks>
+public sealed class SemanticsArtifactShapeTests : IDisposable
+{
+    private static readonly string[] RemovedFlags =
+    [
+        "StrictDecoding",
+        "StrictEncoding",
+        "OutputVerification",
+        "AtomicInstall",
+        "LegacyRequiresExplicitSource",
+    ];
+
+    private readonly string _root =
+        Directory.CreateTempSubdirectory("ec_semantics_").FullName;
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    private static int Run(params string[] args)
+    {
+        TextWriter outWriter = Console.Out;
+        TextWriter errWriter = Console.Error;
+
+        try
+        {
+            Console.SetOut(new StringWriter());
+            Console.SetError(new StringWriter());
+
+            return Program.RunConsoleMode(args);
+        }
+        finally
+        {
+            Console.SetOut(outWriter);
+            Console.SetError(errWriter);
+        }
+    }
+
+    private JsonDocument WriteAndRead(bool journal)
+    {
+        File.WriteAllText(Path.Combine(_root, "a.txt"), "hello\n");
+        string path = Path.Combine(_root, journal ? "journal.json" : "plan.json");
+
+        Assert.Equal(0, journal
+            ? Run("-BasePath", _root, "-Target", "utf-16-bom", "-Journal", path, "-Quiet")
+            : Run("-BasePath", _root, "-Target", "utf-16-bom", "-Plan", path, "-Quiet"));
+
+        return JsonDocument.Parse(File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void APlanStatesWhatItsSemanticsVersionGuarantees()
+    {
+        using JsonDocument document = WriteAndRead(journal: false);
+        JsonElement root = document.RootElement;
+
+        Assert.Equal(
+            ConversionSemantics.Describes,
+            root.GetProperty("SemanticsDescription").GetString());
+
+        Assert.Equal(ConversionSemantics.Current, root.GetProperty("SemanticsVersion").GetInt32());
+    }
+
+    [Fact]
+    public void AJournalStatesWhatItsSemanticsVersionGuarantees()
+    {
+        using JsonDocument document = WriteAndRead(journal: true);
+        JsonElement root = document.RootElement;
+
+        Assert.Equal(
+            ConversionSemantics.Describes,
+            root.GetProperty("SemanticsDescription").GetString());
+
+        Assert.Equal(ConversionSemantics.Current, root.GetProperty("SemanticsVersion").GetInt32());
+    }
+
+    /// <summary>
+    /// The constants are gone from both artifacts, including the object that held them.
+    /// </summary>
+    [Fact]
+    public void NeitherArtifactCarriesTheConstantGuaranteeFlags()
+    {
+        foreach (bool journal in new[] { false, true })
+        {
+            using JsonDocument document = WriteAndRead(journal);
+            string json = document.RootElement.GetRawText();
+
+            Assert.False(
+                document.RootElement.TryGetProperty("Semantics", out _),
+                $"the {(journal ? "journal" : "plan")} still carries a Semantics object");
+
+            foreach (string flag in RemovedFlags)
+            {
+                Assert.DoesNotContain(flag, json, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    /// <summary>Nothing may consult the description to decide anything.</summary>
+    [Fact]
+    public void TheDescriptionIsNotUsedToDecideCompatibility()
+    {
+        File.WriteAllText(Path.Combine(_root, "a.txt"), "hello\n");
+        string planPath = Path.Combine(_root, "plan.json");
+
+        Assert.Equal(0, Run(
+            "-BasePath", _root, "-Target", "utf-16-bom", "-Plan", planPath, "-Quiet"));
+
+        string text = File.ReadAllText(planPath);
+        File.WriteAllText(
+            planPath,
+            text.Replace(ConversionSemantics.Describes, "something else entirely"));
+
+        ConversionPlan? plan = ConversionPlan.Load(planPath, out string? error);
+
+        Assert.NotNull(plan);
+        Assert.Null(error);
+    }
+}

--- a/sources/EncodingChecker/ConversionJournal.cs
+++ b/sources/EncodingChecker/ConversionJournal.cs
@@ -125,14 +125,18 @@ internal sealed record JournalEntry
 /// </remarks>
 internal sealed record ConversionJournal
 {
-    internal const int CurrentJournalVersion = 4;
+    internal const int CurrentJournalVersion = 5;
 
     public int JournalVersion { get; init; } = CurrentJournalVersion;
 
     /// <summary>The conversion behaviour this run used.</summary>
     public int SemanticsVersion { get; init; } = ConversionSemantics.Current;
 
-    public ConversionSemantics Semantics { get; init; } = new();
+    /// <summary>
+    /// What <see cref="SemanticsVersion"/> guarantees, in words, for whoever opens the
+    /// file. Compatibility is decided by the version alone, so this is never read back.
+    /// </summary>
+    public string SemanticsDescription { get; init; } = ConversionSemantics.Describes;
 
     public required string EcVersion { get; init; }
 

--- a/sources/EncodingChecker/ConversionPlan.cs
+++ b/sources/EncodingChecker/ConversionPlan.cs
@@ -32,7 +32,9 @@ internal enum PlannedAction
 /// </summary>
 /// <remarks>
 /// Recorded in every plan so an approved plan cannot later be applied under different
-/// conversion or classification behaviour.
+/// conversion or classification behaviour. <see cref="Current"/> is the only value
+/// <see cref="ConversionPlan.Load"/> enforces; <see cref="Describes"/> accompanies it
+/// for readers and decides nothing.
 /// </remarks>
 internal sealed record ConversionSemantics
 {
@@ -44,24 +46,6 @@ internal sealed record ConversionSemantics
     /// <summary>The guarantees of <see cref="Current"/> shown to the reader.</summary>
     internal const string Describes =
         "source-bound detection, strict codecs, verified output, atomic install, explicit source required for legacy text, proven BOM-less UTF-16 byte order, BOM or explicit source required for UTF-32, a reviewed refusal is binding";
-
-    /// <summary>Malformed input is rejected rather than replaced.</summary>
-    public bool StrictDecoding { get; init; } = true;
-
-    /// <summary>Unrepresentable content is rejected rather than substituted.</summary>
-    public bool StrictEncoding { get; init; } = true;
-
-    /// <summary>Output is re-decoded and compared before installation.</summary>
-    public bool OutputVerification { get; init; } = true;
-
-    /// <summary>The source is never rewritten in place.</summary>
-    public bool AtomicInstall { get; init; } = true;
-
-    /// <summary>
-    /// Automatically detected legacy text requires a user-selected source codec;
-    /// Unicode and ASCII are converted automatically.
-    /// </summary>
-    public bool LegacyRequiresExplicitSource { get; init; } = true;
 }
 
 /// <summary>One file's entry in a conversion plan.</summary>
@@ -142,7 +126,7 @@ internal sealed record ApprovedDecision(
 internal sealed record ConversionPlan
 {
     /// <summary>The plan file schema version.</summary>
-    internal const int CurrentPlanVersion = 5;
+    internal const int CurrentPlanVersion = 6;
 
     public int PlanVersion { get; init; } = CurrentPlanVersion;
 
@@ -153,8 +137,11 @@ internal sealed record ConversionPlan
 
     public required string EcVersion { get; init; }
 
-    /// <summary>The guarantees recorded for the reader.</summary>
-    public ConversionSemantics Semantics { get; init; } = new();
+    /// <summary>
+    /// What <see cref="SemanticsVersion"/> guarantees, in words, for whoever opens the
+    /// file. Compatibility is decided by the version alone, so this is never read back.
+    /// </summary>
+    public string SemanticsDescription { get; init; } = ConversionSemantics.Describes;
 
     /// <summary>The directory containing all planned relative paths.</summary>
     public required string BaseDirectory { get; init; }

--- a/sources/EncodingChecker/ConversionReport.cs
+++ b/sources/EncodingChecker/ConversionReport.cs
@@ -73,10 +73,15 @@ internal sealed class ConversionReportEntry
     /// What detection could not establish about a BOM-less Unicode source. Internal
     /// planning state; not in CSV.
     /// </summary>
-    internal BomlessUnicodeKind BomlessUnicodeDoubt { get; set; }
+    /// <remarks>
+    /// Null means not yet classified. <see cref="BomlessUnicodeKind.None"/> means
+    /// classified with no doubt found, so the file is examined once either way.
+    /// </remarks>
+    internal BomlessUnicodeKind? BomlessUnicodeDoubt { get; set; }
 
     /// <summary>Whether that doubt exists at all.</summary>
-    internal bool HasBomlessUnicodeDoubt => BomlessUnicodeDoubt != BomlessUnicodeKind.None;
+    internal bool HasBomlessUnicodeDoubt =>
+        BomlessUnicodeDoubt is not null and not BomlessUnicodeKind.None;
 
     /// <summary>
     /// The SHA-256 this file must still have when installed, or <see langword="null"/>

--- a/sources/EncodingChecker/Program.CliExecution.cs
+++ b/sources/EncodingChecker/Program.CliExecution.cs
@@ -87,7 +87,11 @@ internal static partial class Program
             .. plan.Files
                 .Select(f => new ConversionReportEntry
                 {
-                    FilePath = plan.ResolvePath(f)!,
+                    FilePath = plan.ResolvePath(f)
+                        ?? throw new InvalidOperationException(
+                            $"'{f.RelativePath}' resolves outside the plan's directory. "
+                            + "FindStaleFiles rejects such a plan before this point, so "
+                            + "reaching here means that check was bypassed."),
                     SourceEncoding = f.SourceEncoding,
                     SourceHasBom = f.SourceHasBom,
                     TargetEncoding = plan.TargetEncoding,

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13.0.0")]
-[assembly: AssemblyFileVersion("3.13.0.0")]
+[assembly: AssemblyVersion("3.14.0.0")]
+[assembly: AssemblyFileVersion("3.14.0.0")]

--- a/sources/EncodingChecker/ScanEngine.cs
+++ b/sources/EncodingChecker/ScanEngine.cs
@@ -533,7 +533,8 @@ internal static class ScanEngine
                     // the result stays Unchanged; the row must still say which it is,
                     // and say it with the same code conversion would use.
                     entry.ReasonCode =
-                        BomlessUnicodeSafety.ReasonCodeFor(entry.BomlessUnicodeDoubt);
+                        BomlessUnicodeSafety.ReasonCodeFor(
+                            entry.BomlessUnicodeDoubt ?? BomlessUnicodeKind.None);
                     entry.Diagnostic =
                         BomlessUnicodeSafety.DescribeUnprovableByteOrder(detected!);
                 }
@@ -589,7 +590,8 @@ internal static class ScanEngine
                     // refuses that same file later.
                     entry.Result = ConversionRowResult.Invalid;
                     entry.ReasonCode =
-                        BomlessUnicodeSafety.ReasonCodeFor(entry.BomlessUnicodeDoubt);
+                        BomlessUnicodeSafety.ReasonCodeFor(
+                            entry.BomlessUnicodeDoubt ?? BomlessUnicodeKind.None);
                     entry.Diagnostic =
                         BomlessUnicodeSafety.DescribeUnprovableByteOrder(detected!)
                         + $" The label '{label}' is in the allowed list, but EC cannot"
@@ -837,11 +839,12 @@ internal static class ScanEngine
             ? entry.DetectedEncodingHasBom
             : sourceHasBom;
 
-        BomlessUnicodeKind bomlessUnicodeDoubt = entry.HasBomlessUnicodeDoubt
-            ? entry.BomlessUnicodeDoubt
-            : bomlessCandidate is null
+        // A stored None is an answer, so only null triggers classification.
+        BomlessUnicodeKind bomlessUnicodeDoubt =
+            entry.BomlessUnicodeDoubt
+            ?? (bomlessCandidate is null
                 ? BomlessUnicodeKind.None
-                : ClassifyBomlessUnicode(path, bomlessCandidate, candidateHasBom);
+                : ClassifyBomlessUnicode(path, bomlessCandidate, candidateHasBom));
 
         entry.BomlessUnicodeDoubt = bomlessUnicodeDoubt;
 


### PR DESCRIPTION
Four backlog findings closed, one dropped after measurement, and a change to the shape of
the plan and journal files that makes this a minor release rather than the tidying it
started as.

## What changed

**EC-15 — a plan says what its version means.** Five serialized booleans
(`StrictDecoding`, `StrictEncoding`, `OutputVerification`, `AtomicInstall`,
`LegacyRequiresExplicitSource`) were hardcoded `true`, written on every run, and read back
by nothing. The same build wrote them and the semantics version they sat beside, so they
could never disagree with it — what they could do is invite a reader to take a serialized
`true` as evidence that a particular check ran on that file. They are replaced by
`SemanticsDescription`: the sentence `ConversionSemantics.Describes` already held.

The artifacts changed shape, so their versions say so: plan schema 5 to 6, journal schema
4 to 5. **A plan written by v3.13.0 or earlier is refused** and has to be re-planned and
reviewed again. Conversion semantics stay at 7 — this build would make exactly the
decisions such a plan records, and refuses it because the file shape changed, not the
behaviour. Landing a day earlier this would have cost nothing, so the release notes carry
that cost as its own section rather than leaving it to the compatibility table.

**EC-18 — a file already cleared is not examined again.** Only a *positive* BOM-less
ambiguity result was cached, so a stored false ran the full opposite-order decode again on
every pass. The classification is now nullable: null means not yet classified, `None`
means classified with nothing found. Not a performance fix — measurement found no
meaningful cost, because a provable file fails that decode inside its first buffer. The
defect was a stored state that could not distinguish "no" from "not asked".

**EC-23 — plan application names the invariant it rests on.** `plan.ResolvePath(f)!` was
safe only because `FindStaleFiles` rejects an out-of-directory plan twenty-nine lines
earlier, and nothing said so. It is now an explicit throw that does.

**BL-27 — release evidence promises only what the build being driven can show.** Both
documents claimed the smoke report carries "the executable and managed-assembly hashes".
Real release evidence carried no managed hash and rendered an empty pair of backticks,
while printing the `EncodingChecker.dll` path as though a value followed — the release
workflow drives the *published* executable, and a single-file publish leaves no loose DLL.
The report now records the assembly only when there is one to hash and says there is none
when there is not; both documents describe both cases, because an ordinary Release build
does have one.

**CX-06 — re-scored Occasional to Theoretical, and the fix dropped.** No text reaches the
entropy gate: of 3,620 gated files across the four corpora, the 47 that trip 7.4 bits are
all binary, and the highest-entropy text file among 3,568 candidates is dense Chinese XML
in gb2312 at 6.8133. A working fix was written and then dropped — making the guard yield
to a byte-order mark moved BOM-prefixed binary from `(Unknown)` to `utf-16` and a scan
containing one from exit 0 to exit 3, a measured behaviour change bought against a benefit
no corpus file demonstrates.

## Verification

- 755 tests pass, none skipped (was 751); release build with no warnings
- The four new tests were mutation-checked one at a time. Each mutation built cleanly and
  failed exactly the test aimed at it: the plan stops carrying the description, the removed
  flags come back, the journal stops carrying the description, and `Load` starts consulting
  the description. Both source files restored byte-identical, confirmed by SHA-256
- GUI smoke suite: 10 of 10 phases against **both** builds — the ordinary Release build,
  where it finds a loose managed assembly and hashes it, and the published single-file
  executable, where it reports that there is none
- `docs/Test-DefectBacklog.ps1` passes at 62 findings — 50 fixed, 8 open
- EC-18 and EC-23 carry no tests, deliberately: neither changes observable behaviour, so a
  test would pin the shape of the code rather than anything EC promises, and the backlog
  records that reasoning rather than leaving them to look untested by oversight
- No four-corpus audit — this release changes no detection or conversion policy, so the
  checklist does not require one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
