### PR TITLE
Run the GUI smoke suite on pull requests, not only at tag time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,57 @@ jobs:
 
       - name: Test
         run: dotnet test sources\EncodingChecker.sln --configuration Release --no-build
+
+  # The unit suite covers everything reachable without a window. This covers the
+  # GUI's sequence, which has already shipped a defect while every component in it
+  # was correct and tested. The release job runs the same suite against the signed,
+  # published executable; running it here too means a regression is found on the
+  # pull request that introduced it rather than at tag time, with a release waiting.
+  #
+  # It is a separate job so the check has its own name: a red "gui-smoke" says which
+  # suite failed without opening the log, which matters for a gate whose failures
+  # have been ambiguous before.
+  gui-smoke:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Build
+        run: dotnet build sources\EncodingChecker.sln --configuration Release
+
+      # Drives the ordinary Release build. The published single-file executable is
+      # what the release job drives, and only that job can produce one.
+      #
+      # Two prerequisites are refused with exit 2 rather than reported as a pass:
+      # an interactive Windows desktop, which a hosted windows-latest runner has,
+      # and a build carrying the review dialog's automation ids.
+      - name: Drive the GUI smoke suite
+        shell: pwsh
+        run: |
+          $suite = "sources\EncodingChecker.GuiSmoke\bin\Release\net10.0-windows\EncodingChecker.GuiSmoke.exe"
+
+          & $suite --output "$env:RUNNER_TEMP\gui-smoke"
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "GUI smoke suite failed with exit code $LASTEXITCODE."
+          }
+
+      # Kept on success as well as failure: the report carries each phase's before
+      # and after file hashes, and a run that passed is the sample that shows
+      # whether an intermittent phase has stopped being intermittent.
+      #
+      # Missing evidence only warns here. When the suite cannot start it has already
+      # failed the step above, and erroring again would bury that message.
+      - name: Keep the GUI smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-smoke-evidence
+          path: ${{ runner.temp }}/gui-smoke
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
CI covered build and unit tests. The ten-phase GUI suite ran only in the release job, on a
tag — so the one class of defect the unit suite cannot reach, the window's *sequence*
rather than its components, was checked once per release. A regression could sit on master
until the worst possible moment, and v3.14.0 showed that moment: the gate fired during the
release and had to be diagnosed with a half-finished release waiting on it.

The suite now also runs on every pull request and push to master, against the ordinary
Release build. The release job keeps its own run against the signed, published executable —
the only place that binary exists.

**Why a separate job rather than more steps in `build`.** The check gets its own name. A
red `gui-smoke` says which suite failed without anyone opening a log, which matters for a
gate whose failures have been ambiguous before. It costs about a minute of duplicated build
time.

**Why this is worth more than the usual regression argument.** EC-24 fixed a selection path
that could fail on a machine whose automation tree differed, and records plainly that the
mechanism was proven while the incident that exposed it was never reproduced. Running once
per release, a rare failure needs many releases to characterise. Running per pull request
accumulates the sample instead — which is precisely the evidence that entry says it does
not have.

Evidence is uploaded on success as well as failure, because a passing run is what shows an
intermittent phase has stopped being intermittent. Retention is bounded at 14 days.
Missing evidence only warns rather than errors: when the suite cannot start it has already
failed the step before it, and erroring twice would bury the message that explains why.

## Verification

- The YAML parses; two jobs (`build`, `gui-smoke`), triggers unchanged
- The job's exact command was run locally against the ordinary Release build: 10/10 phases
- This pull request exercises the new job on itself, since `pull_request` builds the
  workflow from the PR head

**Not made a required check yet.** That is a branch-protection setting, and it should wait
until several green runs have accumulated. Requiring a check whose reliability is still
being measured is how people learn to re-run red builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
