### PR TITLE
Record the release sequence in the checklist

### DIFF
--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -9,6 +9,45 @@ Release build), and `parity` (the shared detector sources still match across all
 repositories). The items below repeat the ones worth confirming by eye at release time,
 and add the ones no workflow can answer.
 
+## The sequence
+
+The gates below say what to check. This says in what order, and which steps cannot be
+swapped. Each numbered step is expanded by a section further down.
+
+1. **Merge everything the release will contain.** Nothing half-landed.
+2. **Decide the version from what actually changed in the shipped project**, not from how
+   much work went in:
+   `git diff v<previous>..master -- sources/EncodingChecker/`
+   Test projects, the smoke driver, workflows and documentation do not reach a user. A
+   release can be large in commits and still be a patch.
+3. **Bump and write the notes in one commit** - `AssemblyInfo.cs`, the README heading, and
+   `docs/RELEASE-NOTES-v<version>.md`.
+4. **Run the local gates.** Release build with no warnings, the unit suite, the ten GUI
+   smoke phases, `Test-DefectBacklog.ps1`, and confirm `--version` and the built-in help
+   both report the new number.
+5. **Rehearse.** Run `release.yml` by `workflow_dispatch` against the bump branch. It
+   builds, tests, publishes, signs if the secrets exist, and drives the GUI suite against
+   the published executable - then stops, because creating the release requires a tag
+   *push*. This is the only way to exercise the real release path before committing to a
+   tag, and it costs one dispatch.
+6. **Push the branch, open the pull request, merge it once the three checks are green.**
+7. **Tag from a clean tree.** An annotated tag, `v<version>` exactly, pushed to origin.
+   Pushing the tag is what publishes; there is no undo that leaves no trace.
+8. **Let the release workflow run** and confirm what it produced: the release exists, is
+   not a draft, and carries both archives.
+9. **Gather the evidence yourself.** Download both archives and hash them locally rather
+   than trusting the reported digests, and reproduce the published executable by
+   publishing a clean checkout of the tag. A matching hash ties the release to its source
+   by measurement instead of assertion.
+10. **Edit the release body.**
+11. **Write the `SAFETY-AUDIT.md` record - after the tag, never before.** Committing it
+    changes the assembly through the PDB checksum, so a hash quoted in a record that is
+    part of the same commit describes a build that no longer exists.
+12. **Open and merge the audit-record pull request.**
+
+Steps 7 and 11 are the two that cannot move. Everything before 7 can be repeated freely;
+nothing after it can be taken back quietly.
+
 ## Source and version
 
 - [ ] Working tree is clean.


### PR DESCRIPTION
The release sequence, which should have been in #91 and was not.

The commit was made after that branch was pushed and never pushed again, so #91 carried
only the version bump while its description described this work. The description claimed
something the diff did not contain. This is that commit, cherry-picked onto master.

## What it adds

`RELEASE-CHECKLIST.md` said what to verify and never what to do first. The sequence lived
in whoever ran the last release. It is now twelve numbered steps, each expanded by a
section already in the file, with three points that are not obvious from the gates:

- **Decide the version from what changed in the shipped project**, not from how much work
  went in — `git diff v<previous>..master -- sources/EncodingChecker/`. Test projects, the
  smoke driver, workflows and documentation do not reach a user. v3.14.1 is the example:
  eleven documentation commits, a CI job, a driver fix, every source file re-encoded, and
  one behavioural change.
- **Rehearse before tagging.** `workflow_dispatch` on `release.yml` runs the whole release
  path and then stops, because creating the release requires a tag *push*. It is the only
  way to exercise the real path while a mistake is still free.
- **Write the audit record after the tag, never before.** Committing it changes the
  assembly through the PDB checksum, so a hash quoted in a record that ships in the same
  commit describes a build that no longer exists.

It closes on the distinction worth keeping: everything before the tag push can be repeated
freely, and nothing after it can be taken back quietly.

Documentation only. No code, no workflow, no version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
