### PR TITLE
Make the release gate deterministic, and bound wildcard matching

### DIFF
--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=63 fixed=51 open=8 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
+<!-- backlog-counts total=63 fixed=52 open=7 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
 
-**Derived count: 63 findings — 51 fixed, 8 open, 1 not reproduced,
+**Derived count: 63 findings — 52 fixed, 7 open, 1 not reproduced,
 1 withdrawn, 1 not a defect, and 1 design decision.** Recompute and validate
 these figures with:
 
@@ -50,7 +50,6 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 
 | ID | Finding | Status | Impact | Reach | Details |
 |---|---|---|---|---|---|
-| EC-08 | An include pattern can hang a scan indefinitely | Open | Medium | Theoretical | [EC-08](#ec-08) |
 | EC-17 | A text-validation comment contradicts the calculation | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | Detection permits concurrent writes and deletes | Open | Low | Rare | [EC-20](#ec-20) |
 | CX-06 | The entropy gate runs before BOM detection | Open | Medium | Theoretical | [CX-06](#cx-06) |
@@ -68,6 +67,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-03 | The GUI omitted the source-choice advisory | Fixed | — | — | [EC-03](#ec-03) |
 | EC-04 | `-Plan` could exit successfully after scan failures | Fixed | — | — | [EC-04](#ec-04) |
 | BL-01 | Ambiguous BOM-less UTF-32 can be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
+| EC-08 | A constructed include pattern could hang a scan indefinitely | Fixed | — | — | [EC-08](#ec-08) |
 | EC-24 | The GUI smoke gate could select in the wrong combo | Fixed | — | — | [EC-24](#ec-24) |
 | EC-18 | A negative BOM-less UTF-16 ambiguity result is recomputed | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application relies on a null-forgiving path dereference | Fixed | — | — | [EC-23](#ec-23) |
@@ -125,27 +125,42 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 
 ### EC-08
 
-**A hostile include mask can monopolize the regex engine.**
-`DirectoryTraversal.CompilePatterns` still translates `*` to `.*`, creates a
-regex with `RegexOptions.Compiled`, and therefore uses
-`Regex.InfiniteMatchTimeout`. On 2026-09-08 a scan with
-twelve separated wildcards against a nonmatching forty-character run of `a`
-did not finish within three seconds and had to be terminated.
+**Fixed by evaluating wildcard masks with .NET's non-backtracking engine.** The
+translation is unchanged — `*` becomes `.*`, `?` becomes `.`, and a
+separator-free mask still matches at any depth — so include and exclude results
+are the same. What changes is that matching runs in time proportional to the
+input rather than retrying an exponential number of alternatives.
+`NonBacktracking` replaces `Compiled`; the two are mutually exclusive.
 
-The trigger requires both inputs to be deliberately hostile: roughly ten or
-more separated wildcards and a filename with roughly twenty-four or more mostly
-consecutive copies of the separating character. Earlier measurements found
-realistic names answered in 0–5 ms, while the forty-`a` case exceeded 20 s.
-The mask comes from the operator, not an untrusted file.
+Was: `CompilePatterns` built a `Compiled` regex, which uses
+`Regex.InfiniteMatchTimeout`. A mask carrying twelve separated wildcards, matched
+against a nonmatching forty-character run of `a`, did not finish within three
+seconds and had to be terminated, while realistic names answered in 0–5 ms. The
+trigger needs both inputs to be deliberately hostile, and the mask comes from the
+operator rather than an untrusted file — which is why reach stayed Theoretical.
+An unbounded runtime is still worth removing for the price of one option.
 
-`RegexOptions.NonBacktracking` removed the blow-up, matched the current engine on
-the tested masks, and cost nothing measurable beside file I/O. It was measured
-and deliberately reverted because of the constructed reach. Three dead ends are
-worth preserving: a matching filename stops at the first success and proves
-nothing; `*` crossing directory separators is deliberate and tested; replacing
-`.*` with `[^/]*` does not prevent backtracking in a separator-free filename.
-`PathAwarePatternTests.PathQualifiedPattern_MatchesOnlyTheIntendedSubtree` pins
-the intended `src/*.cs` directory behavior.
+**It is not free, and the earlier note here that it cost nothing was wrong.**
+Measured over 3,937 files, median of five warm runs: 128 ms with `Compiled`
+against 148 ms with `NonBacktracking` — about 16%, or roughly 5 µs per file, and
+the same figure for a plain `*.txt` mask as for `*a*b*.txt`. That is the price of
+a bounded worst case, recorded so the next reader weighs it instead of
+rediscovering it.
+
+An independent differential comparison of the two engines over 500 generated
+masks against 200 generated paths — 100,000 pairs, including separators and the
+regex-special characters EC escapes — found no case where they disagreed.
+
+`PathAwarePatternTests.WildcardPatternsUseTheNonBacktrackingEngine` asserts the
+option before exercising the hostile input, so restoring the old engine fails in
+9 ms instead of hanging the run. That mutation was performed, and the file
+restored byte-identical by SHA-256.
+
+Three dead ends stay recorded: a matching filename stops at the first success and
+proves nothing; `*` crossing directory separators is deliberate and tested; and
+replacing `.*` with `[^/]*` does not prevent backtracking within a separator-free
+filename. `PathAwarePatternTests.PathQualifiedPattern_MatchesOnlyTheIntendedSubtree`
+pins the intended `src/*.cs` directory behavior.
 
 ### EC-15
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=62 fixed=50 open=8 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
+<!-- backlog-counts total=63 fixed=51 open=8 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
 
-**Derived count: 62 findings — 50 fixed, 8 open, 1 not reproduced,
+**Derived count: 63 findings — 51 fixed, 8 open, 1 not reproduced,
 1 withdrawn, 1 not a defect, and 1 design decision.** Recompute and validate
 these figures with:
 
@@ -68,6 +68,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-03 | The GUI omitted the source-choice advisory | Fixed | — | — | [EC-03](#ec-03) |
 | EC-04 | `-Plan` could exit successfully after scan failures | Fixed | — | — | [EC-04](#ec-04) |
 | BL-01 | Ambiguous BOM-less UTF-32 can be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
+| EC-24 | The GUI smoke gate could select in the wrong combo | Fixed | — | — | [EC-24](#ec-24) |
 | EC-18 | A negative BOM-less UTF-16 ambiguity result is recomputed | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application relies on a null-forgiving path dereference | Fixed | — | — | [EC-23](#ec-23) |
 | BL-27 | Release evidence records no managed-assembly hash | Fixed | — | — | [BL-27](#bl-27) |
@@ -716,6 +717,69 @@ inside the visible part of the same dropdown. Both combo-scoped and process-wide
 exact-name searches now follow the same documented rule, and fallback input
 uses the supplied window. Phase J drives the source-choice refusal against the
 built application.
+
+### EC-24
+
+**Fixed by setting the drop-down instead of hunting its popup.** The combo
+supports `ValuePattern` and reports `IsReadOnly` false, so the driver asks the
+control for the value. That opens no popup and reaches no other window, so
+neither mechanism below is available to fail.
+
+Was: the driver expanded the combo and searched for a list item, first under the
+combo and then across the process. How a provider exposes a drop-down's items
+varies with popup state and environment, so the first search could miss. The
+second accepted any visible item in the process carrying a matching name, and
+this application has two encoding combos — `lstConvert` on the main window and
+`lstSourceEncoding` in the review — holding the same names, so it could select
+in the wrong one and leave the combo under test unchanged.
+
+**Found by the release gate failing on bytes that then passed.** The v3.14.0
+release job failed at phase E with `'utf-16BE' was not selected in
+'lstSourceEncoding'`, and a re-run of the same commit passed all ten phases.
+Nothing in that release touched the driver, the review form, or the encoding
+list.
+
+This is [BL-26](#bl-26) arriving a second time. That fix made phase J work and
+left the mechanism in place; the v3.12.1 record said the asymmetry it kept "is
+the kind of thing a future phase could still trip over," and phase E is that
+phase. The keyboard fallback went with the searches: it foregrounded a window
+and typed into whatever held focus, and could not have repaired either cause.
+
+**The unsafe mechanism is proven; the cause of the runner incident is not.** An
+independent review built a harness holding two controls that offer the same item
+name, and reproduced the old process-wide fallback selecting the wrong control
+and leaving the combo under test unchanged — the exact shape of the reported
+failure. That establishes the defect. It does not establish that the release
+runner exposed that state, and no reproduction of the incident itself exists: on
+this machine the popup sits inside the combo's subtree and only one process-wide
+match is visible, so the ambiguity never arises here. This entry closes the
+mechanism, not the incident.
+
+**What the replacement was shown to do.** On the current .NET 10 WinForms
+provider, setting the value selects the matching item rather than only changing
+displayed text — phase E completes end to end, so the choice reaches conversion
+and the output text is preserved. An unknown value is a no-op on this provider,
+which the existing postcondition catches; no membership check is added, since one
+would reinstate the popup dependency this removes. Two mutations — never setting
+the value, and setting a different one — each built cleanly and failed phase E
+with the message the release job produced, and the file restored byte-identical
+by SHA-256.
+
+**A timeout now names the error it retried.** `WaitFor` discarded
+`ElementNotAvailableException`, `InvalidOperationException` and `COMException`
+and then reported only a generic timeout, so a probe that threw on every attempt
+looked exactly like one that simply never became true. It now keeps the last such
+error and `WaitUntil` reports it, so the next failure of this gate is
+diagnosable from its message.
+
+**Recorded, not fixed here.** `ConfigureScan` asks for `utf-8` on `lstConvert`
+while that control is still disabled, and succeeds only because `utf-8` is
+already selected, so the method returns before setting anything: the suite never
+exercises the new path on that combo, and a changed application default would
+fail every phase at setup. Separately, `Current.IsEnabled` was observed stale for
+five seconds on a control that then accepted `Invoke`, and the driver uses
+`IsEnabled` as a readiness signal elsewhere. Neither was reproduced as a
+failure.
 
 ## Decisions and mistakes that must remain visible
 

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -336,6 +336,13 @@ internal sealed class EcGuiDriver : IDisposable
         ((ValuePattern)rawValue).SetValue(value);
     }
 
+    /// <summary>Sets a drop-down list to <paramref name="value"/>.</summary>
+    /// <remarks>
+    /// Reaching a drop-down item through the tree depends on how the provider exposes the
+    /// popup, which varies with its state and the environment, and on which of the two
+    /// encoding combos owns a match for the same name. Asking the control for the value
+    /// opens no popup and so depends on neither.
+    /// </remarks>
     private void SelectCombo(
         AutomationElement root,
         string automationId,
@@ -346,67 +353,22 @@ internal sealed class EcGuiDriver : IDisposable
         if (SelectedName(combo).Equals(value, StringComparison.OrdinalIgnoreCase))
             return;
 
-        if (combo.TryGetCurrentPattern(
-                ExpandCollapsePattern.Pattern,
-                out object? rawExpand))
+        if (!combo.TryGetCurrentPattern(ValuePattern.Pattern, out object? rawValue))
+            throw new InvalidOperationException($"'{automationId}' cannot be set by value.");
+
+        var setter = (ValuePattern)rawValue;
+
+        if (setter.Current.IsReadOnly)
         {
-            ((ExpandCollapsePattern)rawExpand).Expand();
+            throw new InvalidOperationException(
+                $"'{automationId}' is read-only, so '{value}' cannot be set.");
         }
 
-        AutomationElement? item = WaitFor(
-            () => FindNamedItem(combo, value) ?? FindVisibleProcessItem(value),
-            TimeSpan.FromSeconds(5));
-
-        if (item is not null &&
-            item.TryGetCurrentPattern(SelectionItemPattern.Pattern, out object? rawSelection))
-        {
-            ((SelectionItemPattern)rawSelection).Select();
-        }
-        else
-        {
-            SetForegroundWindow(root.Current.NativeWindowHandle);
-            combo.SetFocus();
-            System.Windows.Forms.SendKeys.SendWait(value);
-            System.Windows.Forms.SendKeys.SendWait("{ENTER}");
-        }
+        setter.SetValue(value);
 
         WaitUntil(
             () => SelectedName(combo).Equals(value, StringComparison.OrdinalIgnoreCase),
             $"'{value}' was not selected in '{automationId}'.");
-    }
-
-    private AutomationElement? FindNamedItem(
-        AutomationElement root,
-        string value)
-    {
-        AutomationElementCollection items = root.FindAll(
-            TreeScope.Descendants, Condition.TrueCondition);
-
-        // UIA can select WinForms items that sit below the popup viewport and are
-        // therefore reported offscreen.
-        return items.Cast<AutomationElement>().FirstOrDefault(element =>
-            element.Current.ControlType == ControlType.ListItem &&
-            element.Current.Name.Equals(value, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private AutomationElement? FindVisibleProcessItem(string value)
-    {
-        var condition = new AndCondition(
-            new PropertyCondition(
-                AutomationElement.ProcessIdProperty,
-                _process.Id),
-            new PropertyCondition(
-                AutomationElement.ControlTypeProperty,
-                ControlType.ListItem));
-
-        AutomationElementCollection items = AutomationElement.RootElement.FindAll(
-            TreeScope.Descendants, condition);
-
-        // A hidden process-wide match may belong to another collapsed combo that
-        // contains the same encoding name, so only its visible popup is safe to use.
-        return items.Cast<AutomationElement>().FirstOrDefault(element =>
-            element.Current.Name.Equals(value, StringComparison.OrdinalIgnoreCase) &&
-            !element.Current.IsOffscreen);
     }
 
     private static string SelectedName(AutomationElement combo)
@@ -637,9 +599,18 @@ internal sealed class EcGuiDriver : IDisposable
         WaitFor(probe, Timeout) ?? throw new TimeoutException(timeoutMessage);
 
     private static T? WaitFor<T>(Func<T?> probe, TimeSpan timeout)
+        where T : class =>
+        WaitFor(probe, timeout, out _);
+
+    /// <param name="lastError">
+    /// The last error retried before giving up. A probe that threw every time is the
+    /// likeliest reason a wait expired, and it is what a bare timeout cannot report.
+    /// </param>
+    private static T? WaitFor<T>(Func<T?> probe, TimeSpan timeout, out Exception? lastError)
         where T : class
     {
         Stopwatch timer = Stopwatch.StartNew();
+        lastError = null;
 
         while (timer.Elapsed < timeout)
         {
@@ -649,15 +620,20 @@ internal sealed class EcGuiDriver : IDisposable
 
                 if (value is not null)
                     return value;
+
+                lastError = null;
             }
-            catch (ElementNotAvailableException)
+            catch (ElementNotAvailableException ex)
             {
+                lastError = ex;
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException ex)
             {
+                lastError = ex;
             }
-            catch (COMException)
+            catch (COMException ex)
             {
+                lastError = ex;
             }
 
             Thread.Sleep(50);
@@ -670,10 +646,19 @@ internal sealed class EcGuiDriver : IDisposable
     {
         if (WaitFor(
                 () => predicate() ? new object() : null,
-                Timeout) is null)
+                Timeout,
+                out Exception? lastError) is not null)
         {
-            throw new TimeoutException(timeoutMessage);
+            return;
         }
+
+        if (lastError is null)
+            throw new TimeoutException(timeoutMessage);
+
+        throw new TimeoutException(
+            $"{timeoutMessage} Last retried automation error: "
+            + $"{lastError.GetType().Name}: {lastError.Message}",
+            lastError);
     }
 
     private static void ClickAt(int x, int y)
@@ -696,10 +681,6 @@ internal sealed class EcGuiDriver : IDisposable
 
     private const uint MouseLeftDown = 0x0002;
     private const uint MouseLeftUp = 0x0004;
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetForegroundWindow(int hWnd);
 
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
+++ b/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
 
 namespace EncodingChecker.Tests;
 
@@ -111,5 +112,20 @@ public sealed class PathAwarePatternTests : IDisposable
 
         Assert.DoesNotContain("Properties/AssemblyInfo.cs", found);
         Assert.Contains("Properties/AssemblyInfoHelper.cs", found);
+    }
+
+    [Fact]
+    public void WildcardPatternsUseTheNonBacktrackingEngine()
+    {
+        string hostileMask = string.Concat(Enumerable.Repeat("*a", 12)) + "b";
+
+        Regex pattern = Assert.Single(
+            DirectoryTraversal.CompilePatterns([hostileMask], defaultToMatchAll: false));
+
+        // Asserted before the match below, so restoring the old engine fails here
+        // instead of hanging the test run.
+        Assert.True(pattern.Options.HasFlag(RegexOptions.NonBacktracking));
+
+        Assert.DoesNotMatch(pattern, new string('a', 40));
     }
 }

--- a/sources/EncodingChecker/DirectoryTraversal.cs
+++ b/sources/EncodingChecker/DirectoryTraversal.cs
@@ -349,9 +349,13 @@ internal static class DirectoryTraversal
                         ? "^" + body + "$"
                         : "^(?:.*/)?" + body + "$";
 
+                // Matching runs in time proportional to the input, so a mask carrying
+                // many separated wildcards cannot stall a scan. NonBacktracking replaces
+                // Compiled rather than joining it: the two are mutually exclusive.
                 return new Regex(
                     anchored,
-                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+                    RegexOptions.IgnoreCase | RegexOptions.CultureInvariant |
+                    RegexOptions.NonBacktracking);
             })
         ];
     }


### PR DESCRIPTION
Two independent fixes, both mutation-checked, neither changing conversion behaviour,
schemas, or CLI syntax. No version bump is implied.

## EC-24 — the release gate could select in the wrong combo

The v3.14.0 release job failed at phase E with `'utf-16BE' was not selected in
'lstSourceEncoding'`, and a re-run of the same commit passed all ten phases. Nothing in
that release touched the driver, the review form, or the encoding list.

`SelectCombo` expanded the combo and searched for a list item, first under the combo and
then **across the whole process**, accepting any visible item with a matching name. This
application has two encoding combos — `lstConvert` on the main window and
`lstSourceEncoding` in the review — holding the same names, so that search could select in
the wrong one and leave the combo under test unchanged.

The combo supports `ValuePattern` with `IsReadOnly` false, so the driver now asks the
control for the value. No popup opens and no other window is touched, so neither the
popup-location dependency nor the name collision is reachable. The keyboard fallback goes
with the searches: it foregrounded a window and typed into whatever held focus, and could
not have repaired either cause.

`WaitFor` also discarded `ElementNotAvailableException`, `InvalidOperationException` and
`COMException` before reporting a bare timeout, so a probe that threw every time looked
identical to one that never became true. It now keeps the last such error and `WaitUntil`
reports it.

**Proven and unproven, kept apart.** An independent review reproduced the old fallback
selecting the wrong control in a harness with two same-named items. That establishes the
defect. It does **not** establish that the runner exposed that state, and the incident was
never reproduced — locally the popup sits inside the combo's subtree and only one match is
visible. EC-24 records the difference rather than letting the inference stand as fact.

## EC-08 — a constructed include pattern could hang a scan

`CompilePatterns` built a `Compiled` regex, which carries `Regex.InfiniteMatchTimeout`. A
mask with twelve separated wildcards against a nonmatching forty-character run did not
finish within three seconds. `NonBacktracking` replaces `Compiled`; the two are mutually
exclusive. The translation is untouched, so include and exclude results are unchanged.

An independent differential comparison over 500 masks × 200 paths — 100,000 pairs — found
no case where the two engines disagreed.

**It is not free, and the ledger's earlier claim that it cost nothing was wrong.** Over
3,937 files, median of five warm runs: 128 ms with `Compiled` against 148 ms with
`NonBacktracking` — about 16%, roughly 5 µs per file. The entry now carries that figure.

## Verification

- Release build 0 warnings; **756 tests** pass, none skipped
- GUI smoke suite 10/10 against both an ordinary build and the published single-file
  executable, run repeatedly
- Mutation checks on both fixes: the driver mutations reproduce the release job's exact
  message; reverting the regex option fails the new test in 9 ms rather than hanging. All
  files restored byte-identical by SHA-256
- `docs/Test-DefectBacklog.ps1` passes at **63 findings — 52 fixed, 7 open**
- A release rehearsal was run on this branch before merge, driving the smoke suite against
  the published executable — the exact path that failed on v3.14.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
