### PR TITLE
Release v3.14.1, and record the release sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml/badge.svg)](https://github.com/amrali-eg/EncodingChecker/actions/workflows/ci.yml)
 
-# EncodingChecker v3.14.0
+# EncodingChecker v3.14.1
 
 EncodingChecker is a Windows tool for finding, checking, and safely converting text-file encodings. Use the GUI for everyday work or the command line for repeatable jobs.
 

--- a/docs/RELEASE-NOTES-v3.14.1.md
+++ b/docs/RELEASE-NOTES-v3.14.1.md
@@ -1,0 +1,71 @@
+# EncodingChecker v3.14.1
+
+One product fix. Everything else in this release is invisible to anyone running
+`EncodingChecker.exe`, and the notes say so rather than padding the list.
+
+## A constructed include pattern can no longer hang a scan
+
+`-Include` and `-Exclude` masks are translated to regular expressions. That translation
+is unchanged — `*` still becomes `.*`, `?` still becomes `.`, and a mask with no
+separator still matches at any directory depth. What changed is how .NET evaluates the
+result.
+
+The old engine could be made to retry an exponential number of alternatives. A mask
+carrying twelve separated wildcards, matched against a nonmatching forty-character run of
+the separating character, did not finish within three seconds and had to be killed.
+Realistic names answered in 0–5 ms throughout. The new engine returns the correct answer
+in 0.427 ms, and runs in time proportional to the input, so no mask can stall a scan.
+
+**Include and exclude results are identical.** An independent differential comparison ran
+500 generated masks against 200 generated paths — 100,000 pairs, including directory
+separators and the regex-special characters EC escapes — and found no case where the two
+engines disagreed. A regression test asserts the engine before exercising the hostile
+input, so restoring the old one fails in 9 ms rather than hanging the test run.
+
+**It is not free.** Measured over 3,937 files, median of five warm runs: 128 ms before,
+148 ms after — about 16%, or roughly 5 µs per file, and the same figure for a plain
+`*.txt` mask as for `*a*b*.txt`. That is the price of a bounded worst case, and it is
+recorded here so nobody has to measure it again.
+
+Both inputs have to be deliberately hostile for the old behaviour to appear, and the mask
+comes from the operator rather than from an untrusted file, which is why the defect was
+scored Theoretical. An unbounded runtime was still worth removing for the price of one
+option.
+
+## What else is in this release, and why you will not notice it
+
+- **The release gate is deterministic.** The GUI smoke suite could select an encoding
+  from the wrong drop-down, because it searched the whole application for any visible item
+  with a matching name and two combos hold the same names. It failed once during the
+  v3.14.0 release and passed on a re-run of the same commit. It now sets the value
+  directly. This is test machinery; `EncodingChecker.exe` is unaffected.
+- **That suite now runs on every pull request**, not only at tag time, so a GUI regression
+  is found by the change that caused it.
+- **Every `.cs` file changed by one byte.** Source files now agree on encoding — UTF-8
+  without a byte-order mark, CRLF — with an `.editorconfig` recording the choice. No
+  compiled behaviour changes; the assembly hash does, because the sources did.
+- **The defect ledger and release documentation were rewritten** to be read by a
+  maintainer rather than decoded, and four claims in them turned out to be untrue and were
+  corrected.
+
+## Compatibility
+
+Nothing changes. Conversion semantics stay at **7**, the plan schema at **6**, the journal
+schema at **5**. Plans and journals written by v3.14.0 apply unchanged. Every exit code,
+reason code, report column and journal field is what it was, and the set of files any given
+`-Include` or `-Exclude` mask selects is unchanged.
+
+## Verification
+
+- 756 tests pass, none skipped (was 755); release build with no warnings
+- The GUI smoke suite passes all ten phases, against both an ordinary Release build and the
+  published single-file executable
+- The regex fix was mutation-checked: restoring `RegexOptions.Compiled` fails the new test
+  in 9 ms, on the engine assertion rather than by hanging, and the file restored
+  byte-identical by SHA-256
+- Phase B now also asserts that the ASCII file receives a verified recovery record. EC
+  converts ASCII to UTF-8 even though the bytes are identical, and until now nothing
+  checked that the restore point was written for that case
+- `docs/Test-DefectBacklog.ps1` passes at **65 findings — 52 fixed, 9 open**
+- **No four-corpus audit was run.** This release changes no detection or conversion policy,
+  so the checklist does not require one

--- a/sources/EncodingChecker/Properties/AssemblyInfo.cs
+++ b/sources/EncodingChecker/Properties/AssemblyInfo.cs
@@ -41,5 +41,5 @@ using System.Runtime.Versioning;
 // You can specify all the values, or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.14.0.0")]
-[assembly: AssemblyFileVersion("3.14.0.0")]
+[assembly: AssemblyVersion("3.14.1.0")]
+[assembly: AssemblyFileVersion("3.14.1.0")]


### PR DESCRIPTION
Two commits: the version bump with its notes, and the release sequence recorded in the
checklist.

## Why this is a patch

In the shipped project exactly one file changed behaviour since v3.14.0 —
`DirectoryTraversal.cs`, where EC-08 replaced the backtracking regex engine. Every other
file under `sources/EncodingChecker/` changed by one byte: the byte-order mark the
encoding pass removed.

```
git diff v3.14.0..master -- sources/EncodingChecker/
20 files changed, 25 insertions(+), 21 deletions(-)
```

No conversion or detection policy moved, no schema moved, no CLI option moved, and the set
of files any `-Include` or `-Exclude` mask selects is unchanged. That also settles the
audit question: the checklist requires a four-corpus run only when detection or conversion
policy changes.

## The notes say what is not in it

The release gate becoming deterministic, the smoke suite moving to every pull request, the
source-encoding normalization and the documentation rewrite are all real work, and none of
it reaches `EncodingChecker.exe`. The notes list them under a heading that says so, rather
than padding the changelog with work a user cannot observe.

They also carry the cost of the one fix — 128 ms against 148 ms over 3,937 files — because
the ledger's earlier claim that it cost nothing was wrong, and a reader weighing the
upgrade should not have to measure it again.

## The release sequence

`RELEASE-CHECKLIST.md` said what to verify and never what to do first. The sequence lived
in whoever ran the last release. It is now twelve numbered steps, each expanded by a
section already in the file, with three points that are not obvious from the gates:

- Decide the version from what changed in the shipped project, not from how much work went
  in. This release is the example.
- Rehearse before tagging. `workflow_dispatch` on `release.yml` runs the whole path and
  then stops, because creating the release requires a tag *push*.
- Write the audit record after the tag, never before — committing it changes the assembly
  through the PDB checksum.

## Verification

- Release build 0 warnings; **756 tests**; GUI smoke **10/10**; backlog checker at
  **65 findings — 52 fixed, 9 open**
- `--version` and the built-in help both report **3.14.1**
- **Release rehearsal run against this branch** — build, test, publish, GUI smoke against
  the published executable, package — and it stopped without publishing, as designed.
  Its summary read: *"executables not signed, because the certificate secrets are not
  configured"*, which is the corrected reporting from #90 working on a real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
