### PR TITLE
Clarify defect backlog and release-gate documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,12 @@ jobs:
       - name: Test
         run: dotnet test sources\EncodingChecker.sln --configuration Release --no-build
 
-  # The unit suite covers everything reachable without a window. This covers the
-  # GUI's sequence, which has already shipped a defect while every component in it
-  # was correct and tested. The release job runs the same suite against the signed,
-  # published executable; running it here too means a regression is found on the
-  # pull request that introduced it rather than at tag time, with a release waiting.
+  # The unit suite covers conversion policy, plan binding and orchestration, none of
+  # which needs a window. This covers the GUI's sequence, which has already shipped a
+  # defect while every component in it was correct and tested. The release job runs the
+  # same suite against the published executable; running it here too means a regression
+  # is found on the pull request that introduced it rather than at tag time, with a
+  # release waiting.
   #
   # It is a separate job so the check has its own name: a red "gui-smoke" says which
   # suite failed without opening the log, which matters for a gate whose failures

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,12 +140,16 @@ jobs:
             Remove-Item $certPath -Force -ErrorAction SilentlyContinue
           }
 
-      # Drives the signed, published executable rather than a build of the same
-      # commit, so what is verified is the bytes that ship. A failure here fails
-      # the job, and no release is created.
+      # Drives the published framework-dependent executable rather than a build of
+      # the same commit, so what is verified is a file that ships. A failure here
+      # fails the job, and no release is created.
       #
-      # It is placed after signing because signing rewrites the file: verifying
-      # the unsigned one would leave the shipped binary undriven.
+      # Placed after the signing step because signing rewrites the file: verifying
+      # the unsigned one would leave the shipped binary undriven. Signing is
+      # conditional on the certificate secrets, so when they are absent this drives
+      # an unsigned file.
+      #
+      # The self-contained executable is packaged without being driven.
       - name: Drive the GUI smoke suite
         shell: pwsh
         run: |
@@ -190,8 +194,15 @@ jobs:
         if: github.event_name != 'push'
         shell: pwsh
         run: |
+          $signing = if ($env:CODE_SIGNING_CERT -and $env:CODE_SIGNING_CERT_PASSWORD) {
+            "signed"
+          } else {
+            "not signed, because the certificate secrets are not configured"
+          }
+
           $summary = "REHEARSAL for version ${{ steps.version.outputs.version }} - " +
-                     "built, tested, signed, GUI-checked and packaged. No release was created."
+                     "built, tested, GUI-checked and packaged; executables $signing. " +
+                     "No release was created."
           $summary
           "## Release rehearsal" >> $env:GITHUB_STEP_SUMMARY
           "" >> $env:GITHUB_STEP_SUMMARY

--- a/docs/DEFECT-BACKLOG-HISTORY.md
+++ b/docs/DEFECT-BACKLOG-HISTORY.md
@@ -1,0 +1,173 @@
+# Defect backlog - historical records
+
+Audit trail for [DEFECT-BACKLOG.md](DEFECT-BACKLOG.md), kept out of it so the
+current findings read as current. Nothing here was reworded when it moved: the
+recheck that produced the ledger, the measurements behind three rejected
+throughput changes, and the mapping from the pre-reformat rows.
+
+
+## 2026-09-08 recheck record
+
+Every pre-reformat row was checked against source, a current regression test, a
+current Release-build probe, or a clearly marked historical measurement. The
+source inspection used `c071c10`; the factual recheck is preserved as local
+commit `902f567` immediately before this reformat.
+
+For chronology, BL-06 through BL-17 came from the independent review of
+`74d5b3d` after v3.11.2. BL-22 through BL-24 came from a later independent review
+of released commit `518a844` after v3.12.0. These source identities are retained
+because the observations were made against those builds, even though the
+current statuses were rechecked against `c071c10`.
+
+Current behavioral probes established:
+
+- the EC-08 hostile regex exceeded a three-second child-process budget;
+- automatic and explicit UTF-8 paths both refused a double BOM;
+- an old plan in the scan root was scanned as ASCII;
+- a filename beginning `=1+1` still produced an absolute-path CSV cell;
+- BL-01 and BL-18 both changed Unicode under the wrong automatic interpretation;
+- BL-19 and BL-21 were reported inconsistently but refused or failed before a
+  write; and
+- both names of a hard-linked file preserved exact text and received separate
+  recovery artifacts through the normal Windows replacement path.
+
+No old row was skipped. Three portions remain only partly reproducible:
+
+- BL-05 requires precise force-close timing and was inspected rather than
+  triggered;
+- BL-20's move fallback requires a platform where `File.Replace` is unsupported;
+  and
+- the historical timing figures above were not rerun; their current code and
+  safety properties were checked.
+
+## Three hashing optimisations were measured and rejected
+
+Conversion can read the same file several times, but each read answers a
+different question: does the source still match approval, did the backup really
+land, and does the installed output contain the verified text? Three throwaway
+variants were interleaved against the same 292 MiB, 60-file workload with backup
+and journal enabled:
+
+| Variant | Measurement | Safety or usability cost |
+|---|---|---|
+| Baseline | 1030 ms median | None |
+| Digest backup while copying | 872 ms; 15.3% faster | Nothing independently re-reads the restore point on disk |
+| Hash source and output while streaming | 3.5% faster in its own batch | Both values derive from intended I/O rather than independent reads |
+| XxHash128 instead of SHA-256 | 1078 ms; 4.7% slower | Recorded hashes lose `Get-FileHash` interoperability and collision resistance |
+
+The source can be read up to seven times per converted file, and one hash is
+computed twice over bytes already held in memory. Those reads are still not
+redundant. The only materially faster variant removed the backup re-read after
+`Flush(flushToDisk: true)`, which is the only independent check that the restore
+point exists intact. XxHash128 itself measured 16,447 MiB/s against SHA-256 at
+2,429 MiB/s—6.8x—but made the parallel I/O-bound workload slower. On that
+machine SHA-256 also beat SHA-1 (981 MiB/s), MD5 (754 MiB/s), and SHA-512
+(805 MiB/s).
+
+These figures are conditional: a 24-core machine, fast local disk, warm cache,
+and eight workers. Cold or network storage may increase the benefit of removing
+a read while also increasing the value of verifying it. Even a different speed
+result—even 40%—would not change what each check proves. The observed ceiling
+was about 15%, and that was the variant which removed the strongest backup
+evidence. Only a single-worker run on a slow CPU is likely to make hashing itself
+visible. Future throughput work should make the backup re-read cheaper rather
+than delete it.
+
+## Pre-reformat row mapping
+
+The task expected 78 rows, 45 with an existing ID and 33 without one. The exact
+`c071c10` input had 79 data-shaped rows, 45 of which mentioned an existing ID.
+The disjoint breakdown is 35 original canonical rows, 21 unique anonymous
+finding or decision rows, 13 duplicate or correction rows, 7 benchmark or
+comparison-evidence rows, and 3 malformed blank-cell headers. Four findings
+existed only as prose, and one GUI-driver finding existed only in a narrative
+section. That yields the 61 unique ledger entries above. The mapping below
+accounts for every old location without pretending that a table header or
+benchmark variant is a new defect.
+
+| Old location | Canonical finding or destination | Note |
+|---|---|---|
+| R001 | [EC-01](DEFECT-BACKLOG.md#ec-01) | Original ledger row |
+| R002 | [EC-02](DEFECT-BACKLOG.md#ec-02) | Original ledger row |
+| R003 | [EC-03](DEFECT-BACKLOG.md#ec-03) | Original ledger row |
+| R004 | [EC-04](DEFECT-BACKLOG.md#ec-04) | Original ledger row |
+| R005 | [EC-05](DEFECT-BACKLOG.md#ec-05) | Original ledger row |
+| R006 | [EC-06](DEFECT-BACKLOG.md#ec-06) | Original ledger row |
+| R007 | [EC-07](DEFECT-BACKLOG.md#ec-07) | Original ledger row |
+| R008 | [EC-08](DEFECT-BACKLOG.md#ec-08) | Original ledger row |
+| R009 | [EC-09](DEFECT-BACKLOG.md#ec-09) | Original ledger row |
+| R010 | [EC-10](DEFECT-BACKLOG.md#ec-10) | Original ledger row |
+| R011 | [EC-11](DEFECT-BACKLOG.md#ec-11) | Original ledger row |
+| R012 | [EC-12](DEFECT-BACKLOG.md#ec-12) | Original ledger row |
+| R013 | [EC-13](DEFECT-BACKLOG.md#ec-13) | Original ledger row |
+| R014 | [EC-14](DEFECT-BACKLOG.md#ec-14) | Original ledger row |
+| R015 | [EC-15](DEFECT-BACKLOG.md#ec-15) | Original ledger row |
+| R016 | [EC-16](DEFECT-BACKLOG.md#ec-16) | Original ledger row |
+| R017 | [EC-17](DEFECT-BACKLOG.md#ec-17) | Original ledger row |
+| R018 | [EC-18](DEFECT-BACKLOG.md#ec-18) | Original ledger row |
+| R019 | [EC-19](DEFECT-BACKLOG.md#ec-19) | Original ledger row |
+| R020 | [EC-20](DEFECT-BACKLOG.md#ec-20) | Original ledger row |
+| R021 | [EC-21](DEFECT-BACKLOG.md#ec-21) | Original ledger row |
+| R022 | [EC-22](DEFECT-BACKLOG.md#ec-22) | Original ledger row |
+| R023 | [EC-23](DEFECT-BACKLOG.md#ec-23) | Original ledger row |
+| R024 | [CX-01](DEFECT-BACKLOG.md#cx-01) | Original ledger row |
+| R025 | [CX-02](DEFECT-BACKLOG.md#cx-02) | Original ledger row |
+| R026 | [CX-03](DEFECT-BACKLOG.md#cx-03) | Original ledger row |
+| R027 | [CX-05](DEFECT-BACKLOG.md#cx-05) | Original ledger row |
+| R028 | [CX-06](DEFECT-BACKLOG.md#cx-06) | Original ledger row |
+| R029 | [CX-07](DEFECT-BACKLOG.md#cx-07) | Original ledger row |
+| R030 | [CX-08](DEFECT-BACKLOG.md#cx-08) | Original ledger row |
+| R031 | [CX-09](DEFECT-BACKLOG.md#cx-09) | Original ledger row |
+| R032 | [CX-10](DEFECT-BACKLOG.md#cx-10) | Original ledger row |
+| R033 | [CX-11](DEFECT-BACKLOG.md#cx-11) | Original ledger row |
+| R034 | [CX-12](DEFECT-BACKLOG.md#cx-12) | Original ledger row |
+| R035 | [CX-13](DEFECT-BACKLOG.md#cx-13) | Original ledger row |
+| R036 | [BL-01](DEFECT-BACKLOG.md#bl-01) | Previously anonymous finding |
+| R037 | [BL-02](DEFECT-BACKLOG.md#bl-02) | Previously anonymous finding |
+| R038 | [BL-03](DEFECT-BACKLOG.md#bl-03) | Previously anonymous finding |
+| R039 | [BL-04](DEFECT-BACKLOG.md#bl-04) | Previously anonymous finding |
+| R040 | [BL-05](DEFECT-BACKLOG.md#bl-05) | Previously anonymous finding |
+| R041 | [BL-06](DEFECT-BACKLOG.md#bl-06) | Previously anonymous finding |
+| R042 | [BL-07](DEFECT-BACKLOG.md#bl-07) | Previously anonymous finding |
+| R043 | [BL-08](DEFECT-BACKLOG.md#bl-08) | Previously anonymous finding |
+| R044 | [BL-09](DEFECT-BACKLOG.md#bl-09) | Previously anonymous finding |
+| R045 | [BL-10](DEFECT-BACKLOG.md#bl-10) | Previously anonymous finding |
+| R046 | [BL-11](DEFECT-BACKLOG.md#bl-11) | Previously anonymous finding |
+| R047 | [BL-12](DEFECT-BACKLOG.md#bl-12) | Previously anonymous finding |
+| R048 | [BL-13](DEFECT-BACKLOG.md#bl-13) | Previously anonymous finding |
+| R049 | [BL-14](DEFECT-BACKLOG.md#bl-14) | Previously anonymous finding |
+| R050 | [BL-15](DEFECT-BACKLOG.md#bl-15) | Previously anonymous finding |
+| R051 | [BL-16](DEFECT-BACKLOG.md#bl-16) | Previously anonymous finding |
+| R052 | [BL-17](DEFECT-BACKLOG.md#bl-17) | Previously anonymous finding |
+| R053 | [BL-22](DEFECT-BACKLOG.md#bl-22) | Previously anonymous finding |
+| R054 | [BL-23](DEFECT-BACKLOG.md#bl-23) | Previously anonymous finding |
+| R055 | [BL-24](DEFECT-BACKLOG.md#bl-24) | Previously anonymous finding |
+| R056 | [CX-07](DEFECT-BACKLOG.md#cx-07) | Duplicate correction row |
+| R057 | [BL-02](DEFECT-BACKLOG.md#bl-02) | Duplicate withdrawal row |
+| R058 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | Baseline data, not a finding |
+| R059 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | Backup-read variant, not a separate finding |
+| R060 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | Streaming-hash variant, not a separate finding |
+| R061 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | XxHash variant, not a separate finding |
+| R062 | [BL-25](DEFECT-BACKLOG.md#bl-25) | Malformed comparison-table header, not a finding |
+| R063 | [BL-25](DEFECT-BACKLOG.md#bl-25) | Raw-hash comparison evidence |
+| R064 | [BL-25](DEFECT-BACKLOG.md#bl-25) | Content-digest comparison evidence |
+| R065 | [BL-25](DEFECT-BACKLOG.md#bl-25) | Backup-comparison evidence |
+| R066 | [Canonical ledger](DEFECT-BACKLOG.md#canonical-ledger) | Malformed score-table header, not a finding |
+| R067 | [CX-06](DEFECT-BACKLOG.md#cx-06) | Duplicate score row |
+| R068 | [BL-01](DEFECT-BACKLOG.md#bl-01) | Duplicate score row |
+| R069 | [EC-08](DEFECT-BACKLOG.md#ec-08) | Duplicate score row |
+| R070 | [BL-02](DEFECT-BACKLOG.md#bl-02) | Duplicate score row |
+| R071 | [EC-16](DEFECT-BACKLOG.md#ec-16) | Duplicate score row |
+| R072 | [EC-20](DEFECT-BACKLOG.md#ec-20) | Duplicate score row |
+| R073 | [EC-15](DEFECT-BACKLOG.md#ec-15) | Duplicate score row |
+| R074 | [EC-17](DEFECT-BACKLOG.md#ec-17) | Duplicate score row |
+| R075 | [EC-23](DEFECT-BACKLOG.md#ec-23) | Duplicate score row |
+| R076 | [EC-18](DEFECT-BACKLOG.md#ec-18) | Duplicate score row |
+| R077 | [BL-25](DEFECT-BACKLOG.md#bl-25) | Design-decision row |
+| R078 | [EC-19](DEFECT-BACKLOG.md#ec-19) | Malformed not-reproduced table header, not a finding |
+| R079 | [EC-19](DEFECT-BACKLOG.md#ec-19) | Duplicate evidence row |
+| P001 | [BL-18](DEFECT-BACKLOG.md#bl-18) | Former prose-only finding |
+| P002 | [BL-19](DEFECT-BACKLOG.md#bl-19) | Former prose-only finding |
+| P003 | [BL-20](DEFECT-BACKLOG.md#bl-20) | Former prose-only finding |
+| P004 | [BL-21](DEFECT-BACKLOG.md#bl-21) | Former prose-only finding |
+| S001 | [BL-26](DEFECT-BACKLOG.md#bl-26) | Former narrative-only GUI-driver finding |

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -50,13 +50,13 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 
 | ID | Finding | Status | Impact | Likelihood | Details |
 |---|---|---|---|---|---|
-| EC-17 | A text-validation comment contradicts the calculation | Open | Low | Common | [EC-17](#ec-17) |
-| EC-20 | Detection permits concurrent writes and deletes | Open | Low | Rare | [EC-20](#ec-20) |
-| CX-06 | The entropy gate runs before BOM detection | Open | Medium | Theoretical | [CX-06](#cx-06) |
-| BL-05 | Force-closing during a run can race UI callbacks | Open | Low | Rare | [BL-05](#bl-05) |
-| BL-19 | NUL-heavy ASCII can be reported as BOM-less UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
-| BL-20 | Hard-linked paths are processed independently | Open | Low | Rare | [BL-20](#bl-20) |
-| BL-21 | Detection can accept a truncated trailing sequence that conversion rejects | Open | Low | Rare | [BL-21](#bl-21) |
+| EC-17 | A comment describes the text check backwards | Open | Low | Common | [EC-17](#ec-17) |
+| EC-20 | A file can change while EC is detecting its encoding | Open | Low | Rare | [EC-20](#ec-20) |
+| CX-06 | EC checks for random-looking data before checking for a BOM | Open | Medium | Theoretical | [CX-06](#cx-06) |
+| BL-05 | Force-closing during a conversion can produce an error on exit | Open | Low | Rare | [BL-05](#bl-05) |
+| BL-19 | ASCII with many NUL bytes can be reported as UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
+| BL-20 | Two hard-link names for one file are converted separately | Open | Low | Rare | [BL-20](#bl-20) |
+| BL-21 | Detection can accept a cut-off final character that conversion rejects | Open | Low | Rare | [BL-21](#bl-21) |
 
 ### Fixed and resolved findings
 
@@ -121,171 +121,10 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 
 <!-- backlog-ledger:end -->
 
-## Details for open findings
+## Finding details
 
-### EC-08
-
-**Fixed by evaluating wildcard masks with .NET's non-backtracking engine.** The
-translation is unchanged — `*` becomes `.*`, `?` becomes `.`, and a
-separator-free mask still matches at any depth — so include and exclude results
-are the same. What changes is that matching runs in time proportional to the
-input rather than retrying an exponential number of alternatives.
-`NonBacktracking` replaces `Compiled`; the two are mutually exclusive.
-
-Was: `CompilePatterns` built a `Compiled` regex, which uses
-`Regex.InfiniteMatchTimeout`. A mask carrying twelve separated wildcards, matched
-against a nonmatching forty-character run of `a`, did not finish within three
-seconds and had to be terminated, while realistic names answered in 0–5 ms. The
-trigger needs both inputs to be deliberately hostile, and the mask comes from the
-operator rather than an untrusted file — which is why reach stayed Theoretical.
-An unbounded runtime is still worth removing for the price of one option.
-
-**It is not free, and the earlier note here that it cost nothing was wrong.**
-Measured over 3,937 files, median of five warm runs: 128 ms with `Compiled`
-against 148 ms with `NonBacktracking` — about 16%, or roughly 5 µs per file, and
-the same figure for a plain `*.txt` mask as for `*a*b*.txt`. That is the price of
-a bounded worst case, recorded so the next reader weighs it instead of
-rediscovering it.
-
-An independent differential comparison of the two engines over 500 generated
-masks against 200 generated paths — 100,000 pairs, including separators and the
-regex-special characters EC escapes — found no case where they disagreed.
-
-`PathAwarePatternTests.WildcardPatternsUseTheNonBacktrackingEngine` asserts the
-option before exercising the hostile input, so restoring the old engine fails in
-9 ms instead of hanging the run. That mutation was performed, and the file
-restored byte-identical by SHA-256.
-
-Three dead ends stay recorded: a matching filename stops at the first success and
-proves nothing; `*` crossing directory separators is deliberate and tested; and
-replacing `.*` with `[^/]*` does not prevent backtracking within a separator-free
-filename. `PathAwarePatternTests.PathQualifiedPattern_MatchesOnlyTheIntendedSubtree`
-pins the intended `src/*.cs` directory behavior.
-
-### EC-15
-
-**Before:** plans and journals carried five safety flags that were always `true`.
-EC never read them when applying a plan, so they proved nothing about whether any
-individual check had run - but a reader could easily take a serialized `true` as
-proof that one had.
-
-**Now:** the files carry one safety-rules version and a sentence describing it.
-EC checks the version; the sentence exists only to tell a reader what the version
-means.
-
-This was a clarity fix, not a conversion-safety fix. EC always executed its strict
-behaviour; only the artifact implied the flags were the reason.
-
-Evidence: `StrictDecoding`, `StrictEncoding`, `OutputVerification`,
-`AtomicInstall` and `LegacyRequiresExplicitSource` were replaced by
-`SemanticsDescription`, the sentence `ConversionSemantics.Describes` already
-held. `SemanticsVersion` remains the only enforced compatibility value, and a
-test confirms the description is never consulted: altering it inside a plan file
-changes nothing about whether that plan loads.
-
-The artifacts changed shape, so their versions say so: plan schema 5 to 6,
-journal schema 4 to 5. That rejects plans written by v3.13.0 as well as older
-ones - semantics 7 shipped in that release, so this is not the free change it
-would have been a day earlier.
-
-### EC-17
-
-**A comment describes the text check backwards.** Control and private-use
-characters *lower* the printable-text ratio. The comment beside the calculation
-says they are ignored.
-
-Nothing a user sees is wrong: the binary-rejection behaviour is the intended one.
-What is wrong is what the next person reads, which is why reach is Common.
-
-Evidence: `TextValidation.cs` increments the total rune count before its category
-switch, so those scalars count toward the denominator while never incrementing
-`printable`.
-
-Still open because the fix is not confined to one repository. The comment is
-byte-identical in EncodingChecker, LineEndingNormalizer and CorpusTesters, and
-the parity check requires it to stay that way, so all three must change together.
-
-### EC-18
-
-**Before:** EC remembered only when it *had* found a BOM-less UTF-16 ambiguity.
-When it found none, that answer was forgotten, and the full check could run again
-on the next pass.
-
-**Now:** both answers are remembered, so each file is examined once. The stored
-value is nullable: null means not yet classified, and `None` means classified
-with no doubt found.
-
-Nothing a user sees changes, which is why this carries no test of its own. It was
-not a speed problem either: measurement found no meaningful cost, because a
-provable file fails the opposite-order decode inside its first buffer. The defect
-was redundant work and a state that could not tell "no" from "not asked".
-
-### EC-20
-
-**A file can change while EC is working out what encoding it is.** Detection
-opens the file in a mode that lets another program write to it or delete it at
-the same time, so the encoding EC reports can describe bytes that have already
-changed.
-
-No source file is altered by this. Before conversion writes anything it takes its
-own copy of the bytes, bound to a hash. What can go stale is what detection and
-validation *report*.
-
-Evidence: `TextEncoding.DetectFromFile` opens with
-`FileShare.ReadWrite | FileShare.Delete`, while the validation and
-source-snapshot paths use `FileShare.Read`.
-
-Still open because the obvious correction is not obviously right. Tightening
-detection to match would make EC fail on any file another program holds open,
-which includes ordinary log files.
-
-### EC-23
-
-**Before:** applying a plan assumed an earlier check had already produced a valid
-file path. The assumption held, but nothing said so - and had later code bypassed
-that check, the failure would have surfaced as an unexplained null reference.
-
-**Now:** EC stops with an explicit error naming the check that must have run.
-
-Under the present flow nothing changes, which is why nothing new is asserted and
-no test accompanies it. EC-06 is what happened the last time an invariant of this
-shape was left implicit.
-
-Evidence: `FindStaleFiles` rejects a plan whose paths resolve outside its
-directory; reaching the dereference means that check did not run.
-
-### CX-06
-
-**EC decides a file looks like random data before it looks for a byte-order
-mark.** In principle a file could be reported as unknown, or as the wrong
-encoding, even though its first bytes say what it is.
-
-This changes what EC *reports*. It is not evidence that conversion writes a file
-it should have refused.
-
-Evidence: the entropy guard returns before `UnicodeDetector.DetectFromBuffer`
-examines the mark.
-
-**Re-scored Occasional to Theoretical on 2026-09-08, after measurement.** No
-text reaches the gate. Across all four corpora, 3,620 files are large enough to
-be gated (512 bytes) and 47 trip the 7.4-bit threshold — every one of them
-binary: 35 fixtures under `13_Binary/`, plus images and a spreadsheet in
-directories the corpora label `None`. The highest-entropy *text* file among 3,568
-candidates is dense Chinese XML in gb2312 at **6.8133**, a margin of 0.59 below
-the threshold, with UTF-16 Chinese just behind it. Base64 caps at 6.0 by
-construction. Reaching 7.4 needs a near-uniform byte distribution, which prose
-in any encoding does not produce.
-
-**A fix was written and then dropped**, which is the part worth recording. Making
-the guard yield to a byte-order mark works, and costs something measurable:
-`CheckBom` returns a codec from the marker bytes alone, so BOM-prefixed binary
-began detecting as `utf-16` instead of `(Unknown)`, and a scan containing one
-moved from exit 0 to exit 3. Strict validation still caught it and no bytes
-changed, so nothing was corrupted — but that is a measured behaviour change
-bought against a benefit no corpus file demonstrates.
-
-Reopen this on evidence of real text at or above the threshold, not on the
-mechanism, which is not in doubt.
+One entry per finding, ordered by ID. The status is not repeated here - the
+ledger above is the only place that assigns it, so these cannot disagree with it.
 
 ### BL-01
 
@@ -303,269 +142,6 @@ Widening the opposite-order test would not have been enough on its own — see
 [BL-18](#bl-18), whose bytes are *invalid* under the opposite UTF-32 order. Both
 are closed by refusing BOM-less UTF-32 outright, at the cost of refusing
 ordinary BOM-less UTF-32 as well; nothing in the bytes separates the two.
-
-### BL-05
-
-**Force-closing EC mid-conversion can produce an error as it exits.** If the user
-confirms a second close while the run is still stopping, a background task can
-try to use a window that has already gone.
-
-No file content is lost. Files already converted were installed one at a time and
-stay installed, and the file in flight stays protected. The expected symptom is
-an exception while EC closes.
-
-Evidence: `OnFormClosing` deliberately allows a confirmed second close, because
-cancellation is cooperative. A background task can then call the synchronous
-confirmation `Invoke`, and its completion touches controls on the form.
-
-Still open because it was confirmed by reading the current code rather than by
-triggering it; the timing it needs has not been reproduced.
-
-### BL-18
-
-**Fixed** by the same rule as [BL-01](#bl-01): BOM-less UTF-32 is refused
-rather than converted, so a UTF-16 file that happens to decode as UTF-32 is left
-alone instead of rewritten as different text.
-
-Was: a BOM-less UTF-16 file with one character per LF-terminated line puts a C0
-control in every second code unit, so each four-byte group is an in-range
-unassigned scalar and the file decodes as valid UTF-32. Converting it wrote
-different text, and output verification could not notice, because both sides of
-its comparison used the same wrong codec.
-
-This is the case an opposite-order test cannot catch: those bytes are *invalid*
-as UTF-32BE, so the check that protects BOM-less UTF-16 returns false. What the
-bytes fail to establish is the codec, not merely its byte order — which is why
-the fix refuses on the absence of a BOM rather than on ambiguity.
-
-No scalar classification changed. Private-use characters are what icon fonts put
-in ordinary text files, so rejecting unassigned or private-use scalars would have
-broken real sources; a test converts U+E000, U+F8FF, U+E0B0, U+F00C and U+F0000
-and checks all five survive.
-
-### BL-19
-
-**An ASCII file carrying many NUL bytes can be reported as UTF-16.** A current
-65,536-byte ASCII fixture with a NUL every 100 bytes — 1.001% of all bytes — was
-reported as UTF-16BE.
-
-Conversion then refused it with exit 5 and the source hash did not change. So the
-wrong answer reaches what EC *reports*, not what it writes. This is the one open
-finding where EC answers its own central question incorrectly.
-
-Evidence: the UTF-16 structure heuristic triggers at 2% of bytes within one
-candidate UTF-16 channel, which for this shape is roughly 1% of all bytes. An
-earlier version of this document said 2.3% of all bytes; that figure was wrong.
-
-### BL-20
-
-**Two names for one file are converted twice, and stop being the same file.**
-Windows can expose a single file under two hard-link names. EC treats them as two
-separate files and converts each.
-
-Text is preserved either way: in a current probe both names of one UTF-8 file
-were converted, both kept their text exactly, and each received its own verified
-`.bak` and `.ecmeta.json`. What is lost is the link itself — the normal Windows
-`File.Replace` path breaks it, so afterwards the two names refer to different
-files. The work is also done twice.
-
-No claim is made about the `File.Move(..., overwrite: true)` fallback, which
-could not be forced on this platform.
-
-Still open partly as a question rather than a defect: whether EC should preserve
-hard-link identity or treat selected paths independently is a design choice
-nobody has made.
-
-### BL-21
-
-**Detection can accept a cut-off final character that conversion then rejects.**
-A UTF-8 file ending in the incomplete bytes `E2 82` was reported as UTF-8 by
-`-DetectOnly`. Conversion refused the same file, returned `SourceDecodeError`
-and exit 3, and left it unchanged.
-
-The safety path is correct — the file is refused, not converted. The
-inconsistency is that detection had already reported it as fine.
-
-Evidence: detection reads a sample and does not treat an incomplete tail as an
-error. Conversion reaches the real end of the file and flushes the strict
-decoder, which does. The difference is deliberate on both sides.
-
-## Details for findings from the original review
-
-### EC-01
-
-**A reviewed refusal is binding.** `PlannedFile.HasReliableUnicodeDetection`
-carries the policy input that was formerly lost at the plan boundary.
-`AppliedPlanFidelityTests.ThePlanCarriesTheDetectionReliabilityTheVetoDependsOn`
-pins it.
-
-### EC-02
-
-**Read-only modes use the conversion safety decision.**
-`ReadOnlyModeAmbiguityTests` proves that an unprovable BOM-less Unicode source is
-not reported valid when conversion would refuse it.
-
-### EC-03
-
-**The v3.10.1 advisory reaches the real window.** GUI smoke phase H asserts on
-the rendered source-choice text rather than only on an internal decision.
-
-### EC-04
-
-**Plan failures control the exit code.** The plan branch returns processing
-failure before considering `-FailOnChanges`; `PlanPreflightReportingTests`
-covers the ordering.
-
-### EC-05
-
-**Only scheduled conversions require a source hash.** Plan loading no longer
-makes an unreadable skipped or refused entry render the whole plan unusable.
-
-### EC-06
-
-**Drive roots resolve without manufacturing `C:\\`.**
-`ConversionPlan.ResolvePath` now uses a root-aware containment check, with
-theories for `C:\`, nested paths, and outside paths.
-
-This defect was found before v3.11.0, recorded as confirmed, reported as closed,
-and shipped broken in both **v3.11.0 and v3.11.1**. It was rediscovered during an
-unrelated review. This history is why status is now derived from a checkable
-ledger rather than a summary.
-
-### EC-07
-
-**The refusal gives two actionable choices.**
-`BomlessUnicodeSafety.DescribeRefusal` offers both UTF-16 byte orders instead of
-recommending the unproved estimate.
-
-### EC-09
-
-**Selected EC artifacts are counted.** `.bak`, `.ecmeta.json`, and temporary
-conversion files update `TraversalCounters.FilesExcludedAsEcArtifact`, pinned by
-`ArtifactExclusionCoverageTests`.
-
-### EC-10
-
-**A failed snapshot is an error, not a policy decision.** Journal outcome tests
-pin `ScanFailed` to `Error` rather than `Refused`.
-
-### EC-11
-
-**Both console cancellation subscriptions have bounded lifetimes.** Each Ctrl+C
-handler is removed in `finally`, so it cannot retain a disposed token source.
-
-### EC-12
-
-**Skipped and unchanged are separate GUI counts.** The tally is pinned by
-`SkippedFilesAreNotCountedAsUnchanged`.
-
-### EC-13
-
-**Mixed batches describe source choice per file.** `DescribeSourceChoice` no
-longer presents one run-wide explicit encoding when several were used.
-
-### EC-14
-
-**Source and output text hashes come from separate reads.** The conversion
-record accepts the output digest produced by verification and rejects a missing
-one; `RecordedProvenanceTests` compares the installed output independently.
-
-### EC-16
-
-**Settings use the same atomic artifact writer as other records.** An
-interruption before replacement leaves the previous preferences intact. This
-was closed incidentally by the v3.12.1 artifact-writer refactor, not by a
-settings-specific change.
-
-### EC-19
-
-**The proposed encoding-instance gap did not reach conversion.** Conversion
-re-resolves the codec name through `Encoding.GetEncoding`, whose UTF-8 instance
-has the expected preamble. A current file beginning with two UTF-8 BOMs was
-refused with `MultipleLeadingByteOrderMarks` and exit 5 through both automatic
-detection and `-From utf-8`.
-
-### EC-21
-
-**All three save dialogs have deterministic disposal.** Each construction site
-uses `using var`.
-
-### EC-22
-
-**Each JSON store shares its reader and writer options.** Plan and recovery
-metadata no longer serialize and deserialize through mismatched option objects.
-
-### CX-01
-
-**A present option must carry a usable value.** Empty values for all value-taking
-flags are rejected with exit 1; `BlankOptionValueSafetyTests` verifies that
-nothing changes.
-
-### CX-02
-
-**A stale sidecar cannot survive backup replacement.**
-`RemoveBeforeBackupReplacement` removes the old record before replacing the
-backup, including a read-only record.
-
-### CX-03
-
-**Applied plans re-check every path component.**
-`HasReparsePointInPath` rejects a root or descendant replaced by a junction;
-applied-plan integrity tests cover the final component and outside-root cases.
-
-### CX-05
-
-**The journal can say what is and is not known after installation.**
-`ConvertedWithWarning` distinguishes a completed install with a later warning;
-`InstallationUnknown` represents a failure after the replacement outcome can no
-longer be proved.
-
-### CX-07
-
-**Old JSON and CSV artifacts are intentionally ordinary input.** The earlier
-ledger claimed they were excluded and even described a correction that was
-never made. `docs/CLI.md` deliberately says old plans, journals, and reports are
-scanned because a user may wish to convert them. A current `old-plan.json` probe
-was detected as ASCII. Only backups, sidecars, temporary files, and the current
-command's output paths are excluded.
-
-This false correction was discovered by re-deriving the row from source rather
-than trusting its own note.
-
-### CX-08
-
-**CLI mode conflicts are executable documentation.**
-`DocumentedOptionContractTests` pins the rejected combinations around
-`-DetectOnly`, validation, conversion, plan, and apply.
-
-### CX-09
-
-**An interrupted GUI write run still produces a journal.** Unit coverage and
-GUI smoke phase I reconcile completed and unattempted entries.
-
-### CX-10
-
-**An explicit choice does not erase detection history.** Plan summaries now say
-“chosen by you; detection still ran and is recorded,” with provenance tests.
-
-### CX-11
-
-**Settings-path creation is inside startup error handling.** A failure no longer
-escapes before the guarded settings load begins.
-
-### CX-12
-
-**Window restoration checks the monitors that exist now.**
-`WindowPosition.IsReachable` requires a useful title-bar intersection, with
-tests for removed, left-side, and secondary displays.
-
-### CX-13
-
-**Detector parity is enforced before integration and release.** The parity
-workflow runs on pull requests, and the release workflow declares it as a job
-dependency.
-
-## Details for findings found later
 
 ### BL-02
 
@@ -596,6 +172,23 @@ Before this correction, choosing an encoding after the review's directory had
 changed could close the dialog and report “Conversion cancelled. No files were
 modified,” although the user had not cancelled. EC-06 made every row hit that
 path when the review root was a drive root.
+
+### BL-05
+
+**Force-closing EC mid-conversion can produce an error as it exits.** If the user
+confirms a second close while the run is still stopping, a background task can
+try to use a window that has already gone.
+
+No file content is lost. Files already converted were installed one at a time and
+stay installed, and the file in flight stays protected. The expected symptom is
+an exception while EC closes.
+
+Evidence: `OnFormClosing` deliberately allows a confirmed second close, because
+cancellation is cooperative. A background task can then call the synchronous
+confirmation `Invoke`, and its completion touches controls on the form.
+
+Still open because it was confirmed by reading the current code rather than by
+triggering it; the timing it needs has not been reproduced.
 
 ### BL-06
 
@@ -714,27 +307,74 @@ an ordinary “wrong target, convert again” workflow until the user manually
 deleted recovery files. CX-02 instead ensures stale metadata cannot describe a
 new backup.
 
-### BL-27
+### BL-18
 
-**Fixed by promising only what the build being driven can show.** The report
-hashes a loose managed assembly when one sits beside the executable, and says
-there is none when it does not, rather than printing a path with an empty hash
-after it. `RELEASE-CHECKLIST.md` and `GUI-SMOKE-TEST.md` describe both cases.
-The executable *is* the artifact, so its hash is the provenance that matters;
-v3.13.0 demonstrated the stronger form by reproducing that hash byte-for-byte
-from the tagged commit.
+**Fixed** by the same rule as [BL-01](#bl-01): BOM-less UTF-32 is refused
+rather than converted, so a UTF-16 file that happens to decode as UTF-32 is left
+alone instead of rewritten as different text.
 
-Was: `gui-smoke-report.json` carried no `EcManagedAssemblySha256` key and the
-Markdown rendered an empty pair of backticks, while both printed the
-`EncodingChecker.dll` path as though a value followed — because a single-file
-publish leaves no loose DLL where the suite looked. That held since single-file
-publishing began, so the v3.12.0 and v3.12.1 evidence carries the same empty
-field.
+Was: a BOM-less UTF-16 file with one character per LF-terminated line puts a C0
+control in every second code unit, so each four-byte group is an in-range
+unassigned scalar and the file decodes as valid UTF-32. Converting it wrote
+different text, and output verification could not notice, because both sides of
+its comparison used the same wrong codec.
 
-The alternative, hashing the publish intermediate `win-x64/EncodingChecker.dll`,
-was rejected: it exists only during the build and no user ever receives it, so
-recording it would document a byproduct rather than the release. Nothing about
-conversion was involved either way; this is evidence hygiene.
+This is the case an opposite-order test cannot catch: those bytes are *invalid*
+as UTF-32BE, so the check that protects BOM-less UTF-16 returns false. What the
+bytes fail to establish is the codec, not merely its byte order — which is why
+the fix refuses on the absence of a BOM rather than on ambiguity.
+
+No scalar classification changed. Private-use characters are what icon fonts put
+in ordinary text files, so rejecting unassigned or private-use scalars would have
+broken real sources; a test converts U+E000, U+F8FF, U+E0B0, U+F00C and U+F0000
+and checks all five survive.
+
+### BL-19
+
+**An ASCII file carrying many NUL bytes can be reported as UTF-16.** A current
+65,536-byte ASCII fixture with a NUL every 100 bytes — 1.001% of all bytes — was
+reported as UTF-16BE.
+
+Conversion then refused it with exit 5 and the source hash did not change. So the
+wrong answer reaches what EC *reports*, not what it writes. This is the one open
+finding where EC answers its own central question incorrectly.
+
+Evidence: the UTF-16 structure heuristic triggers at 2% of bytes within one
+candidate UTF-16 channel, which for this shape is roughly 1% of all bytes. An
+earlier version of this document said 2.3% of all bytes; that figure was wrong.
+
+### BL-20
+
+**Two names for one file are converted twice, and stop being the same file.**
+Windows can expose a single file under two hard-link names. EC treats them as two
+separate files and converts each.
+
+Text is preserved either way: in a current probe both names of one UTF-8 file
+were converted, both kept their text exactly, and each received its own verified
+`.bak` and `.ecmeta.json`. What is lost is the link itself — the normal Windows
+`File.Replace` path breaks it, so afterwards the two names refer to different
+files. The work is also done twice.
+
+No claim is made about the `File.Move(..., overwrite: true)` fallback, which
+could not be forced on this platform.
+
+Still open partly as a question rather than a defect: whether EC should preserve
+hard-link identity or treat selected paths independently is a design choice
+nobody has made.
+
+### BL-21
+
+**Detection can accept a cut-off final character that conversion then rejects.**
+A UTF-8 file ending in the incomplete bytes `E2 82` was reported as UTF-8 by
+`-DetectOnly`. Conversion refused the same file, returned `SourceDecodeError`
+and exit 3, and left it unchanged.
+
+The safety path is correct — the file is refused, not converted. The
+inconsistency is that detection had already reported it as fine.
+
+Evidence: detection reads a sample and does not treat an incomplete tail as an
+error. Conversion reaches the real end of the file and flushes the strict
+decoder, which does. The difference is deliberate on both sides.
 
 ### BL-22
 
@@ -814,6 +454,365 @@ built application.
 This fix kept the search-for-an-item design and made it consistent.
 [EC-24](#ec-24) later found that searching for items at all was unreliable, and
 replaced the approach rather than adjusting it again.
+
+### BL-27
+
+**Fixed by promising only what the build being driven can show.** The report
+hashes a loose managed assembly when one sits beside the executable, and says
+there is none when it does not, rather than printing a path with an empty hash
+after it. `RELEASE-CHECKLIST.md` and `GUI-SMOKE-TEST.md` describe both cases.
+The executable *is* the artifact, so its hash is the provenance that matters;
+v3.13.0 demonstrated the stronger form by reproducing that hash byte-for-byte
+from the tagged commit.
+
+Was: `gui-smoke-report.json` carried no `EcManagedAssemblySha256` key and the
+Markdown rendered an empty pair of backticks, while both printed the
+`EncodingChecker.dll` path as though a value followed — because a single-file
+publish leaves no loose DLL where the suite looked. That held since single-file
+publishing began, so the v3.12.0 and v3.12.1 evidence carries the same empty
+field.
+
+The alternative, hashing the publish intermediate `win-x64/EncodingChecker.dll`,
+was rejected: it exists only during the build and no user ever receives it, so
+recording it would document a byproduct rather than the release. Nothing about
+conversion was involved either way; this is evidence hygiene.
+
+### CX-01
+
+**A present option must carry a usable value.** Empty values for all value-taking
+flags are rejected with exit 1; `BlankOptionValueSafetyTests` verifies that
+nothing changes.
+
+### CX-02
+
+**A stale sidecar cannot survive backup replacement.**
+`RemoveBeforeBackupReplacement` removes the old record before replacing the
+backup, including a read-only record.
+
+### CX-03
+
+**Applied plans re-check every path component.**
+`HasReparsePointInPath` rejects a root or descendant replaced by a junction;
+applied-plan integrity tests cover the final component and outside-root cases.
+
+### CX-05
+
+**The journal can say what is and is not known after installation.**
+`ConvertedWithWarning` distinguishes a completed install with a later warning;
+`InstallationUnknown` represents a failure after the replacement outcome can no
+longer be proved.
+
+### CX-06
+
+**EC decides a file looks like random data before it looks for a byte-order
+mark.** In principle a file could be reported as unknown, or as the wrong
+encoding, even though its first bytes say what it is.
+
+This changes what EC *reports*. It is not evidence that conversion writes a file
+it should have refused.
+
+Evidence: the entropy guard returns before `UnicodeDetector.DetectFromBuffer`
+examines the mark.
+
+**Re-scored Occasional to Theoretical on 2026-09-08, after measurement.** No
+text reaches the gate. Across all four corpora, 3,620 files are large enough to
+be gated (512 bytes) and 47 trip the 7.4-bit threshold — every one of them
+binary: 35 fixtures under `13_Binary/`, plus images and a spreadsheet in
+directories the corpora label `None`. The highest-entropy *text* file among 3,568
+candidates is dense Chinese XML in gb2312 at **6.8133**, a margin of 0.59 below
+the threshold, with UTF-16 Chinese just behind it. Base64 caps at 6.0 by
+construction. Reaching 7.4 needs a near-uniform byte distribution, which prose
+in any encoding does not produce.
+
+**A fix was written and then dropped**, which is the part worth recording. Making
+the guard yield to a byte-order mark works, and costs something measurable:
+`CheckBom` returns a codec from the marker bytes alone, so BOM-prefixed binary
+began detecting as `utf-16` instead of `(Unknown)`, and a scan containing one
+moved from exit 0 to exit 3. Strict validation still caught it and no bytes
+changed, so nothing was corrupted — but that is a measured behaviour change
+bought against a benefit no corpus file demonstrates.
+
+Reopen this on evidence of real text at or above the threshold, not on the
+mechanism, which is not in doubt.
+
+### CX-07
+
+**Old JSON and CSV artifacts are intentionally ordinary input.** The earlier
+ledger claimed they were excluded and even described a correction that was
+never made. `docs/CLI.md` deliberately says old plans, journals, and reports are
+scanned because a user may wish to convert them. A current `old-plan.json` probe
+was detected as ASCII. Only backups, sidecars, temporary files, and the current
+command's output paths are excluded.
+
+This false correction was discovered by re-deriving the row from source rather
+than trusting its own note.
+
+### CX-08
+
+**CLI mode conflicts are executable documentation.**
+`DocumentedOptionContractTests` pins the rejected combinations around
+`-DetectOnly`, validation, conversion, plan, and apply.
+
+### CX-09
+
+**An interrupted GUI write run still produces a journal.** Unit coverage and
+GUI smoke phase I reconcile completed and unattempted entries.
+
+### CX-10
+
+**An explicit choice does not erase detection history.** Plan summaries now say
+“chosen by you; detection still ran and is recorded,” with provenance tests.
+
+### CX-11
+
+**Settings-path creation is inside startup error handling.** A failure no longer
+escapes before the guarded settings load begins.
+
+### CX-12
+
+**Window restoration checks the monitors that exist now.**
+`WindowPosition.IsReachable` requires a useful title-bar intersection, with
+tests for removed, left-side, and secondary displays.
+
+### CX-13
+
+**Detector parity is enforced before integration and release.** The parity
+workflow runs on pull requests, and the release workflow declares it as a job
+dependency.
+
+### EC-01
+
+**A reviewed refusal is binding.** `PlannedFile.HasReliableUnicodeDetection`
+carries the policy input that was formerly lost at the plan boundary.
+`AppliedPlanFidelityTests.ThePlanCarriesTheDetectionReliabilityTheVetoDependsOn`
+pins it.
+
+### EC-02
+
+**Read-only modes use the conversion safety decision.**
+`ReadOnlyModeAmbiguityTests` proves that an unprovable BOM-less Unicode source is
+not reported valid when conversion would refuse it.
+
+### EC-03
+
+**The v3.10.1 advisory reaches the real window.** GUI smoke phase H asserts on
+the rendered source-choice text rather than only on an internal decision.
+
+### EC-04
+
+**Plan failures control the exit code.** The plan branch returns processing
+failure before considering `-FailOnChanges`; `PlanPreflightReportingTests`
+covers the ordering.
+
+### EC-05
+
+**Only scheduled conversions require a source hash.** Plan loading no longer
+makes an unreadable skipped or refused entry render the whole plan unusable.
+
+### EC-06
+
+**Drive roots resolve without manufacturing `C:\\`.**
+`ConversionPlan.ResolvePath` now uses a root-aware containment check, with
+theories for `C:\`, nested paths, and outside paths.
+
+This defect was found before v3.11.0, recorded as confirmed, reported as closed,
+and shipped broken in both **v3.11.0 and v3.11.1**. It was rediscovered during an
+unrelated review. This history is why status is now derived from a checkable
+ledger rather than a summary.
+
+### EC-07
+
+**The refusal gives two actionable choices.**
+`BomlessUnicodeSafety.DescribeRefusal` offers both UTF-16 byte orders instead of
+recommending the unproved estimate.
+
+### EC-08
+
+**Fixed by evaluating wildcard masks with .NET's non-backtracking engine.** The
+translation is unchanged — `*` becomes `.*`, `?` becomes `.`, and a
+separator-free mask still matches at any depth — so include and exclude results
+are the same. What changes is that matching runs in time proportional to the
+input rather than retrying an exponential number of alternatives.
+`NonBacktracking` replaces `Compiled`; the two are mutually exclusive.
+
+Was: `CompilePatterns` built a `Compiled` regex, which uses
+`Regex.InfiniteMatchTimeout`. A mask carrying twelve separated wildcards, matched
+against a nonmatching forty-character run of `a`, did not finish within three
+seconds and had to be terminated, while realistic names answered in 0–5 ms. The
+trigger needs both inputs to be deliberately hostile, and the mask comes from the
+operator rather than an untrusted file — which is why reach stayed Theoretical.
+An unbounded runtime is still worth removing for the price of one option.
+
+**It is not free, and the earlier note here that it cost nothing was wrong.**
+Measured over 3,937 files, median of five warm runs: 128 ms with `Compiled`
+against 148 ms with `NonBacktracking` — about 16%, or roughly 5 µs per file, and
+the same figure for a plain `*.txt` mask as for `*a*b*.txt`. That is the price of
+a bounded worst case, recorded so the next reader weighs it instead of
+rediscovering it.
+
+An independent differential comparison of the two engines over 500 generated
+masks against 200 generated paths — 100,000 pairs, including separators and the
+regex-special characters EC escapes — found no case where they disagreed.
+
+`PathAwarePatternTests.WildcardPatternsUseTheNonBacktrackingEngine` asserts the
+option before exercising the hostile input, so restoring the old engine fails in
+9 ms instead of hanging the run. That mutation was performed, and the file
+restored byte-identical by SHA-256.
+
+Three dead ends stay recorded: a matching filename stops at the first success and
+proves nothing; `*` crossing directory separators is deliberate and tested; and
+replacing `.*` with `[^/]*` does not prevent backtracking within a separator-free
+filename. `PathAwarePatternTests.PathQualifiedPattern_MatchesOnlyTheIntendedSubtree`
+pins the intended `src/*.cs` directory behavior.
+
+### EC-09
+
+**Selected EC artifacts are counted.** `.bak`, `.ecmeta.json`, and temporary
+conversion files update `TraversalCounters.FilesExcludedAsEcArtifact`, pinned by
+`ArtifactExclusionCoverageTests`.
+
+### EC-10
+
+**A failed snapshot is an error, not a policy decision.** Journal outcome tests
+pin `ScanFailed` to `Error` rather than `Refused`.
+
+### EC-11
+
+**Both console cancellation subscriptions have bounded lifetimes.** Each Ctrl+C
+handler is removed in `finally`, so it cannot retain a disposed token source.
+
+### EC-12
+
+**Skipped and unchanged are separate GUI counts.** The tally is pinned by
+`SkippedFilesAreNotCountedAsUnchanged`.
+
+### EC-13
+
+**Mixed batches describe source choice per file.** `DescribeSourceChoice` no
+longer presents one run-wide explicit encoding when several were used.
+
+### EC-14
+
+**Source and output text hashes come from separate reads.** The conversion
+record accepts the output digest produced by verification and rejects a missing
+one; `RecordedProvenanceTests` compares the installed output independently.
+
+### EC-15
+
+**Before:** plans and journals carried five safety flags that were always `true`.
+EC never read them when applying a plan, so they proved nothing about whether any
+individual check had run - but a reader could easily take a serialized `true` as
+proof that one had.
+
+**Now:** the files carry one safety-rules version and a sentence describing it.
+EC checks the version; the sentence exists only to tell a reader what the version
+means.
+
+This was a clarity fix, not a conversion-safety fix. EC always executed its strict
+behaviour; only the artifact implied the flags were the reason.
+
+Evidence: `StrictDecoding`, `StrictEncoding`, `OutputVerification`,
+`AtomicInstall` and `LegacyRequiresExplicitSource` were replaced by
+`SemanticsDescription`, the sentence `ConversionSemantics.Describes` already
+held. `SemanticsVersion` remains the only enforced compatibility value, and a
+test confirms the description is never consulted: altering it inside a plan file
+changes nothing about whether that plan loads.
+
+The artifacts changed shape, so their versions say so: plan schema 5 to 6,
+journal schema 4 to 5. That rejects plans written by v3.13.0 as well as older
+ones - semantics 7 shipped in that release, so this is not the free change it
+would have been a day earlier.
+
+### EC-16
+
+**Settings use the same atomic artifact writer as other records.** An
+interruption before replacement leaves the previous preferences intact. This
+was closed incidentally by the v3.12.1 artifact-writer refactor, not by a
+settings-specific change.
+
+### EC-17
+
+**A comment describes the text check backwards.** Control and private-use
+characters *lower* the printable-text ratio. The comment beside the calculation
+says they are ignored.
+
+Nothing a user sees is wrong: the binary-rejection behaviour is the intended one.
+What is wrong is what the next person reads, which is why reach is Common.
+
+Evidence: `TextValidation.cs` increments the total rune count before its category
+switch, so those scalars count toward the denominator while never incrementing
+`printable`.
+
+Still open because the fix is not confined to one repository. The comment is
+byte-identical in EncodingChecker, LineEndingNormalizer and CorpusTesters, and
+the parity check requires it to stay that way, so all three must change together.
+
+### EC-18
+
+**Before:** EC remembered only when it *had* found a BOM-less UTF-16 ambiguity.
+When it found none, that answer was forgotten, and the full check could run again
+on the next pass.
+
+**Now:** both answers are remembered, so each file is examined once. The stored
+value is nullable: null means not yet classified, and `None` means classified
+with no doubt found.
+
+Nothing a user sees changes, which is why this carries no test of its own. It was
+not a speed problem either: measurement found no meaningful cost, because a
+provable file fails the opposite-order decode inside its first buffer. The defect
+was redundant work and a state that could not tell "no" from "not asked".
+
+### EC-19
+
+**The proposed encoding-instance gap did not reach conversion.** Conversion
+re-resolves the codec name through `Encoding.GetEncoding`, whose UTF-8 instance
+has the expected preamble. A current file beginning with two UTF-8 BOMs was
+refused with `MultipleLeadingByteOrderMarks` and exit 5 through both automatic
+detection and `-From utf-8`.
+
+### EC-20
+
+**A file can change while EC is working out what encoding it is.** Detection
+opens the file in a mode that lets another program write to it or delete it at
+the same time, so the encoding EC reports can describe bytes that have already
+changed.
+
+No source file is altered by this. Before conversion writes anything it takes its
+own copy of the bytes, bound to a hash. What can go stale is what detection and
+validation *report*.
+
+Evidence: `TextEncoding.DetectFromFile` opens with
+`FileShare.ReadWrite | FileShare.Delete`, while the validation and
+source-snapshot paths use `FileShare.Read`.
+
+Still open because the obvious correction is not obviously right. Tightening
+detection to match would make EC fail on any file another program holds open,
+which includes ordinary log files.
+
+### EC-21
+
+**All three save dialogs have deterministic disposal.** Each construction site
+uses `using var`.
+
+### EC-22
+
+**Each JSON store shares its reader and writer options.** Plan and recovery
+metadata no longer serialize and deserialize through mismatched option objects.
+
+### EC-23
+
+**Before:** applying a plan assumed an earlier check had already produced a valid
+file path. The assumption held, but nothing said so - and had later code bypassed
+that check, the failure would have surfaced as an unexplained null reference.
+
+**Now:** EC stops with an explicit error naming the check that must have run.
+
+Under the present flow nothing changes, which is why nothing new is asserted and
+no test accompanies it. EC-06 is what happened the last time an invariant of this
+shape was left implicit.
+
+Evidence: `FindStaleFiles` rejects a plan whose paths resolve outside its
+directory; reaching the dereference means that check did not run.
 
 ### EC-24
 **Before:** the smoke driver picked an encoding by searching for a list item -

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,39 +4,39 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=63 fixed=52 open=7 not-reproduced=1 withdrawn=1 not-a-defect=1 decision=1 -->
+<!-- backlog-counts total=63 fixed=52 open=7 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
 
-**Derived count: 63 findings — 52 fixed, 7 open, 1 not reproduced,
-1 withdrawn, 1 not a defect, and 1 design decision.** Recompute and validate
-these figures with:
+**Derived count: 63 findings — 52 fixed, 7 open, 1 not reproduced, 1 withdrawn,
+1 intentional behavior, and 1 design decision.** Recompute and check these
+figures with:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File docs/Test-DefectBacklog.ps1
 ```
 
-`powershell` rather than `pwsh` because it is present on every Windows machine; the script
-is ASCII-only and needs no BOM, so either shell runs it. `-ExecutionPolicy Bypass` because
-this repository ships no signed scripts and a stock machine refuses to run them at all. It
-applies to that one process and changes nothing on the machine.
+The checker reads the tables below, verifies that IDs are unique and statuses
+known, requires both impact and likelihood for every open finding, and confirms
+each row links to its own detail heading. Why that exact command, rather than any
+other, is explained at the top of the script.
 
-The checker reads the canonical tables below, verifies unique IDs and known
-statuses, and requires both impact and reach for every open finding.
+## What the statuses mean
 
-## Status and scoring rules
+- **Fixed** - the problem has been corrected, and a current source location,
+  regression test or current-build probe shows the correction in place.
+- **Open** - the problem is still possible: the behaviour remains reachable, or
+  a source path to it remains.
+- **Not reproduced** - a current attempt did not trigger it. That is weaker than
+  proof that it cannot happen.
+- **Withdrawn** - later evidence showed the original report was wrong.
+- **Intentional behavior** - the implementation matches a deliberate contract.
+- **Decision** - two defensible approaches exist and a maintainer may reconsider
+  the choice. It is not a product correction.
 
-- **Fixed** means the responsible code is gone and a current source location,
-  regression test, or current-build probe demonstrates the replacement.
-- **Open** means the behavior remains reachable or a source path to it remains.
-- **Not reproduced** means a current attempt did not trigger the proposed
-  behavior; that is weaker than proof that it cannot occur.
-- **Withdrawn** means the proposed defect was disproved.
-- **Not a defect** means the implementation matches an intentional contract.
-- **Decision** records a deliberate design difference that needs a choice, not
-  a product correction.
-
-Impact asks what a user loses if a finding occurs. Reach asks how readily the
-preconditions occur. They are kept separate because a severe but constructed
-case and a harmless common case require different decisions.
+Two scores are kept apart. **Impact** asks what a user loses if the finding
+occurs. **Likelihood** asks how readily its preconditions arise - not how often
+it is seen in the wild, which nobody here has measured. A severe but constructed
+case and a harmless everyday one need different decisions, and one number cannot
+carry both.
 
 ## Canonical ledger
 
@@ -48,7 +48,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 
 ### Open findings
 
-| ID | Finding | Status | Impact | Reach | Details |
+| ID | Finding | Status | Impact | Likelihood | Details |
 |---|---|---|---|---|---|
 | EC-17 | A text-validation comment contradicts the calculation | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | Detection permits concurrent writes and deletes | Open | Low | Rare | [EC-20](#ec-20) |
@@ -58,70 +58,70 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | BL-20 | Hard-linked paths are processed independently | Open | Low | Rare | [BL-20](#bl-20) |
 | BL-21 | Detection can accept a truncated trailing sequence that conversion rejects | Open | Low | Rare | [BL-21](#bl-21) |
 
-### Closed and other findings
+### Fixed and resolved findings
 
-| ID | Finding | Status | Impact | Reach | Details |
+| ID | Finding | Status | Impact | Likelihood | Details |
 |---|---|---|---|---|---|
-| EC-01 | Applying a plan could convert a file the plan refused | Fixed | — | — | [EC-01](#ec-01) |
-| EC-02 | Read-only validation disagreed with the BOM-less Unicode safety policy | Fixed | — | — | [EC-02](#ec-02) |
+| EC-01 | A saved plan could convert a file it had marked Refused | Fixed | — | — | [EC-01](#ec-01) |
+| EC-02 | Validation could approve a file that conversion would refuse | Fixed | — | — | [EC-02](#ec-02) |
 | EC-03 | The GUI omitted the source-choice advisory | Fixed | — | — | [EC-03](#ec-03) |
 | EC-04 | `-Plan` could exit successfully after scan failures | Fixed | — | — | [EC-04](#ec-04) |
-| BL-01 | Ambiguous BOM-less UTF-32 can be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
+| BL-01 | Ambiguous BOM-less UTF-32 could be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
 | EC-08 | A constructed include pattern could hang a scan indefinitely | Fixed | — | — | [EC-08](#ec-08) |
 | EC-24 | The GUI smoke gate could select in the wrong combo | Fixed | — | — | [EC-24](#ec-24) |
-| EC-18 | A negative BOM-less UTF-16 ambiguity result is recomputed | Fixed | — | — | [EC-18](#ec-18) |
-| EC-23 | Plan application relies on a null-forgiving path dereference | Fixed | — | — | [EC-23](#ec-23) |
-| BL-27 | Release evidence records no managed-assembly hash | Fixed | — | — | [BL-27](#bl-27) |
-| EC-15 | Serialized conversion guarantees are not enforced individually | Fixed | — | — | [EC-15](#ec-15) |
-| BL-18 | BOM-less UTF-16 can be detected and converted as UTF-32 | Fixed | — | — | [BL-18](#bl-18) |
-| EC-05 | An unreadable non-conversion plan entry made a plan unusable | Fixed | — | — | [EC-05](#ec-05) |
-| EC-06 | A drive-root base path made every plan unusable | Fixed | — | — | [EC-06](#ec-06) |
+| EC-18 | EC repeated a BOM-less UTF-16 safety check unnecessarily | Fixed | — | — | [EC-18](#ec-18) |
+| EC-23 | Plan application assumed a required path existed instead of checking it | Fixed | — | — | [EC-23](#ec-23) |
+| BL-27 | GUI smoke reports could show an empty or misleading build hash | Fixed | — | — | [BL-27](#bl-27) |
+| EC-15 | Plans and journals showed fixed safety flags as if they recorded checks | Fixed | — | — | [EC-15](#ec-15) |
+| BL-18 | BOM-less UTF-16 could be detected and converted as UTF-32 | Fixed | — | — | [BL-18](#bl-18) |
+| EC-05 | An unreadable skipped or refused entry blocked the whole plan | Fixed | — | — | [EC-05](#ec-05) |
+| EC-06 | Plans rooted at a drive letter could not be applied | Fixed | — | — | [EC-06](#ec-06) |
 | EC-07 | A refusal advised the same ambiguous encoding it rejected | Fixed | — | — | [EC-07](#ec-07) |
 | EC-09 | Excluded EC artifacts were uncounted | Fixed | — | — | [EC-09](#ec-09) |
 | EC-10 | A scan failure was journaled as a policy refusal | Fixed | — | — | [EC-10](#ec-10) |
 | EC-11 | Plan application leaked a Ctrl+C handler | Fixed | — | — | [EC-11](#ec-11) |
 | EC-12 | The GUI counted skipped files as unchanged | Fixed | — | — | [EC-12](#ec-12) |
 | EC-13 | A mixed-source plan could report one source encoding for the run | Fixed | — | — | [EC-13](#ec-13) |
-| EC-14 | The output-text hash copied the source-text hash | Fixed | — | — | [EC-14](#ec-14) |
-| EC-16 | Settings were written by truncating the live file | Fixed | — | — | [EC-16](#ec-16) |
+| EC-14 | The journal recorded the source text hash as the output text hash | Fixed | — | — | [EC-14](#ec-14) |
+| EC-16 | An interrupted settings save could erase the previous settings | Fixed | — | — | [EC-16](#ec-16) |
 | EC-19 | Double-BOM handling depended on the encoding instance | Not reproduced | — | — | [EC-19](#ec-19) |
 | EC-21 | Save dialogs were not disposed | Fixed | — | — | [EC-21](#ec-21) |
-| EC-22 | Plan and metadata readers used different JSON options from writers | Fixed | — | — | [EC-22](#ec-22) |
+| EC-22 | EC read some JSON files differently from how it wrote them | Fixed | — | — | [EC-22](#ec-22) |
 | CX-01 | Empty option values were silently treated as absent | Fixed | — | — | [CX-01](#cx-01) |
 | CX-02 | A failed second conversion could destroy the first recovery record | Fixed | — | — | [CX-02](#cx-02) |
-| CX-03 | Applying a plan followed a root replaced by a junction | Fixed | — | — | [CX-03](#cx-03) |
-| CX-05 | The journal could not represent uncertainty after installation | Fixed | — | — | [CX-05](#cx-05) |
-| CX-07 | Old plans, journals, and reports should be excluded from scans | Not a defect | — | — | [CX-07](#cx-07) |
+| CX-03 | A saved plan could follow a folder path redirected after approval | Fixed | — | — | [CX-03](#cx-03) |
+| CX-05 | The journal could not describe an uncertain result after replacement | Fixed | — | — | [CX-05](#cx-05) |
+| CX-07 | Old plans, journals, and reports should be excluded from scans | Intentional behavior | — | — | [CX-07](#cx-07) |
 | CX-08 | Documentation and validation disagreed about `-DetectOnly` conflicts | Fixed | — | — | [CX-08](#cx-08) |
 | CX-09 | Cancelling after writes produced no journal | Fixed | — | — | [CX-09](#cx-09) |
 | CX-10 | Plan summaries said detection was bypassed when it ran | Fixed | — | — | [CX-10](#cx-10) |
 | CX-11 | GUI startup could fail before settings error handling began | Fixed | — | — | [CX-11](#cx-11) |
 | CX-12 | Saved window positions ignored the current monitor layout | Fixed | — | — | [CX-12](#cx-12) |
-| CX-13 | Detector parity was not a pull-request or release gate | Fixed | — | — | [CX-13](#cx-13) |
+| CX-13 | CI did not verify that EC, LEN and CorpusTesters shared the detector | Fixed | — | — | [CX-13](#cx-13) |
 | BL-02 | CSV cells need formula neutralization | Withdrawn | — | — | [BL-02](#bl-02) |
 | BL-03 | Conversion parallelism was capped at four | Fixed | — | — | [BL-03](#bl-03) |
-| BL-04 | A ticked source choice could be discarded without explanation | Fixed | — | — | [BL-04](#bl-04) |
-| BL-06 | Target identity was compared by label rather than codec | Fixed | — | — | [BL-06](#bl-06) |
+| BL-04 | The GUI could silently ignore a selected source encoding | Fixed | — | — | [BL-04](#bl-04) |
+| BL-06 | Encoding aliases could cause unnecessary rewrites | Fixed | — | — | [BL-06](#bl-06) |
 | BL-07 | A whole-file unchanged claim came from a 64 KiB sample | Fixed | — | — | [BL-07](#bl-07) |
 | BL-08 | Preview could approve a source that conversion could not decode | Fixed | — | — | [BL-08](#bl-08) |
 | BL-09 | One unexpected file exception could stop the whole run | Fixed | — | — | [BL-09](#bl-09) |
 | BL-10 | An unreadable folder was invisible to machine output | Fixed | — | — | [BL-10](#bl-10) |
 | BL-11 | Folders skipped by name were uncounted | Fixed | — | — | [BL-11](#bl-11) |
 | BL-12 | Some validation failures had no reason code | Fixed | — | — | [BL-12](#bl-12) |
-| BL-13 | Refusal reasons were re-derived after the policy decision | Fixed | — | — | [BL-13](#bl-13) |
+| BL-13 | Different code paths could give different reasons for one refusal | Fixed | — | — | [BL-13](#bl-13) |
 | BL-14 | Decode failures could report a negative chunk offset | Fixed | — | — | [BL-14](#bl-14) |
 | BL-15 | Console output ignored the console's encoding | Fixed | — | — | [BL-15](#bl-15) |
 | BL-16 | Help and CLI documentation stated an old parallelism default | Fixed | — | — | [BL-16](#bl-16) |
 | BL-17 | The lifetime of `<file>.bak` was undocumented | Fixed | — | — | [BL-17](#bl-17) |
-| BL-22 | An unwritable report or journal path was discovered after conversion | Fixed | — | — | [BL-22](#bl-22) |
-| BL-23 | An undefined plan action was reported as a conversion | Fixed | — | — | [BL-23](#bl-23) |
-| BL-24 | Plans, journals, reports, and settings used truncate-in-place writes | Fixed | — | — | [BL-24](#bl-24) |
-| BL-25 | EC and LEN use different transient content-hash machinery | Decision | — | — | [BL-25](#bl-25) |
-| BL-26 | The GUI smoke driver rejected an exact offscreen combo item | Fixed | — | — | [BL-26](#bl-26) |
+| BL-22 | An unwritable report or journal path was found only after files changed | Fixed | — | — | [BL-22](#bl-22) |
+| BL-23 | A damaged plan could report an unknown action as Converted | Fixed | — | — | [BL-23](#bl-23) |
+| BL-24 | An interrupted write could erase a plan, journal, report or settings file | Fixed | — | — | [BL-24](#bl-24) |
+| BL-25 | EC and LEN use different internal methods to verify converted text | Decision | — | — | [BL-25](#bl-25) |
+| BL-26 | The GUI smoke test could reject an encoding below the visible list | Fixed | — | — | [BL-26](#bl-26) |
 
 <!-- backlog-ledger:end -->
 
-## Open-finding evidence
+## Details for open findings
 
 ### EC-08
 
@@ -380,7 +380,7 @@ Evidence: detection reads a sample and does not treat an incomplete tail as an
 error. Conversion reaches the real end of the file and flushes the strict
 decoder, which does. The difference is deliberate on both sides.
 
-## Evidence for the original review findings
+## Details for findings from the original review
 
 ### EC-01
 
@@ -555,7 +555,7 @@ tests for removed, left-side, and secondary displays.
 workflow runs on pull requests, and the release workflow declares it as a job
 dependency.
 
-## Evidence for later findings
+## Details for findings found later
 
 ### BL-02
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -816,58 +816,52 @@ This fix kept the search-for-an-item design and made it consistent.
 replaced the approach rather than adjusting it again.
 
 ### EC-24
+**Before:** the smoke driver picked an encoding by searching for a list item -
+first under the intended drop-down, then across the whole EC process for any
+visible item with a matching name. Both encoding drop-downs contain names such as
+`utf-16BE`, so that second search could select the item in the wrong control and
+leave the one under test unchanged. `lstConvert` is on the main window,
+`lstSourceEncoding` in the review.
 
-**Fixed by setting the drop-down instead of hunting its popup.** The combo
-supports `ValuePattern` and reports `IsReadOnly` false, so the driver asks the
-control for the value. That opens no popup and reaches no other window, so
-neither mechanism below is available to fail.
-
-Was: the driver expanded the combo and searched for a list item, first under the
-combo and then across the process. How a provider exposes a drop-down's items
-varies with popup state and environment, so the first search could miss. The
-second accepted any visible item in the process carrying a matching name, and
-this application has two encoding combos — `lstConvert` on the main window and
-`lstSourceEncoding` in the review — holding the same names, so it could select
-in the wrong one and leave the combo under test unchanged.
+**Now:** the driver sets the value on the intended drop-down. It opens no list,
+searches no other window, changes no foreground focus and sends no keystrokes, so
+neither the popup-location dependency nor the name collision is reachable. The
+combo supports `ValuePattern` and reports `IsReadOnly` false.
 
 **Found by the release gate failing on bytes that then passed.** The v3.14.0
 release job failed at phase E with `'utf-16BE' was not selected in
-'lstSourceEncoding'`, and a re-run of the same commit passed all ten phases.
-Nothing in that release touched the driver, the review form, or the encoding
-list.
+'lstSourceEncoding'`; a re-run of the same commit passed all ten phases. Nothing
+in that release touched the driver, the review form or the encoding list.
 
-This is [BL-26](#bl-26) arriving a second time. That fix made phase J work and
-left the mechanism in place; the v3.12.1 record said the asymmetry it kept "is
-the kind of thing a future phase could still trip over," and phase E is that
-phase. The keyboard fallback went with the searches: it foregrounded a window
-and typed into whatever held focus, and could not have repaired either cause.
+**The mechanism is proven; the cause of that one run is not.** An independent
+review built a harness with two controls offering the same item name and
+reproduced the old fallback selecting the wrong one - the same observable result.
+That establishes the defect. It does not establish that the release runner was in
+that state, and the incident itself was never reproduced: on this machine the
+popup sits inside the combo's subtree and only one process-wide match is visible,
+so the ambiguity never arises here. This entry closes the mechanism, not the
+incident.
 
-**The unsafe mechanism is proven; the cause of the runner incident is not.** An
-independent review built a harness holding two controls that offer the same item
-name, and reproduced the old process-wide fallback selecting the wrong control
-and leaving the combo under test unchanged — the exact shape of the reported
-failure. That establishes the defect. It does not establish that the release
-runner exposed that state, and no reproduction of the incident itself exists: on
-this machine the popup sits inside the combo's subtree and only one process-wide
-match is visible, so the ambiguity never arises here. This entry closes the
-mechanism, not the incident.
-
-**What the replacement was shown to do.** On the current .NET 10 WinForms
-provider, setting the value selects the matching item rather than only changing
-displayed text — phase E completes end to end, so the choice reaches conversion
-and the output text is preserved. An unknown value is a no-op on this provider,
-which the existing postcondition catches; no membership check is added, since one
-would reinstate the popup dependency this removes. Two mutations — never setting
-the value, and setting a different one — each built cleanly and failed phase E
-with the message the release job produced, and the file restored byte-identical
-by SHA-256.
+**Evidence.** On the current .NET 10 WinForms provider, setting the value selects
+the matching item rather than only changing displayed text: phase E completes end
+to end, so the choice reaches conversion and the output text is preserved. An
+unknown value is a no-op on this provider, which the existing postcondition
+catches - no membership check is added, since one would reinstate the popup
+dependency this removes. Two mutations, never setting the value and setting a
+different one, each built cleanly and failed phase E with the message the release
+job produced, and the file restored byte-identical by SHA-256.
 
 **A timeout now names the error it retried.** `WaitFor` discarded
 `ElementNotAvailableException`, `InvalidOperationException` and `COMException`
-and then reported only a generic timeout, so a probe that threw on every attempt
-looked exactly like one that simply never became true. It now keeps the last such
-error and `WaitUntil` reports it, so the next failure of this gate is
-diagnosable from its message.
+and reported only a generic timeout, so a probe that threw every time looked
+exactly like one that never became true. It keeps the last such error and
+`WaitUntil` reports it.
+
+**Relation to [BL-26](#bl-26).** That fix kept the search-for-an-item design and
+made it consistent. The v3.12.1 record said the asymmetry it kept "is the kind of
+thing a future phase could still trip over," and phase E is that phase. The
+keyboard fallback went with the searches: it foregrounded a window and typed into
+whatever held focus, and could not have repaired either cause.
 
 **Recorded, not fixed here.** `ConfigureScan` asks for `utf-8` on `lstConvert`
 while that control is still disabled, and succeeds only because `utf-8` is
@@ -875,8 +869,7 @@ already selected, so the method returns before setting anything: the suite never
 exercises the new path on that combo, and a changed application default would
 fail every phase at setup. Separately, `Current.IsEnabled` was observed stale for
 five seconds on a control that then accepted `Invoke`, and the driver uses
-`IsEnabled` as a readiness signal elsewhere. Neither was reproduced as a
-failure.
+`IsEnabled` as a readiness signal elsewhere. Neither was reproduced as a failure.
 
 ## Decisions and mistakes that must remain visible
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -186,12 +186,20 @@ would have been a day earlier.
 
 ### EC-17
 
-**The printable-ratio comment says the opposite of the calculation.**
-`TextValidation.cs` increments the total rune count before its category switch.
-Control and private-use scalars do not increment `printable`, so they lower the
-ratio; they are not ignored. The behavior is the intended binary-rejection
-behavior. The comment is shared byte-for-byte with LineEndingNormalizer and
-CorpusTesters, so its correction must be synchronized.
+**A comment describes the text check backwards.** Control and private-use
+characters *lower* the printable-text ratio. The comment beside the calculation
+says they are ignored.
+
+Nothing a user sees is wrong: the binary-rejection behaviour is the intended one.
+What is wrong is what the next person reads, which is why reach is Common.
+
+Evidence: `TextValidation.cs` increments the total rune count before its category
+switch, so those scalars count toward the denominator while never incrementing
+`printable`.
+
+Still open because the fix is not confined to one repository. The comment is
+byte-identical in EncodingChecker, LineEndingNormalizer and CorpusTesters, and
+the parity check requires it to stay that way, so all three must change together.
 
 ### EC-18
 
@@ -208,12 +216,22 @@ No observable behaviour changes, so this carries no test of its own.
 
 ### EC-20
 
-**The detector has a looser sharing mode than the paths that rely on its result.**
-`TextEncoding.DetectFromFile` opens with `FileShare.ReadWrite |
-FileShare.Delete`; validation and source-snapshot paths use `FileShare.Read`.
-Detection can therefore describe bytes while another process changes or deletes
-them. This affects detection and validation output; conversion later takes its
-own bound snapshot before writing.
+**A file can change while EC is working out what encoding it is.** Detection
+opens the file in a mode that lets another program write to it or delete it at
+the same time, so the encoding EC reports can describe bytes that have already
+changed.
+
+No source file is altered by this. Before conversion writes anything it takes its
+own copy of the bytes, bound to a hash. What can go stale is what detection and
+validation *report*.
+
+Evidence: `TextEncoding.DetectFromFile` opens with
+`FileShare.ReadWrite | FileShare.Delete`, while the validation and
+source-snapshot paths use `FileShare.Read`.
+
+Still open because the obvious correction is not obviously right. Tightening
+detection to match would make EC fail on any file another program holds open,
+which includes ordinary log files.
 
 ### EC-23
 
@@ -228,10 +246,15 @@ this shape was left implicit.
 
 ### CX-06
 
-**High entropy can hide an otherwise valid BOM.** The entropy guard returns
-before `UnicodeDetector.DetectFromBuffer` examines the BOM. The result can be an
-unknown or wrong encoding even when the file declares it. This changes what EC
-reports; it is not evidence that conversion writes the file.
+**EC decides a file looks like random data before it looks for a byte-order
+mark.** In principle a file could be reported as unknown, or as the wrong
+encoding, even though its first bytes say what it is.
+
+This changes what EC *reports*. It is not evidence that conversion writes a file
+it should have refused.
+
+Evidence: the entropy guard returns before `UnicodeDetector.DetectFromBuffer`
+examines the mark.
 
 **Re-scored Occasional to Theoretical on 2026-09-08, after measurement.** No
 text reaches the gate. Across all four corpora, 3,620 files are large enough to
@@ -273,13 +296,20 @@ ordinary BOM-less UTF-32 as well; nothing in the bytes separates the two.
 
 ### BL-05
 
-**A second close request can outlive the form while its worker still uses it.**
-`OnFormClosing` deliberately allows a confirmed second close because
-cancellation is cooperative. A worker can subsequently call the synchronous
-confirmation `Invoke`, and completion accesses form controls. Finished files
-have already been installed independently and the in-flight file remains
-protected; the expected symptom is an exception during exit, not lost file
-content. The timing-dependent path was source-confirmed but not reproduced.
+**Force-closing EC mid-conversion can produce an error as it exits.** If the user
+confirms a second close while the run is still stopping, a background task can
+try to use a window that has already gone.
+
+No file content is lost. Files already converted were installed one at a time and
+stay installed, and the file in flight stays protected. The expected symptom is
+an exception while EC closes.
+
+Evidence: `OnFormClosing` deliberately allows a confirmed second close, because
+cancellation is cooperative. A background task can then call the synchronous
+confirmation `Invoke`, and its completion touches controls on the form.
+
+Still open because it was confirmed by reading the current code rather than by
+triggering it; the timing it needs has not been reproduced.
 
 ### BL-18
 
@@ -305,32 +335,50 @@ and checks all five survive.
 
 ### BL-19
 
-**The UTF-16 structure heuristic can claim NUL-heavy ASCII.** The earlier
-document said 2.3% of all bytes; that was wrong. A current 65,536-byte ASCII
-fixture with a NUL every 100 bytes—1.001% overall—was reported as UTF-16BE. The
-detector threshold is 2% in one putative UTF-16 byte channel, approximately 1%
-of all bytes for this shape. Conversion refused with exit 5 and the source hash
-did not change, so the wrong claim currently reaches detection and validation,
-not installation.
+**An ASCII file carrying many NUL bytes can be reported as UTF-16.** A current
+65,536-byte ASCII fixture with a NUL every 100 bytes — 1.001% of all bytes — was
+reported as UTF-16BE.
+
+Conversion then refused it with exit 5 and the source hash did not change. So the
+wrong answer reaches what EC *reports*, not what it writes. This is the one open
+finding where EC answers its own central question incorrectly.
+
+Evidence: the UTF-16 structure heuristic triggers at 2% of bytes within one
+candidate UTF-16 channel, which for this shape is roughly 1% of all bytes. An
+earlier version of this document said 2.3% of all bytes; that figure was wrong.
 
 ### BL-20
 
-**Filesystem aliases are treated as separate selected paths.** Two hard links
-to one UTF-8 file were both converted in a current probe. Both retained exact
-text, and each received its own verified `.bak` and `.ecmeta.json`; the normal
-Windows `File.Replace` path broke their link relationship. This can duplicate
-work and does not preserve hard-link identity. The fallback
-`File.Move(..., overwrite: true)` path could not be forced on this platform, so
-no claim is made about that branch.
+**Two names for one file are converted twice, and stop being the same file.**
+Windows can expose a single file under two hard-link names. EC treats them as two
+separate files and converts each.
+
+Text is preserved either way: in a current probe both names of one UTF-8 file
+were converted, both kept their text exactly, and each received its own verified
+`.bak` and `.ecmeta.json`. What is lost is the link itself — the normal Windows
+`File.Replace` path breaks it, so afterwards the two names refer to different
+files. The work is also done twice.
+
+No claim is made about the `File.Move(..., overwrite: true)` fallback, which
+could not be forced on this platform.
+
+Still open partly as a question rather than a defect: whether EC should preserve
+hard-link identity or treat selected paths independently is a design choice
+nobody has made.
 
 ### BL-21
 
-**Sample detection and complete conversion intentionally use different flush
-semantics.** A UTF-8 file ending in incomplete bytes `E2 82` was reported as
-UTF-8 by `-DetectOnly`, because sample detection does not flush an incomplete
-tail. Conversion flushed the strict decoder, returned `SourceDecodeError` and
-exit 3, and left the source unchanged. The safety path is correct; the detector
-can still bless a complete file that conversion rejects.
+**Detection can accept a cut-off final character that conversion then rejects.**
+A UTF-8 file ending in the incomplete bytes `E2 82` was reported as UTF-8 by
+`-DetectOnly`. Conversion refused the same file, returned `SourceDecodeError`
+and exit 3, and left it unchanged.
+
+The safety path is correct — the file is refused, not converted. The
+inconsistency is that detection had already reported it as fine.
+
+Evidence: detection reads a sample and does not treat an incomplete tail as an
+error. Conversion reaches the real end of the file and flushes the strict
+decoder, which does. The difference is deliberate on both sides.
 
 ## Evidence for the original review findings
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=63 fixed=52 open=7 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
+<!-- backlog-counts total=65 fixed=52 open=9 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
 
-**Derived count: 63 findings — 52 fixed, 7 open, 1 not reproduced, 1 withdrawn,
+**Derived count: 65 findings — 52 fixed, 9 open, 1 not reproduced, 1 withdrawn,
 1 intentional behavior, and 1 design decision.** Recompute and check these
 figures with:
 
@@ -52,6 +52,8 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 |---|---|---|---|---|---|
 | EC-17 | A comment describes the text check backwards | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | A file can change while EC is detecting its encoding | Open | Low | Rare | [EC-20](#ec-20) |
+| EC-25 | The smoke suite never sets the main window's target encoding | Open | Low | Rare | [EC-25](#ec-25) |
+| EC-26 | The smoke driver trusts an enabled flag that has been seen stale | Open | Low | Rare | [EC-26](#ec-26) |
 | CX-06 | EC checks for random-looking data before checking for a BOM | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a conversion can produce an error on exit | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | ASCII with many NUL bytes can be reported as UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
@@ -532,8 +534,8 @@ moved from exit 0 to exit 3. Strict validation still caught it and no bytes
 changed, so nothing was corrupted — but that is a measured behaviour change
 bought against a benefit no corpus file demonstrates.
 
-Reopen this on evidence of real text at or above the threshold, not on the
-mechanism, which is not in doubt.
+It stays open at Theoretical. Re-score it only on evidence of real text at or
+above the threshold - not on the mechanism, which is not in doubt.
 
 ### CX-07
 
@@ -862,13 +864,41 @@ thing a future phase could still trip over," and phase E is that phase. The
 keyboard fallback went with the searches: it foregrounded a window and typed into
 whatever held focus, and could not have repaired either cause.
 
-**Recorded, not fixed here.** `ConfigureScan` asks for `utf-8` on `lstConvert`
-while that control is still disabled, and succeeds only because `utf-8` is
-already selected, so the method returns before setting anything: the suite never
-exercises the new path on that combo, and a changed application default would
-fail every phase at setup. Separately, `Current.IsEnabled` was observed stale for
-five seconds on a control that then accepted `Invoke`, and the driver uses
-`IsEnabled` as a readiness signal elsewhere. Neither was reproduced as a failure.
+Two loose ends were found while making this change and neither is fixed by it.
+They carry their own IDs rather than sitting inside a closed entry where the
+ledger cannot give them a status: [EC-25](#ec-25) and [EC-26](#ec-26).
+
+### EC-25
+
+**The smoke suite never exercises setting the main window's target encoding.**
+`ConfigureScan` asks for `utf-8` on `lstConvert` before scanning, while that
+control is still disabled. It succeeds only because `utf-8` is already selected,
+so `SelectCombo` returns before setting anything.
+
+Nothing is wrong with EC here; the gap is in the suite. Two consequences follow.
+The path [EC-24](#ec-24) replaced is never driven on that combo, so a defect in it
+would not be caught. And if the application's default target ever changed, every
+phase would fail during setup rather than in the phase that cares.
+
+Closing it means asserting the default before the scan and exercising a
+non-default target after scanning enables the control. Neither was written,
+because doing so changes the suite that had just been stabilised.
+
+### EC-26
+
+**The driver treats an enabled flag as a readiness signal, and it has been seen
+stale.** `Current.IsEnabled` reported a control disabled for five seconds while
+that same control accepted `Invoke` and closed the review. The driver uses
+`IsEnabled` elsewhere to decide that a scan has finished, that the main window is
+ready, and when cancellation may be attempted.
+
+No failure was reproduced from it. What it means is that a phase could time out
+waiting for a control that was ready the whole time, and report a defect in EC
+that is not there - the same shape of wrong answer that the preflight check exists
+to prevent.
+
+A readiness check that also confirms the operation it is waiting for would not
+depend on the flag. Nothing has been changed yet.
 
 ## Decisions and mistakes that must remain visible
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -830,38 +830,6 @@ broke four existing tests, and one finding was withdrawn after checking the
 actual CSV. This is kept visible because a true mechanism does not automatically
 justify the claimed product risk.
 
-### Three hashing optimisations were measured and rejected
-
-Conversion can read the same file several times, but each read answers a
-different question: does the source still match approval, did the backup really
-land, and does the installed output contain the verified text? Three throwaway
-variants were interleaved against the same 292 MiB, 60-file workload with backup
-and journal enabled:
-
-| Variant | Measurement | Safety or usability cost |
-|---|---|---|
-| Baseline | 1030 ms median | None |
-| Digest backup while copying | 872 ms; 15.3% faster | Nothing independently re-reads the restore point on disk |
-| Hash source and output while streaming | 3.5% faster in its own batch | Both values derive from intended I/O rather than independent reads |
-| XxHash128 instead of SHA-256 | 1078 ms; 4.7% slower | Recorded hashes lose `Get-FileHash` interoperability and collision resistance |
-
-The source can be read up to seven times per converted file, and one hash is
-computed twice over bytes already held in memory. Those reads are still not
-redundant. The only materially faster variant removed the backup re-read after
-`Flush(flushToDisk: true)`, which is the only independent check that the restore
-point exists intact. XxHash128 itself measured 16,447 MiB/s against SHA-256 at
-2,429 MiB/s—6.8x—but made the parallel I/O-bound workload slower. On that
-machine SHA-256 also beat SHA-1 (981 MiB/s), MD5 (754 MiB/s), and SHA-512
-(805 MiB/s).
-
-These figures are conditional: a 24-core machine, fast local disk, warm cache,
-and eight workers. Cold or network storage may increase the benefit of removing
-a read while also increasing the value of verifying it. Even a different speed
-result—even 40%—would not change what each check proves. The observed ceiling
-was about 15%, and that was the variant which removed the strongest backup
-evidence. Only a single-worker run on a slow CPU is likely to make hashing itself
-visible. Future throughput work should make the backup re-read cheaper rather
-than delete it.
 
 ## The source-choice refusal is covered by both a unit test and smoke phase J
 
@@ -876,135 +844,10 @@ the built application: the review must remain open, name
 leave every source byte unchanged. BL-26 records the automation-driver defect
 found while making that phase reliable.
 
-## 2026-09-08 recheck record
 
-Every pre-reformat row was checked against source, a current regression test, a
-current Release-build probe, or a clearly marked historical measurement. The
-source inspection used `c071c10`; the factual recheck is preserved as local
-commit `902f567` immediately before this reformat.
+## Historical records
 
-For chronology, BL-06 through BL-17 came from the independent review of
-`74d5b3d` after v3.11.2. BL-22 through BL-24 came from a later independent review
-of released commit `518a844` after v3.12.0. These source identities are retained
-because the observations were made against those builds, even though the
-current statuses were rechecked against `c071c10`.
-
-Current behavioral probes established:
-
-- the EC-08 hostile regex exceeded a three-second child-process budget;
-- automatic and explicit UTF-8 paths both refused a double BOM;
-- an old plan in the scan root was scanned as ASCII;
-- a filename beginning `=1+1` still produced an absolute-path CSV cell;
-- BL-01 and BL-18 both changed Unicode under the wrong automatic interpretation;
-- BL-19 and BL-21 were reported inconsistently but refused or failed before a
-  write; and
-- both names of a hard-linked file preserved exact text and received separate
-  recovery artifacts through the normal Windows replacement path.
-
-No old row was skipped. Three portions remain only partly reproducible:
-
-- BL-05 requires precise force-close timing and was inspected rather than
-  triggered;
-- BL-20's move fallback requires a platform where `File.Replace` is unsupported;
-  and
-- the historical timing figures above were not rerun; their current code and
-  safety properties were checked.
-
-## Pre-reformat row mapping
-
-The task expected 78 rows, 45 with an existing ID and 33 without one. The exact
-`c071c10` input had 79 data-shaped rows, 45 of which mentioned an existing ID.
-The disjoint breakdown is 35 original canonical rows, 21 unique anonymous
-finding or decision rows, 13 duplicate or correction rows, 7 benchmark or
-comparison-evidence rows, and 3 malformed blank-cell headers. Four findings
-existed only as prose, and one GUI-driver finding existed only in a narrative
-section. That yields the 61 unique ledger entries above. The mapping below
-accounts for every old location without pretending that a table header or
-benchmark variant is a new defect.
-
-| Old location | Canonical finding or destination | Note |
-|---|---|---|
-| R001 | [EC-01](#ec-01) | Original ledger row |
-| R002 | [EC-02](#ec-02) | Original ledger row |
-| R003 | [EC-03](#ec-03) | Original ledger row |
-| R004 | [EC-04](#ec-04) | Original ledger row |
-| R005 | [EC-05](#ec-05) | Original ledger row |
-| R006 | [EC-06](#ec-06) | Original ledger row |
-| R007 | [EC-07](#ec-07) | Original ledger row |
-| R008 | [EC-08](#ec-08) | Original ledger row |
-| R009 | [EC-09](#ec-09) | Original ledger row |
-| R010 | [EC-10](#ec-10) | Original ledger row |
-| R011 | [EC-11](#ec-11) | Original ledger row |
-| R012 | [EC-12](#ec-12) | Original ledger row |
-| R013 | [EC-13](#ec-13) | Original ledger row |
-| R014 | [EC-14](#ec-14) | Original ledger row |
-| R015 | [EC-15](#ec-15) | Original ledger row |
-| R016 | [EC-16](#ec-16) | Original ledger row |
-| R017 | [EC-17](#ec-17) | Original ledger row |
-| R018 | [EC-18](#ec-18) | Original ledger row |
-| R019 | [EC-19](#ec-19) | Original ledger row |
-| R020 | [EC-20](#ec-20) | Original ledger row |
-| R021 | [EC-21](#ec-21) | Original ledger row |
-| R022 | [EC-22](#ec-22) | Original ledger row |
-| R023 | [EC-23](#ec-23) | Original ledger row |
-| R024 | [CX-01](#cx-01) | Original ledger row |
-| R025 | [CX-02](#cx-02) | Original ledger row |
-| R026 | [CX-03](#cx-03) | Original ledger row |
-| R027 | [CX-05](#cx-05) | Original ledger row |
-| R028 | [CX-06](#cx-06) | Original ledger row |
-| R029 | [CX-07](#cx-07) | Original ledger row |
-| R030 | [CX-08](#cx-08) | Original ledger row |
-| R031 | [CX-09](#cx-09) | Original ledger row |
-| R032 | [CX-10](#cx-10) | Original ledger row |
-| R033 | [CX-11](#cx-11) | Original ledger row |
-| R034 | [CX-12](#cx-12) | Original ledger row |
-| R035 | [CX-13](#cx-13) | Original ledger row |
-| R036 | [BL-01](#bl-01) | Previously anonymous finding |
-| R037 | [BL-02](#bl-02) | Previously anonymous finding |
-| R038 | [BL-03](#bl-03) | Previously anonymous finding |
-| R039 | [BL-04](#bl-04) | Previously anonymous finding |
-| R040 | [BL-05](#bl-05) | Previously anonymous finding |
-| R041 | [BL-06](#bl-06) | Previously anonymous finding |
-| R042 | [BL-07](#bl-07) | Previously anonymous finding |
-| R043 | [BL-08](#bl-08) | Previously anonymous finding |
-| R044 | [BL-09](#bl-09) | Previously anonymous finding |
-| R045 | [BL-10](#bl-10) | Previously anonymous finding |
-| R046 | [BL-11](#bl-11) | Previously anonymous finding |
-| R047 | [BL-12](#bl-12) | Previously anonymous finding |
-| R048 | [BL-13](#bl-13) | Previously anonymous finding |
-| R049 | [BL-14](#bl-14) | Previously anonymous finding |
-| R050 | [BL-15](#bl-15) | Previously anonymous finding |
-| R051 | [BL-16](#bl-16) | Previously anonymous finding |
-| R052 | [BL-17](#bl-17) | Previously anonymous finding |
-| R053 | [BL-22](#bl-22) | Previously anonymous finding |
-| R054 | [BL-23](#bl-23) | Previously anonymous finding |
-| R055 | [BL-24](#bl-24) | Previously anonymous finding |
-| R056 | [CX-07](#cx-07) | Duplicate correction row |
-| R057 | [BL-02](#bl-02) | Duplicate withdrawal row |
-| R058 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | Baseline data, not a finding |
-| R059 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | Backup-read variant, not a separate finding |
-| R060 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | Streaming-hash variant, not a separate finding |
-| R061 | [Hashing measurements](#three-hashing-optimisations-were-measured-and-rejected) | XxHash variant, not a separate finding |
-| R062 | [BL-25](#bl-25) | Malformed comparison-table header, not a finding |
-| R063 | [BL-25](#bl-25) | Raw-hash comparison evidence |
-| R064 | [BL-25](#bl-25) | Content-digest comparison evidence |
-| R065 | [BL-25](#bl-25) | Backup-comparison evidence |
-| R066 | [Canonical ledger](#canonical-ledger) | Malformed score-table header, not a finding |
-| R067 | [CX-06](#cx-06) | Duplicate score row |
-| R068 | [BL-01](#bl-01) | Duplicate score row |
-| R069 | [EC-08](#ec-08) | Duplicate score row |
-| R070 | [BL-02](#bl-02) | Duplicate score row |
-| R071 | [EC-16](#ec-16) | Duplicate score row |
-| R072 | [EC-20](#ec-20) | Duplicate score row |
-| R073 | [EC-15](#ec-15) | Duplicate score row |
-| R074 | [EC-17](#ec-17) | Duplicate score row |
-| R075 | [EC-23](#ec-23) | Duplicate score row |
-| R076 | [EC-18](#ec-18) | Duplicate score row |
-| R077 | [BL-25](#bl-25) | Design-decision row |
-| R078 | [EC-19](#ec-19) | Malformed not-reproduced table header, not a finding |
-| R079 | [EC-19](#ec-19) | Duplicate evidence row |
-| P001 | [BL-18](#bl-18) | Former prose-only finding |
-| P002 | [BL-19](#bl-19) | Former prose-only finding |
-| P003 | [BL-20](#bl-20) | Former prose-only finding |
-| P004 | [BL-21](#bl-21) | Former prose-only finding |
-| S001 | [BL-26](#bl-26) | Former narrative-only GUI-driver finding |
+The recheck that produced this ledger, the measurements behind three rejected
+throughput changes, and the pre-reformat row mapping are kept in
+[DEFECT-BACKLOG-HISTORY.md](DEFECT-BACKLOG-HISTORY.md). They are audit trail
+rather than current status, and moving them changed nothing but their address.

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -164,20 +164,24 @@ pins the intended `src/*.cs` directory behavior.
 
 ### EC-15
 
-**Fixed as an artifact-clarity simplification, not a conversion-safety defect.**
-The five flags are gone. Plans and journals now carry `SemanticsDescription` -
-the sentence `ConversionSemantics.Describes` already held - beside the version
-number, so a reader gets what the version means instead of five constants.
-`SemanticsVersion` remains the only enforced compatibility value, and a test
-proves the description is never consulted: altering it in a plan file changes
-nothing about whether that plan loads.
+**Before:** plans and journals carried five safety flags that were always `true`.
+EC never read them when applying a plan, so they proved nothing about whether any
+individual check had run - but a reader could easily take a serialized `true` as
+proof that one had.
 
-Was: `StrictDecoding`, `StrictEncoding`, `OutputVerification`, `AtomicInstall`
-and `LegacyRequiresExplicitSource` were serialized into every plan and journal,
-hardcoded `true`, and read by nothing. They could not disagree with the version,
-so they were a second encoding of it that a reader could mistake for evidence a
-particular check had run. EC always executed its strict behaviour; only the
-artifact implied otherwise.
+**Now:** the files carry one safety-rules version and a sentence describing it.
+EC checks the version; the sentence exists only to tell a reader what the version
+means.
+
+This was a clarity fix, not a conversion-safety fix. EC always executed its strict
+behaviour; only the artifact implied the flags were the reason.
+
+Evidence: `StrictDecoding`, `StrictEncoding`, `OutputVerification`,
+`AtomicInstall` and `LegacyRequiresExplicitSource` were replaced by
+`SemanticsDescription`, the sentence `ConversionSemantics.Describes` already
+held. `SemanticsVersion` remains the only enforced compatibility value, and a
+test confirms the description is never consulted: altering it inside a plan file
+changes nothing about whether that plan loads.
 
 The artifacts changed shape, so their versions say so: plan schema 5 to 6,
 journal schema 4 to 5. That rejects plans written by v3.13.0 as well as older
@@ -203,16 +207,18 @@ the parity check requires it to stay that way, so all three must change together
 
 ### EC-18
 
-**Fixed.** The classification is cached as a nullable value, so null means not
-yet classified and `None` means classified with no doubt found. Both are stored,
-and the file is examined once.
+**Before:** EC remembered only when it *had* found a BOM-less UTF-16 ambiguity.
+When it found none, that answer was forgotten, and the full check could run again
+on the next pass.
 
-Was: only a positive result was kept, so an already-cleared file ran the full
-opposite-order check again on every pass. Measurement found no meaningful cost,
-because a provable file fails that decode in its first buffer; the defect was
-redundant work and a state that could not distinguish "no" from "not asked".
+**Now:** both answers are remembered, so each file is examined once. The stored
+value is nullable: null means not yet classified, and `None` means classified
+with no doubt found.
 
-No observable behaviour changes, so this carries no test of its own.
+Nothing a user sees changes, which is why this carries no test of its own. It was
+not a speed problem either: measurement found no meaningful cost, because a
+provable file fails the opposite-order decode inside its first buffer. The defect
+was redundant work and a state that could not tell "no" from "not asked".
 
 ### EC-20
 
@@ -235,14 +241,18 @@ which includes ordinary log files.
 
 ### EC-23
 
-**Fixed.** The null-forgiving dereference is now an explicit throw that names the
-invariant it rests on: `FindStaleFiles` rejects a plan whose paths resolve
-outside its directory, and reaching the dereference means that check did not
-run.
+**Before:** applying a plan assumed an earlier check had already produced a valid
+file path. The assumption held, but nothing said so - and had later code bypassed
+that check, the failure would have surfaced as an unexplained null reference.
 
-Under the present flow nothing changes, which is why there is nothing new to
-assert and no test accompanies it. EC-06 is what happened when an invariant of
-this shape was left implicit.
+**Now:** EC stops with an explicit error naming the check that must have run.
+
+Under the present flow nothing changes, which is why nothing new is asserted and
+no test accompanies it. EC-06 is what happened the last time an invariant of this
+shape was left implicit.
+
+Evidence: `FindStaleFiles` rejects a plan whose paths resolve outside its
+directory; reaching the dereference means that check did not run.
 
 ### CX-06
 
@@ -655,12 +665,17 @@ consumer to re-derive information the producer already had.
 
 ### BL-13
 
-**The policy owns refusal reason codes.** `ApplyConversion` formerly repeated
-the condition already reduced to `SourceInterpretation`. The copies were
-textually identical, but nothing tied them together; a future refusal could
-fall through the caller's bolt-on guard to `LegacySourceRequired`.
-`ConversionPolicy.ReasonCodeFor` now owns the mapping. Tests cover all 256
-reachable input combinations and require every refusal to carry a reason.
+**Before:** EC decided whether to refuse in one place and worked out the reason to
+report in another. The two were textually identical but nothing held them
+together, so they could drift - and a future refusal could fall through the
+caller's separate follow-up check and be reported as `LegacySourceRequired`.
+
+**Now:** `ConversionPolicy.ReasonCodeFor` produces both the decision and its
+reason.
+
+Evidence: `ApplyConversion` formerly repeated the condition already reduced to
+`SourceInterpretation`. Tests now cover all 256 reachable input combinations and
+require every refusal to carry a reason.
 
 ### BL-14
 
@@ -733,31 +748,46 @@ write.
 
 ### BL-23
 
-**Undefined plan enums are rejected before a source is touched.**
-`System.Text.Json` accepts any number for an enum. An action value of 99 formerly
-fell through the result mapper as `Converted`: apply exited 0, reported one
-conversion, and journaled action 99 even though the source hash was unchanged.
-Plan loading now validates both `Action` and `SourceInterpretation`, while the
-result mapper exhaustively names known actions and throws for anything else.
+**Before:** a damaged or hand-edited plan could carry an action value no build
+ever wrote, and EC reported it as a conversion. An action of 99 exited 0, said
+"1 converted", and wrote a journal recording action 99 - while the source hash
+was unchanged. The journal asserted work that never happened.
+
+**Now:** EC rejects an unknown action or source interpretation before touching any
+source file.
+
+Evidence: `System.Text.Json` accepts any number for an enum, and the result
+mapper's fallback arm was `Converted`. Plan loading now validates both `Action`
+and `SourceInterpretation`, and the mapper names every known action and throws
+for anything else.
 
 ### BL-24
 
-**All durable EC artifacts use replacement writes.** Converted files and
-recovery sidecars already used temporary files and replacement; plans, journals,
-reports, and settings truncated their live destinations. A failed plan write
-could destroy the reviewed plan immediately before use. `AtomicArtifactFile`
-now handles all four. The sidecar retains its stronger dedicated writer and
-read-back verification. This same refactor addressed EC-16.
+**Before:** plans, journals, reports and settings were written by erasing the
+existing file first. If the write then failed, the previous record was gone - and
+for a plan, that meant destroying the reviewed plan immediately before it was to
+be applied.
+
+**Now:** EC writes a complete temporary file beside the destination and replaces
+the old one only after that write succeeds. Converted files and recovery sidecars
+already worked this way; all four saved-file types now use the same mechanism,
+`AtomicArtifactFile`.
+
+The recovery sidecar keeps its own writer, which also reads back and verifies what
+it wrote - more than the shared one does, and not worth reducing. The same change
+closed EC-16.
 
 ### BL-25
 
-**EC and LineEndingNormalizer make the same safety argument with different
-transient machinery.** Both use SHA-256 for source bytes and backup evidence.
-EC also uses SHA-256 for content digests and persists them as
-`SourceTextSha256` and `OutputTextSha256`; LEN uses XxHash3 for a private
-normalized-content digest that is discarded. EC compares hexadecimal digest
-strings with `string.Equals(..., OrdinalIgnoreCase)`; LEN compares digest bytes
-with `CryptographicOperations.FixedTimeEquals`.
+**EC and LineEndingNormalizer both verify that conversion preserved the content,
+using different internal methods.** No defect was found; this records a deliberate
+difference so a future maintainer does not mistake it for one.
+
+Both use SHA-256 for source bytes and backup evidence. EC also uses SHA-256 for
+content digests and saves them as `SourceTextSha256` and `OutputTextSha256`; LEN
+uses XxHash3 for a private normalized-content digest that it discards. EC compares
+hexadecimal digest strings with `string.Equals(..., OrdinalIgnoreCase)`; LEN
+compares digest bytes with `CryptographicOperations.FixedTimeEquals`.
 
 | Evidence | EC | LEN |
 |---|---|---|
@@ -780,6 +810,10 @@ inside the visible part of the same dropdown. Both combo-scoped and process-wide
 exact-name searches now follow the same documented rule, and fallback input
 uses the supplied window. Phase J drives the source-choice refusal against the
 built application.
+
+This fix kept the search-for-an-item design and made it consistent.
+[EC-24](#ec-24) later found that searching for items at all was unreliable, and
+replaced the approach rather than adjusting it again.
 
 ### EC-24
 

--- a/docs/GUI-SMOKE-TEST.md
+++ b/docs/GUI-SMOKE-TEST.md
@@ -18,17 +18,19 @@ sources/EncodingChecker.GuiSmoke/bin/Release/net10.0-windows/EncodingChecker.Gui
 ```
 
 Exit `0` when every phase passes, `1` when one fails, `2` for a usage, environment, or
-build-compatibility problem. Each run writes `gui-smoke-report.json` and `gui-smoke-report.md` carrying the
-EC version, the executable SHA-256, the OS and .NET versions, and each phase's before and
-after file hashes. It also hashes the managed assembly beside the executable when there
-is one, as in an ordinary Release build. A single-file publish has none, and the report
-says so instead of naming a file it could not read.
+build-compatibility problem. Each run writes `gui-smoke-report.json` and
+`gui-smoke-report.md`, carrying the EC version, the executable SHA-256, the OS and .NET
+versions, and each phase's before and after file hashes. It also hashes the managed
+assembly beside the executable when there is one, as in an ordinary Release build. A
+single-file publish has none, and the report says so instead of naming a file it could
+not read.
 
 ## Why this is not an ordinary test
 
-Everything reachable without a window is covered by the unit suite. What is left is
-Windows Forms itself: designer layout, background-worker marshalling, and the review
-dialog under a real message pump.
+Everything reachable without a window is covered by the unit suite. What is left is the
+window itself: whether the controls land where the designer put them, whether progress
+from a background thread reaches the screen safely, and whether the review dialog behaves
+when a person is actually clicking it.
 
 The obvious way to automate that — hosting the forms inside a test process — would mean
 reshaping the application to be drivable, trading a safety property for a test. This
@@ -43,7 +45,7 @@ because nothing ran the sequence.
 
 ## The phases
 
-| | Proves | Would have caught |
+| Phase | Proves | Would have caught |
 |---|---|---|
 | **A** | Opening the review and cancelling writes nothing, with backups enabled: no bytes change, no `.bak`, no `.ecmeta.json`. | A review that writes before you confirm. |
 | **B** | Unicode and ASCII convert with no source choice offered, text preserved exactly, and a recovery record naming `Detected` and the right code page. | A safe batch demanding a source choice, or a conversion that alters text. |
@@ -110,9 +112,9 @@ direction, about the wrong component.
 
 ## Requirements
 
-An interactive Windows desktop. UI Automation cannot drive a window that no session
-owns, so the runner refuses to start with exit `2` rather than reporting a pass it did
-not earn.
+An interactive Windows desktop - a real logged-in session with a screen. The automation
+layer cannot click a window that nobody is looking at, so with no desktop the runner
+refuses to start with exit `2` rather than reporting a pass it did not earn.
 
 A GitHub-hosted `windows-latest` runner **does** provide one. Measured, not assumed:
 `Environment.UserInteractive` is `True` under the `runneradmin` account, and phase A
@@ -123,7 +125,9 @@ exits `0`, because every phase in an empty set passes. The evidence the run uplo
 is what settles it: one phase recorded, `A`, with five files hashed before and five
 after. Read the artifact, not the tick.
 
-**It now gates the release.** `release.yml` runs all ten phases against the signed,
+## Where it runs
+
+**It gates the release.** `release.yml` runs all ten phases against the signed,
 published executable, after signing and before packaging, so what is verified is the
 bytes that ship rather than a rebuild of the same commit. A failure fails the job and
 no release is created. The report is uploaded as a `gui-smoke-evidence` artifact.

--- a/docs/GUI-SMOKE-TEST.md
+++ b/docs/GUI-SMOKE-TEST.md
@@ -128,6 +128,18 @@ published executable, after signing and before packaging, so what is verified is
 bytes that ship rather than a rebuild of the same commit. A failure fails the job and
 no release is created. The report is uploaded as a `gui-smoke-evidence` artifact.
 
-It does not run on every push. A GUI regression is caught at release time, which is
-late for a contributor and early enough for a user — moving it earlier is a separate
-decision about what every pull request should pay for.
+**It also gates every pull request.** `ci.yml` runs the same ten phases against an
+ordinary Release build, as its own `gui-smoke` check, so a GUI regression is found on
+the pull request that introduced it rather than at tag time with a release waiting.
+That costs about two minutes of runner time per pull request, which is the price of
+not diagnosing this class of defect mid-release.
+
+The two runs answer different questions and both are kept. The pull-request run asks
+whether this change broke the window; the release run asks whether the artifact about
+to be published works. Only the release job can ask the second one, because only it
+produces a signed, single-file executable.
+
+Evidence is uploaded from the pull-request run whether it passes or fails. A passing
+run is the sample that shows an intermittent phase has stopped being intermittent —
+which is the open question EC-24 records, since the failure that prompted the fix was
+never reproduced.

--- a/docs/GUI-SMOKE-TEST.md
+++ b/docs/GUI-SMOKE-TEST.md
@@ -49,7 +49,7 @@ because nothing ran the sequence.
 | Phase | Proves | Would have caught |
 |---|---|---|
 | **A** | Opening the review and cancelling writes nothing, with backups enabled: no bytes change, no `.bak`, no `.ecmeta.json`. | A review that writes before you confirm. |
-| **B** | Unicode and ASCII are handled with no source choice offered, and both keep their text exactly. The Unicode file's recovery record names `Detected` and the right code page. | A safe batch demanding a source choice, or a conversion that alters text. |
+| **B** | Unicode and ASCII convert with no source choice offered, both keep their text exactly, and **both** get a verified recovery record naming `Detected` and the right code page — ASCII included, whose bytes do not change. | A safe batch demanding a source choice, a conversion that alters text, or a conversion that skips the restore point when the bytes happen to match. |
 | **C** | A chosen legacy source applies **only** to the ticked files; an unticked file keeps its bytes and gets no backup. The record names `Explicit` and the chosen code page. | A source choice leaking to files it was not ticked for. |
 | **D** | BOM-less UTF-16 whose byte order cannot be proven is refused, is offered a source choice, and cancelling leaves the folder untouched. | Automatic conversion of a file whose byte order is a coin flip. |
 | **E** | Naming `utf-16BE` explicitly converts the same file exactly, with a backup and a recovery record. | A refusal that cannot be answered, or an answered one that loses text. |
@@ -149,10 +149,10 @@ the pull request that introduced it rather than at tag time with a release waiti
 That costs about two minutes of runner time per pull request, which is the price of
 not diagnosing this class of defect mid-release.
 
-The two runs answer different questions and both are kept. The pull-request run asks
-whether this change broke the window; the release run asks whether the artifact about
-to be published works. Only the release job can ask the second one, because only it
-produces a signed, single-file executable.
+The two runs answer different questions, and both upload a report. The pull-request run
+asks whether this change broke the window; the release run asks whether the artifact
+about to be published works. Only the release job can ask the second one, because only it
+produces a published single-file executable.
 
 Evidence is uploaded from the pull-request run whether it passes or fails. A passing
 run is the sample that shows an intermittent phase has stopped being intermittent —

--- a/docs/GUI-SMOKE-TEST.md
+++ b/docs/GUI-SMOKE-TEST.md
@@ -2,8 +2,9 @@
 
 Ten phases that drive a built `EncodingChecker.exe` through Windows UI Automation
 and check the bytes it leaves behind. Every phase creates its own disposable folder,
-performs a real sequence in the real window, and then verifies files — never status
-messages.
+performs a real sequence in the real window, and then verifies files. Where a phase does
+read what the window says, it checks that wording against the bytes on disk rather than
+taking it on trust.
 
 ```powershell
 dotnet build sources/EncodingChecker.sln -c Release
@@ -27,10 +28,10 @@ not read.
 
 ## Why this is not an ordinary test
 
-Everything reachable without a window is covered by the unit suite. What is left is the
-window itself: whether the controls land where the designer put them, whether progress
-from a background thread reaches the screen safely, and whether the review dialog behaves
-when a person is actually clicking it.
+Conversion policy, plan binding and orchestration are covered by the unit suite, which
+needs no window. What is left is the window itself: whether the controls land where the
+designer put them, whether progress from a background thread reaches the screen safely,
+and whether the review dialog behaves when a person is actually clicking it.
 
 The obvious way to automate that — hosting the forms inside a test process — would mean
 reshaping the application to be drivable, trading a safety property for a test. This
@@ -48,7 +49,7 @@ because nothing ran the sequence.
 | Phase | Proves | Would have caught |
 |---|---|---|
 | **A** | Opening the review and cancelling writes nothing, with backups enabled: no bytes change, no `.bak`, no `.ecmeta.json`. | A review that writes before you confirm. |
-| **B** | Unicode and ASCII convert with no source choice offered, text preserved exactly, and a recovery record naming `Detected` and the right code page. | A safe batch demanding a source choice, or a conversion that alters text. |
+| **B** | Unicode and ASCII are handled with no source choice offered, and both keep their text exactly. The Unicode file's recovery record names `Detected` and the right code page. | A safe batch demanding a source choice, or a conversion that alters text. |
 | **C** | A chosen legacy source applies **only** to the ticked files; an unticked file keeps its bytes and gets no backup. The record names `Explicit` and the chosen code page. | A source choice leaking to files it was not ticked for. |
 | **D** | BOM-less UTF-16 whose byte order cannot be proven is refused, is offered a source choice, and cancelling leaves the folder untouched. | Automatic conversion of a file whose byte order is a coin flip. |
 | **E** | Naming `utf-16BE` explicitly converts the same file exactly, with a backup and a recovery record. | A refusal that cannot be answered, or an answered one that loses text. |
@@ -120,17 +121,27 @@ A GitHub-hosted `windows-latest` runner **does** provide one. Measured, not assu
 `Environment.UserInteractive` is `True` under the `runneradmin` account, and phase A
 opened the review, cancelled it, and verified the bytes on disk.
 
-The exit code alone would not have shown that. A `--phase` matching nothing also
-exits `0`, because every phase in an empty set passes. The evidence the run uploaded
-is what settles it: one phase recorded, `A`, with five files hashed before and five
-after. Read the artifact, not the tick.
+The exit code alone would not have shown that, because a green tick says only that
+nothing failed. The evidence the run uploaded is what settles it: one phase recorded,
+`A`, with five files hashed before and five after. Read the artifact, not the tick.
 
 ## Where it runs
 
-**It gates the release.** `release.yml` runs all ten phases against the signed,
-published executable, after signing and before packaging, so what is verified is the
-bytes that ship rather than a rebuild of the same commit. A failure fails the job and
-no release is created. The report is uploaded as a `gui-smoke-evidence` artifact.
+**It gates the release.** `release.yml` runs all ten phases against the published
+framework-dependent executable, `publish\win-x64\EncodingChecker.exe`, so what is
+verified is a file that ships rather than a rebuild of the same commit. A failure fails
+the job and no release is created.
+
+Two limits are worth knowing rather than assuming. The run happens **after** the signing
+step, so it drives the signed bytes when signing runs - but signing is conditional on the
+certificate secrets being configured, and when they are not it is skipped and the suite
+drives an unsigned file. And the **self-contained** executable under
+`win-x64-selfcontained` is packaged and shipped without being driven at all; only the
+framework-dependent one is.
+
+The report is uploaded as a `gui-smoke-evidence` workflow artifact, which expires on
+GitHub's retention schedule. It is not attached to the release, so it is not permanent
+evidence unless someone attaches it.
 
 **It also gates every pull request.** `ci.yml` runs the same ten phases against an
 ordinary Release build, as its own `gui-smoke` check, so a GUI regression is found on

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -30,8 +30,9 @@ and add the ones no workflow can answer.
       no pull request here.
 - [ ] Ambiguous BOM-less UTF-16 is refused without changing bytes or creating a backup.
 - [ ] Structurally provable BOM-less UTF-16 still converts correctly.
-- [ ] BOM-less UTF-32 is refused in every mode, with `UnprovableBomlessUtf32`, and
-      converts when given a BOM or an explicit source.
+- [ ] BOM-less UTF-32 is never converted automatically; it is refused with
+      `UnprovableBomlessUtf32`. It converts when a BOM confirms the encoding, or when
+      the user selects the source encoding explicitly.
 - [ ] Explicit source selection still receives strict decoding and output verification.
 - [ ] A stale reviewed plan leaves every selected source unchanged.
 - [ ] Backup and recovery-sidecar hashes match the source bytes used for conversion.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -1,10 +1,13 @@
 # Release checklist
 
-Automated coverage is the first gate and is enforced by CI. Three checks are required
-before anything merges to master: `build` (compile and unit tests), `gui-smoke` (the ten
-phases below, against an ordinary Release build), and `parity` (the shared detector
-sources still match across all three repositories). What follows is what CI cannot
-answer.
+This file records every gate a release passes, automated and manual, so that one list
+can be worked through end to end.
+
+Three checks are required before anything merges to master, and CI enforces them:
+`build` (compile and unit tests), `gui-smoke` (the ten phases below, against an ordinary
+Release build), and `parity` (the shared detector sources still match across all three
+repositories). The items below repeat the ones worth confirming by eye at release time,
+and add the ones no workflow can answer.
 
 ## Source and version
 
@@ -76,12 +79,19 @@ is what ties a release to its source.
 
 **Two workflows run this for you.** `ci.yml` runs all ten phases on every pull request
 and push to master, against an ordinary Release build, as a required `gui-smoke` check.
-`release.yml` runs them again against the signed, published executable — the bytes that
-ship, not a rebuild of the same commit — after signing and before packaging, and uploads
-the report as a `gui-smoke-evidence` artifact. A failure there stops the release.
+`release.yml` runs them again against the published framework-dependent executable —
+a file that ships, not a rebuild of the same commit — after the signing step and before
+packaging, and uploads the report as a `gui-smoke-evidence` artifact. A failure there
+stops the release.
+
+Be precise about what that second run covers. Signing is conditional on the certificate
+secrets: when they are absent the step is skipped and the suite drives an **unsigned**
+file. And only the framework-dependent executable is driven; the self-contained build is
+packaged and shipped without being driven. Widening the run to both is a decision nobody
+has taken.
 
 So a regression should be caught on the pull request. The release run remains the only
-one that drives the artifact users receive. Run it locally while developing if you like;
+one that drives a file users receive. Run it locally while developing if you like;
 neither gate depends on your remembering to.
 
 Two prerequisites, each refused with exit 2 rather than reported as a pass: an
@@ -106,7 +116,11 @@ checks the status line *against* the bytes on disk rather than trusting it.
 The ten phases record themselves. `gui-smoke-report.md` and `gui-smoke-report.json`
 already carry the EC version, the executable hash, the OS and .NET versions, and every
 phase's before and after file hashes — better evidence than a transcribed letter, and not
-subject to a typo. Keep both files with the release.
+subject to a typo.
+
+They are uploaded as a workflow artifact and expire on GitHub's retention schedule. If a
+release needs them permanently, attach both files to the GitHub release; nothing does
+that automatically today.
 
 What still needs a person is the spot check above, because nobody has automated a
 judgement about whether text is readable. Fill this in and keep it alongside them.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -38,11 +38,6 @@ For a release changing detection or conversion policy:
 
 - [ ] Run the four-corpus audit from a clean committed build.
 - [ ] Record the exact commit, assembly hash, audit configuration, and limitations.
-- [ ] Run the independent-oracle sentinel set, if this release calls for one.
-      **Nothing in this repository defines that term or that set.** It appears here and
-      nowhere else, and the instruction pointed back at this checklist, so as written the
-      item cannot be actioned. Left in place rather than deleted, because the person who
-      added it meant something; it needs writing down or removing deliberately.
 
 ## The GUI smoke test
 

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -1,7 +1,10 @@
 # Release checklist
 
-Automated coverage is the first gate and is enforced by CI. What follows is what CI
-cannot answer.
+Automated coverage is the first gate and is enforced by CI. Three checks are required
+before anything merges to master: `build` (compile and unit tests), `gui-smoke` (the ten
+phases below, against an ordinary Release build), and `parity` (the shared detector
+sources still match across all three repositories). What follows is what CI cannot
+answer.
 
 ## Source and version
 
@@ -66,11 +69,15 @@ is what ties a release to its source.
 
 **[What each of the ten phases proves, and what it would catch →](GUI-SMOKE-TEST.md)**
 
-**The release workflow runs this for you, and a failure stops the release.** It drives
-the signed, published executable — the bytes that ship, not a rebuild of the same
-commit — after signing and before packaging, and uploads the report as a
-`gui-smoke-evidence` artifact. Run it locally while developing; before tagging, you no
-longer have to remember to.
+**Two workflows run this for you.** `ci.yml` runs all ten phases on every pull request
+and push to master, against an ordinary Release build, as a required `gui-smoke` check.
+`release.yml` runs them again against the signed, published executable — the bytes that
+ship, not a rebuild of the same commit — after signing and before packaging, and uploads
+the report as a `gui-smoke-evidence` artifact. A failure there stops the release.
+
+So a regression should be caught on the pull request. The release run remains the only
+one that drives the artifact users receive. Run it locally while developing if you like;
+neither gate depends on your remembering to.
 
 Two prerequisites, each refused with exit 2 rather than reported as a pass: an
 interactive Windows desktop, which a hosted `windows-latest` runner provides, and a

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -17,10 +17,14 @@ answer.
 
 - [ ] Release build succeeds with no warnings.
 - [ ] `dotnet test sources/EncodingChecker.Tests/EncodingChecker.Tests.csproj -c Release` — all green.
-- [ ] The scheduled **Shared Unicode detector parity** workflow is green. It compares
-      the shared detector source in EncodingChecker, LineEndingNormalizer, and
-      CorpusTesters after normalizing namespace, a redundant `using System` import,
-      and line-ending differences.
+- [ ] The **Shared Unicode detector parity** check is green. It compares the shared
+      detector source in EncodingChecker, LineEndingNormalizer and CorpusTesters,
+      ignoring the differences that are meant to differ: the namespace, a `using System`
+      line only EncodingChecker needs, byte-order marks, line endings, and runs of blank
+      lines. Anything else that differs is a real divergence. It runs on every pull
+      request and push, weekly on a schedule, and again inside the release job - the
+      schedule matters because a change in either of the other two repositories produces
+      no pull request here.
 - [ ] Ambiguous BOM-less UTF-16 is refused without changing bytes or creating a backup.
 - [ ] Structurally provable BOM-less UTF-16 still converts correctly.
 - [ ] BOM-less UTF-32 is refused in every mode, with `UnprovableBomlessUtf32`, and
@@ -34,15 +38,21 @@ For a release changing detection or conversion policy:
 
 - [ ] Run the four-corpus audit from a clean committed build.
 - [ ] Record the exact commit, assembly hash, audit configuration, and limitations.
-- [ ] Run the independent-oracle sentinel set when the release checklist requires it.
+- [ ] Run the independent-oracle sentinel set, if this release calls for one.
+      **Nothing in this repository defines that term or that set.** It appears here and
+      nowhere else, and the instruction pointed back at this checklist, so as written the
+      item cannot be actioned. Left in place rather than deleted, because the person who
+      added it meant something; it needs writing down or removing deliberately.
 
 ## The GUI smoke test
 
 **Why it is a gate of its own.** EC's conversion policy, plan binding, and orchestration
-sequence are covered by the unit suite. What is left is Windows Forms itself — designer
-layout, background-worker marshalling, and the dialog's behaviour under a real message
-pump. The suite reaches those by driving the shipped executable through the
-accessibility layer, so no part of the application is reshaped to make it drivable.
+sequence are covered by the unit suite. What is left is the window itself — whether the
+controls land where the designer put them, whether progress from a background thread
+reaches the screen safely, and whether the review dialog behaves when a person is
+clicking it. The suite reaches those by driving the shipped executable through the same
+accessibility layer a screen reader uses, so no part of the application is reshaped to
+make it testable.
 
 **Why it is not optional.** EC has already shipped a defect of exactly this shape: every
 component was correct and tested while the GUI's *sequence* converted files the CLI

--- a/docs/Test-DefectBacklog.ps1
+++ b/docs/Test-DefectBacklog.ps1
@@ -1,4 +1,17 @@
-﻿[CmdletBinding()]
+﻿# Run as:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File docs/Test-DefectBacklog.ps1
+#
+# `powershell` rather than `pwsh`: Windows PowerShell is on every Windows machine
+# and pwsh may not be installed. This file is ASCII-only and carries a BOM, so
+# both shells read it identically whatever the system code page is. It shipped
+# once as BOM-less UTF-8 containing em-dashes, which Windows PowerShell read in
+# the system code page, and it would not parse.
+#
+# `-ExecutionPolicy Bypass`: this repository ships no signed scripts, and a stock
+# machine refuses to run unsigned ones. It applies to that one process and
+# changes nothing on the machine.
+
+[CmdletBinding()]
 param(
     [string] $Path
 )
@@ -81,7 +94,7 @@ $rows = foreach ($line in [regex]::Split($ledger, '\r?\n')) {
         Finding = $cells[1]
         Status  = $cells[2]
         Impact  = $cells[3]
-        Reach   = $cells[4]
+        Likelihood = $cells[4]
         Details = $cells[5]
     }
 }
@@ -96,7 +109,7 @@ $knownStatuses = @(
     'Open',
     'Not reproduced',
     'Withdrawn',
-    'Not a defect',
+    'Intentional behavior',
     'Decision'
 )
 
@@ -110,8 +123,9 @@ foreach ($row in $rows) {
     }
 
     if ($row.Status -eq 'Open' -and
-        ($row.Impact -in @('', '-', $EmDash) -or $row.Reach -in @('', '-', $EmDash))) {
-        $errors.Add("$($row.Id) is open but lacks impact or reach.")
+        ($row.Impact -in @('', '-', $EmDash) -or
+         $row.Likelihood -in @('', '-', $EmDash))) {
+        $errors.Add("$($row.Id) is open but lacks impact or likelihood.")
     }
 
     $expectedLink = "[$($row.Id)](#$($row.Id.ToLowerInvariant()))"
@@ -133,7 +147,7 @@ $actual = @{
     open             = @($rows | Where-Object Status -eq 'Open').Count
     'not-reproduced' = @($rows | Where-Object Status -eq 'Not reproduced').Count
     withdrawn        = @($rows | Where-Object Status -eq 'Withdrawn').Count
-    'not-a-defect'   = @($rows | Where-Object Status -eq 'Not a defect').Count
+    'intentional-behavior' = @($rows | Where-Object Status -eq 'Intentional behavior').Count
     decision         = @($rows | Where-Object Status -eq 'Decision').Count
 }
 
@@ -157,7 +171,8 @@ foreach ($key in $actual.Keys) {
 
 $summary = "**Derived count: $($actual.total) findings $EmDash $($actual.fixed) fixed, " +
     "$($actual.open) open, $($actual['not-reproduced']) not reproduced, " +
-    "$($actual.withdrawn) withdrawn, $($actual['not-a-defect']) not a defect, " +
+    "$($actual.withdrawn) withdrawn, " +
+    "$($actual['intentional-behavior']) intentional behavior, " +
     "and $($actual.decision) design decision.**"
 $normalizedContent = [regex]::Replace($content, '\s+', ' ')
 

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -200,6 +200,14 @@ internal sealed class SmokeSuite
             before["unicode.txt"],
             sourceMode: "Detected",
             sourceCodePage: 1200);
+
+        // ASCII to UTF-8 leaves the bytes identical, but it is still planned as a
+        // conversion, so it must leave the same recovery evidence behind.
+        AssertRecovery(
+            Path.Combine(directory, "plain.txt"),
+            before["plain.txt"],
+            sourceMode: "Detected",
+            sourceCodePage: 20127);
     }
 
     private void PhaseC(PhaseContext phase)


### PR DESCRIPTION
Eleven commits with one purpose: make the safety and release documentation accurate,
and readable by a maintainer who does not already know EC's class names.

No production behaviour changes. One test assertion is added, and two workflow comments
plus one workflow summary string are corrected.

---

## Part one — the defect backlog

**Structure.** Three sections grouped entries by *when* a finding was reported, which is
not what anyone opens the file to learn — and six **Fixed** findings (EC-08, EC-15,
EC-18, EC-23, BL-01, BL-18) were still filed under a heading that said "open". They were
open when their evidence was written and were fixed in place afterwards. There is now one
`Finding details` section ordered by ID, and the ledger table above remains the only place
that assigns status, so the two cannot disagree.

The recheck record, the rejected hashing measurements, and the 79-row pre-reformat mapping
moved to `DEFECT-BACKLOG-HISTORY.md`. Not one word of them changed — they are audit trail;
only links that now cross a file boundary were rewritten.

**Wording.** Every entry leads with what can happen, states whether a source file can
change, and puts the code detail after that under *Evidence*. Four open findings now also
answer a question the ledger was not answering — *why is this still open*: EC-17 needs
three repositories changed together, EC-20's obvious fix would break scanning of open log
files, BL-05 was confirmed by reading code rather than by triggering it, and BL-20 is an
unmade design decision.

**Names.** `Reach` becomes `Likelihood`; `Not a defect` becomes `Intentional behavior`.
`Test-DefectBacklog.ps1` changes in the same commit — status list, count key, score check
and summary string — because the ledger and its validator cannot disagree about what a
status is called. Twenty-four fixed findings were retitled to say what happened rather
than how it worked.

**Two loose ends got IDs.** EC-24 carried two unresolved observations in its closing
paragraph, where a Fixed entry cannot give them a status. They are now **EC-25** (the
suite never sets the main window's target encoding) and **EC-26** (the driver trusts an
enabled flag seen stale for five seconds), both Open, both about the instrument rather
than the product.

**65 findings — 52 fixed, 9 open.** Checker green.

---

## Part two — GUI smoke test and release checklist

**Four claims were not true**, found by checking the documents against the workflow and
the v3.14.0 run rather than against each other:

| Claim | Reality |
|---|---|
| "the signed, published executable" | Signing is conditional on the certificate secrets and **was skipped for v3.14.0** |
| the artifact is "the executable that ships" | Only the **framework-dependent** build is driven; the self-contained build is packaged untested |
| "Keep both files with the release" | They are workflow artifacts on a retention schedule; the v3.14.0 release carries only the two archives |
| phases verify files, "never status messages" | H and J assert on rendered wording and I reads the status line — against the bytes, which is the real point |

The rehearsal summary was the sharpest: it announced "built, tested, **signed**,
GUI-checked and packaged" whatever happened, so a rehearsal without the secrets reported
signing that never ran. It now checks and says which it was.

**Phase B was under-asserting.** The table claimed a recovery record for the ASCII file;
only the Unicode one was checked. Running the phase with the workspace kept settled it —
ASCII to UTF-8 is planned as a conversion even though the bytes are identical, and
`plain.txt` does get a `.bak` and an `.ecmeta.json` recording source 20127 in `Detected`
mode. The assertion is added rather than the claim weakened, because a conversion whose
bytes do not change is where a missing restore point is easiest to overlook.

**Also corrected.** `--phase` can no longer match nothing — the parser accepts only A–J
and throws — so the sentence resting on that is gone. The UTF-32 checklist item said
BOM-less UTF-32 is "refused in every mode" and then that explicit selection converts it.
The checklist opened by saying what follows is "what CI cannot answer", immediately above
a section listing what CI does answer. And Windows Forms internals — "background-worker
marshalling", "under a real message pump", "a window that no session owns" — are said in
plain words in both files.

**Removed:** the *independent-oracle sentinel set* checklist item. It named a one-time
CorpusTesters experiment that was already decided against, the term appeared exactly once
in the repository and was defined nowhere, and the instruction pointed back at this
checklist. Nothing replaces it; the five real gates all remain stated.

---

## Verification

- **756 unit tests**, release build 0 warnings
- **GUI smoke 10/10** from a clean rebuild; the new Phase B assertion mutation-checked
  (expecting code page 1252 fails with "Recovery metadata contains the wrong source codec
  identity"), file restored byte-identical
- `docs/Test-DefectBacklog.ps1` passes at **65 findings — 52 fixed, 9 open**
- Both workflows still parse; jobs unchanged
- Every rewritten entry checked mechanically for dropped numbers and identifiers — that
  check caught four losses during drafting (`UTF-8` in BL-20; `None`, `ApplyConversion`,
  `SourceInterpretation`, `Converted` in the fixed-finding pass), all restored
- All internal links resolve; all files CRLF, UTF-8 without BOM

## Deliberately not done here

Making signing mandatory, driving the self-contained executable, and attaching smoke
reports to the release all change behaviour rather than description. They are documented
as current limits instead, and are worth taking as their own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
