### PR TITLE
Make the GUI smoke gate prove what it claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,11 @@ jobs:
             throw "GUI smoke suite failed with exit code $LASTEXITCODE."
           }
 
-      # Kept on success as well as failure: the report carries each phase's before
-      # and after file hashes, and a run that passed is the sample that shows
-      # whether an intermittent phase has stopped being intermittent.
+      # Kept on success as well as failure: the report carries each phase's after
+      # hashes and, for the phases that compare bytes, the before hashes too. A run
+      # that passed is the sample that shows whether an intermittent phase has stopped
+      # being intermittent. Phase I's cancellation margin is not in here - it is the
+      # [INFO] line in the step above.
       #
       # Missing evidence only warns here. When the suite cannot start it has already
       # failed the step above, and erroring again would bury that message.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
   gui-smoke:
     runs-on: windows-latest
 
+    # This job drives a real window, so a modal dialog nobody dismisses or a process that
+    # ignores Kill would otherwise run to GitHub's six-hour default - on a required check.
+    # Runs take about two minutes; this bounds a hang without failing a slow runner.
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
         run: dotnet publish sources\EncodingChecker\EncodingChecker.csproj -p:PublishProfile=SelfContainedRelease
 
       - name: Code-sign executables
+        id: sign
         if: ${{ env.CODE_SIGNING_CERT != '' && env.CODE_SIGNING_CERT_PASSWORD != '' }}
         shell: pwsh
         run: |
@@ -194,10 +195,12 @@ jobs:
         if: github.event_name != 'push'
         shell: pwsh
         run: |
-          $signing = if ($env:CODE_SIGNING_CERT -and $env:CODE_SIGNING_CERT_PASSWORD) {
-            "signed"
-          } else {
-            "not signed, because the certificate secrets are not configured"
+          # Read what the signing step did rather than deciding again from the secrets:
+          # two derivations of one fact can disagree, and this one is the report.
+          $signing = switch ('${{ steps.sign.outcome }}') {
+            'success' { 'signed' }
+            'skipped' { 'not signed, because the certificate secrets are not configured' }
+            default   { "not signed - the signing step reported '$_'" }
           }
 
           $summary = "REHEARSAL for version ${{ steps.version.outputs.version }} - " +

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
       #
       # The self-contained executable is packaged without being driven.
       - name: Drive the GUI smoke suite
+        timeout-minutes: 10
         shell: pwsh
         run: |
           $app = "sources\EncodingChecker\bin\Release\net10.0-windows\publish\win-x64\EncodingChecker.exe"
@@ -199,7 +200,7 @@ jobs:
           # two derivations of one fact can disagree, and this one is the report.
           $signing = switch ('${{ steps.sign.outcome }}') {
             'success' { 'signed' }
-            'skipped' { 'not signed, because the certificate secrets are not configured' }
+            'skipped' { 'not signed; the signing step was skipped' }
             default   { "not signed - the signing step reported '$_'" }
           }
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=65 fixed=52 open=9 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
+<!-- backlog-counts total=65 fixed=53 open=8 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
 
-**Derived count: 65 findings — 52 fixed, 9 open, 1 not reproduced, 1 withdrawn,
+**Derived count: 65 findings — 53 fixed, 8 open, 1 not reproduced, 1 withdrawn,
 1 intentional behavior, and 1 design decision.** Recompute and check these
 figures with:
 
@@ -53,7 +53,6 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-17 | A comment describes the text check backwards | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | A file can change while EC is detecting its encoding | Open | Low | Rare | [EC-20](#ec-20) |
 | EC-25 | The smoke suite never sets the main window's target encoding | Open | Low | Rare | [EC-25](#ec-25) |
-| EC-26 | The smoke driver trusts an enabled flag that has been seen stale | Open | Low | Rare | [EC-26](#ec-26) |
 | CX-06 | EC checks for random-looking data before checking for a BOM | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a conversion can produce an error on exit | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | ASCII with many NUL bytes can be reported as UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
@@ -71,6 +70,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | BL-01 | Ambiguous BOM-less UTF-32 could be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
 | EC-08 | A constructed include pattern could hang a scan indefinitely | Fixed | — | — | [EC-08](#ec-08) |
 | EC-24 | The GUI smoke gate could select in the wrong combo | Fixed | — | — | [EC-24](#ec-24) |
+| EC-26 | The smoke driver read a status line the window had not written yet | Fixed | — | — | [EC-26](#ec-26) |
 | EC-18 | EC repeated a BOM-less UTF-16 safety check unnecessarily | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application assumed a required path existed instead of checking it | Fixed | — | — | [EC-23](#ec-23) |
 | BL-27 | GUI smoke reports could show an empty or misleading build hash | Fixed | — | — | [BL-27](#bl-27) |
@@ -886,19 +886,43 @@ because doing so changes the suite that had just been stabilised.
 
 ### EC-26
 
-**The driver treats an enabled flag as a readiness signal, and it has been seen
-stale.** `Current.IsEnabled` reported a control disabled for five seconds while
-that same control accepted `Invoke` and closed the review. The driver uses
-`IsEnabled` elsewhere to decide that a scan has finished, that the main window is
-ready, and when cancellation may be attempted.
+**Before:** the driver treated an enabled button as "the run has finished". The
+window enables its buttons before it assigns the final status text, so a phase
+that read the status the moment the buttons came back could read the previous
+message, or none at all.
 
-No failure was reproduced from it. What it means is that a phase could time out
-waiting for a control that was ready the whole time, and report a defect in EC
-that is not there - the same shape of wrong answer that the preflight check exists
-to prevent.
+**Now:** the driver waits for the status a phase is about to assert, rather than
+for the button. Phase I counts the files actually rewritten, waits for that figure
+to appear as `N converted` and, when the run stopped early, for `M not attempted`,
+and only then reads the line. No sleep is involved: a sleep makes a race less
+likely rather than absent.
 
-A readiness check that also confirms the operation it is waiting for would not
-depend on the flag. Nothing has been changed yet.
+**EC is unchanged.** Enabling the buttons before assigning the status is a
+reasonable order for a window, and nothing a user sees depends on it. The defect
+was in the instrument's idea of "finished".
+
+**Reproduced, which is what closed it.** On 2026-09-09 a full run failed phase I
+with *"The 324 unreached file(s) are missing from the status"*, quoting a status
+that was the window's control names with no run message among them - the
+assignment had not happened yet. It then passed three times in isolation and twice
+in full runs. That is what makes this shape dangerous: the phase reports a defect
+in EC, in the alarming direction, and then disappears when you look again. Roughly
+one failure in fifteen runs before the fix.
+
+Twenty-five consecutive full runs passed afterwards. That is corroboration rather
+than proof - at the observed rate, twenty-five clean runs happen by chance about
+one time in five - so what closes this is the identified cause and a wait on the
+text being read, with the runs agreeing.
+
+`MainForm.UpdateControlsOnActionDone` enables `btnView` on its first line and
+assigns `actionStatus.Text` forty-five lines later. A driver polling every 50 ms
+lands between the two often enough to matter.
+
+The original observation has the same root and is kept: `Current.IsEnabled` was
+seen reporting a control disabled for five seconds while that control accepted
+`Invoke`. Whether the flag is stale or merely early, it answers a question the
+driver was not asking. A readiness check that confirms the thing being waited for
+does not have that problem, and that is now the rule this driver follows.
 
 ## Decisions and mistakes that must remain visible
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -871,34 +871,38 @@ ledger cannot give them a status: [EC-25](#ec-25) and [EC-26](#ec-26).
 
 ### EC-25
 
-**Before:** `ConfigureScan` asked for `utf-8` on `lstConvert` before scanning,
-while that control is still disabled. It succeeded only because `utf-8` was
-already selected, so the call returned before setting anything. The selection path
-[EC-24](#ec-24) replaced was therefore never driven on that combo, and a changed
-application default would have failed every phase during setup rather than in the
-phase that cares.
+**Before:** the smoke suite assumed that the main window's target encoding was
+`utf-8`, but it never proved that assumption. During setup it tried to select
+`utf-8` before the target list was enabled. Because `utf-8` was already selected,
+the helper returned without changing anything. The suite therefore never tested
+whether it could actually change that list. If EC's default changed, every phase
+would fail during setup instead of one focused check explaining what was wrong.
 
-**Now:** the suite states the assumption and exercises the path. `ConfigureScan`
-requires the window to open on `utf-8` and fails with one message naming that if
-it does not. Phase A sets the target to `us-ascii` and back after cancelling its
-review, where the run is over and the phase already proves no bytes moved.
+**Now:** every phase first checks that the window opens with `utf-8` selected and
+reports that assumption clearly if it is not true. After phase A cancels the
+review, it changes the target to `us-ascii` and then back to `utf-8`. Phase A is a
+safe place for this check because it already verifies that cancelling the review
+does not change any files. The round trip proves both that the expected default is
+present and that the target control can really be changed.
 
-`us-ascii` rather than a BOM variant on purpose: `utf-8-bom` and `utf-16BE` share
-a prefix with other entries, so a setter that matched on prefix would have made
-the check pass while selecting something else.
+`us-ascii` was chosen because its name is unambiguous in the list. BOM variants
+such as `utf-8-bom` and `utf-16BE` share prefixes with other entries, so an
+imprecise selection helper could appear to work while selecting the wrong item.
 
-**EC is unchanged.** The gap was in the suite. It is worth noting what the
-assertion protects, though: `MainForm` selects `utf-8` only when
-`FindStringExact` finds it and falls back to the first entry otherwise, so the
-default every phase depends on is conditional in the product rather than
-guaranteed.
+**EC is unchanged.** The gap was in the smoke suite. `MainForm` selects `utf-8`
+only when that exact entry is available; otherwise it selects the first entry.
+The suite therefore needs to check the startup value rather than silently depend
+on it.
 
-**Both halves are load-bearing**, checked by mutation with the build required to
-succeed and the compiled binary's hash required to change first. Expecting a
-different default fails in 750 ms with `GuiDriverException`; making the setter a
-no-op is caught by the round trip. Fifteen consecutive full runs passed after the
-change - fewer than the twenty-five behind [EC-26](#ec-26), because altering the
-suite retires the evidence gathered for the previous one.
+**Evidence:** both halves were checked by mutation, each requiring the build to
+succeed and the compiled binary's hash to change before anything was run - a
+mutation that fails to compile otherwise leaves the previous binary answering the
+question. Deliberately expecting a different default produced a clear failure in
+750 ms. Temporarily making the target-selection method do nothing was caught when
+phase A could not change to `us-ascii` and back. After the source was restored
+byte-for-byte, fifteen consecutive complete smoke-suite runs passed - fewer than
+some earlier findings carry, because altering the suite retires the evidence
+gathered for the previous one.
 
 ### EC-26
 
@@ -947,26 +951,32 @@ lookup waited the full thirty seconds and threw `TimeoutException: Control
 'btnCancel' was not found`. A run that finished between the check and the click
 would have failed the phase - the same flake the guard was written to prevent.
 
-**The replacement was wrong too, and review caught it rather than a control.** It
+**The next two replacements were wrong too, and review caught both.** The first
 treated a button it could not find as proof that the run had finished, and stopped
 looking after two seconds. A missing button has two meanings - the run beat the
 phase to it, or automation failed to see a button that is on screen - and only the
-window's own final status separates them. A driver that could never resolve the
-button would have reported phase I as passing while cancelling nothing: blinded to
-`btnCancel` permanently, that version passes twice out of two, converts all four
-hundred files, and still calls the result an interrupted run.
+window's own final status separates them.
 
-Cancelling now races a real button against a confirmed final status, and reports
-when neither arrives. Blinded to both, it fails twice out of two with *"The run
-offered neither a Cancel button nor a final status"*. A button that disappears
-between being found and being clicked has to be confirmed by a final status before
-that disappearance is accepted, and a run already over when the cancel step is
-reached is accepted through that same confirmation, which two more runs show.
+The second raced a real button against that final status, but still accepted an
+ordinary completed run as a successful cancellation test. Blinded only to
+`btnCancel`, it would wait until all four hundred files finished and pass because
+the phase checked its cancellation-specific results only when files happened to
+remain untouched. It had proved completion, not cancellation.
 
-What the controls could not settle is whether the two-second budget had ever been
-the limiting factor on this machine. Blinding the driver for three seconds ends
-identically on both versions, because the conversion finishes inside that window.
-That part of the correction rests on the reasoning, not on a measured difference.
+**Now:** phase I passes only after at least one file is converted, at least one is
+left untouched, and the final status says `Conversion stopped` with the matching
+converted and not-attempted counts. It asks for cancellation after the first
+observed write. If completion wins the race, the phase fails plainly instead of
+calling that a cancellation test. A button that disappears between lookup and
+click is likewise accepted only as evidence that the run completed, which still
+fails this phase because cancellation was not exercised.
+
+The decisive negative control hides only `btnCancel` while leaving the final
+status readable. The previous shape passed twice and converted all four hundred
+files. The final shape fails with *"The conversion finished before cancellation
+could be exercised."* Hiding both the button and final status also fails, retaining
+the distinction between a completed run and automation that can observe neither
+outcome.
 
 **A regression was introduced and fixed inside this change, and is recorded
 because the numbers below would otherwise look better than the work was.** The
@@ -977,49 +987,60 @@ runs gave one pass and fourteen phase I failures. Reading only the status bar's
 own subtree, and treating a lost race as "no evidence yet" rather than as a
 failure, is what fixed it.
 
-**Runs afterwards.** Fifteen consecutive full runs on the status-bar read,
-seventeen across the shape that preceded the raced cancel, and ten on the file
-committed here. As with
-[EC-27](#ec-27), clean runs corroborate rather than prove; what closes this is
-that the dependency is gone from the driver, and that the controls which could
-have caught a mistake did.
+**Runs afterwards.** Earlier revisions completed fifteen consecutive full runs on
+the status-bar read, seventeen on the shape before cancellation was made strict,
+and ten on the raced-cancel shape. The final stricter phase passed five focused
+runs, converting 24-32 of the four hundred files and leaving the rest untouched
+each time, and then ten consecutive complete runs. That margin - roughly a twelfth
+of the workload converted before cancellation lands - is what keeps the new
+strictness from turning a fast machine into a failing gate, and it is worth
+re-checking on hardware quicker than this one. As with [EC-27](#ec-27), clean runs
+corroborate rather
+than prove; what closes this is that the enabled-state dependency and the
+completion-as-cancellation false pass are both unreachable in the final code.
 
 ### EC-27
 
-**Before:** the driver treated an enabled button as "the run has finished". The
-window enables its buttons before it assigns the final status text, so a phase
-that read the status the moment the buttons came back could read the previous
-message, or none at all.
+**Before:** the smoke driver treated an enabled button as proof that the run had
+finished. The main window restores its buttons before it writes the final status
+message. During that short interval, the driver could read the previous message,
+an empty value, or unrelated text from the window instead of the result of the
+run that had just ended.
 
-**Now:** the driver waits for the status a phase is about to assert, rather than
-for the button. Phase I counts the files actually rewritten, waits for that figure
-to appear as `N converted` and, when the run stopped early, for `M not attempted`,
-and only then reads the line. No sleep is involved: a sleep makes a race less
-likely rather than absent.
+**Now:** the driver waits for the result that the phase is about to verify. In
+phase I it waits until the status contains both `N converted` and `M not
+attempted`, using the numbers observed on disk, and only then reads the complete
+line. It does not use a fixed delay. A delay would merely make the race less
+likely; waiting for the required text removes the race from this check.
 
-**EC is unchanged.** Enabling the buttons before assigning the status is a
-reasonable order for a window, and nothing a user sees depends on it. The defect
-was in the instrument's idea of "finished".
+**EC is unchanged.** Restoring the buttons before writing the status is a
+reasonable user-interface sequence. The defect was in the test driver's
+assumption that the first event proved the second had already happened.
 
-**Reproduced, which is what closed it.** On 2026-09-09 a full run failed phase I
-with *"The 324 unreached file(s) are missing from the status"*, quoting a status
-that was the window's control names with no run message among them - the
-assignment had not happened yet. It then passed three times in isolation and twice
-in full runs. That is what makes this shape dangerous: the phase reports a defect
-in EC, in the alarming direction, and then disappears when you look again. Roughly
-one failure in fifteen runs before the fix.
+**How it was found:** on 2026-09-09, one complete run failed phase I with *"The
+324 unreached file(s) are missing from the status"*. The text captured by the
+driver contained control names but no final conversion message because that
+message had not yet been written. The same phase then passed three times by itself
+and twice as part of the complete suite. This intermittent pattern was dangerous:
+the suite could report a product defect that was not present, then pass when the
+same test was repeated. It occurred roughly once in fifteen runs before the fix.
 
-Twenty-five consecutive full runs passed afterwards. That is corroboration rather
-than proof - at the observed rate, twenty-five clean runs happen by chance about
-one time in five - so what closes this is the identified cause and a wait on the
-text being read, with the runs agreeing.
+Code review confirmed the ordering in `MainForm.UpdateControlsOnActionDone`: the
+window restores the View button and writes the final status later in the same
+update. Because the driver checked every 50 ms, it could observe the window
+between those two actions.
 
-`MainForm.UpdateControlsOnActionDone` enables `btnView` on its first line and
-assigns `actionStatus.Text` forty-five lines later. A driver polling every 50 ms
-lands between the two often enough to matter.
+Twenty-five consecutive complete runs passed after the status-based wait was
+added. Those runs support the fix but do not prove it by themselves: at the
+roughly one-in-fifteen failure rate observed, twenty-five clean runs happen by
+chance about one time in five. The finding
+is closed because its cause was identified and the driver now waits for the exact
+text it needs instead of inferring completion from a button.
 
-This is one consequence of [EC-26](#ec-26) removed, not EC-26 itself. The driver
-still consults the flag in four other readiness checks.
+EC-27 fixed one visible result of [EC-26](#ec-26): reading the final status too
+early. EC-26 was later fixed by removing the remaining enabled-button checks from
+readiness decisions. The driver now waits for evidence produced by the operation
+itself.
 
 ## Decisions and mistakes that must remain visible
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=66 fixed=54 open=8 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
+<!-- backlog-counts total=66 fixed=55 open=7 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
 
-**Derived count: 66 findings — 54 fixed, 8 open, 1 not reproduced, 1 withdrawn,
+**Derived count: 66 findings — 55 fixed, 7 open, 1 not reproduced, 1 withdrawn,
 1 intentional behavior, and 1 design decision.** Recompute and check these
 figures with:
 
@@ -52,7 +52,6 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 |---|---|---|---|---|---|
 | EC-17 | A comment describes the text check backwards | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | A file can change while EC is detecting its encoding | Open | Low | Rare | [EC-20](#ec-20) |
-| EC-26 | The smoke driver trusts an enabled flag that has been seen stale | Open | Low | Rare | [EC-26](#ec-26) |
 | CX-06 | EC checks for random-looking data before checking for a BOM | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a conversion can produce an error on exit | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | ASCII with many NUL bytes can be reported as UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
@@ -71,6 +70,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-08 | A constructed include pattern could hang a scan indefinitely | Fixed | — | — | [EC-08](#ec-08) |
 | EC-24 | The GUI smoke gate could select in the wrong combo | Fixed | — | — | [EC-24](#ec-24) |
 | EC-25 | The smoke suite never set the main window's target encoding | Fixed | — | — | [EC-25](#ec-25) |
+| EC-26 | The smoke driver trusted an enabled flag that had been seen stale | Fixed | — | — | [EC-26](#ec-26) |
 | EC-27 | The smoke driver read a status line the window had not written yet | Fixed | — | — | [EC-27](#ec-27) |
 | EC-18 | EC repeated a BOM-less UTF-16 safety check unnecessarily | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application assumed a required path existed instead of checking it | Fixed | — | — | [EC-23](#ec-23) |
@@ -902,28 +902,68 @@ suite retires the evidence gathered for the previous one.
 
 ### EC-26
 
-**The driver treats an enabled flag as a readiness signal, and it has been seen
-stale.** `Current.IsEnabled` reported a control disabled for five seconds while
-that same control accepted `Invoke` and closed the review.
+**Before:** the driver asked whether a button was enabled and treated the answer
+as "the work has finished". `Current.IsEnabled` had been seen reporting a control
+disabled for five seconds while that same control accepted `Invoke` and closed the
+review, so four readiness checks rested on a flag that was known to lie: that a
+scan had finished, that writing had begun, whether cancellation was still
+possible, and that the main window had returned to idle. A phase could time out
+waiting for a control that was ready the whole time, and report a defect in EC
+that was not there.
 
-Four readiness checks still rest on it: that a scan has finished, that writing has
-begun, whether cancellation is still possible, and that the main window has
-returned to idle. None of them confirms the thing it is waiting for; each asks the
-flag instead.
+**Now:** each of those waits names evidence the operation itself produced - rows
+in the list, bytes on disk, the summary the window writes when it stops - through
+one helper, `WaitForOperationOutcome`. The rule it enforces is that `IsEnabled`
+answers "is this button enabled", which is a different question from "has the work
+finished". The helper that read the flag is gone from the driver, so the compiler,
+not a convention, is what keeps it out of the next readiness check.
 
-What it means is that a phase could time out waiting for a control that was ready
-the whole time, and report a defect in EC that is not there - the same shape of
-wrong answer the preflight check exists to prevent.
+**EC is unchanged.** Enabling a button before the work behind it is complete is a
+reasonable thing for a window to do, and nothing a user sees depends on the order.
+The defect was in the instrument's idea of "finished". The one production file
+this touches, `MainForm`, was read and not edited.
 
-**This was briefly closed on the strength of [EC-27](#ec-27), and should not have
-been.** That fix stopped one phase reading a status the window had not written
-yet, by waiting for the text rather than the button. It removed a consequence of
-trusting the flag in one place; it did not remove the dependency, and the four
-checks above are unchanged. Twenty-five clean runs say nothing about a flag that
-was seen misreporting once.
+**What the controls showed.** One found a defect by failing. Another could not
+be run at all.
 
-Closing it means readiness checks that confirm the operation rather than consult
-the flag. Nothing has been changed for that yet.
+The first control - forcing the flag to stay false and proving the suite still
+completes - could not be run as asked, because there is no longer anything to
+force: removing the helper left no caller for a stale flag to reach. That is a
+stronger guarantee than the control would have given, and it is also why the
+control is absent rather than passed.
+
+The second let the conversion finish before the phase reached its cancel step, to
+exercise the path a fast machine would take. Instrumented, the ordinary run
+rewrites 48 of 400 files and leaves 352 untouched; under the control it rewrites
+all 400 and leaves none, so the mutation demonstrably changed what happened. Phase
+I passed three times either way.
+
+The third clicked Cancel on a run that had already stopped, and **failed three
+times out of three** - which is the finding. The first attempt at this fix caught
+`ElementNotEnabledException`, on the assumption that a finished run leaves a
+disabled button. It does not: `MainForm` sets `btnCancel.Visible = false` when a
+run ends, so the button leaves the automation tree altogether and the ordinary
+lookup waited the full thirty seconds and threw `TimeoutException: Control
+'btnCancel' was not found`. A run that finished between the check and the click
+would have failed the phase - the same flake the guard was written to prevent.
+Cancelling is now a bounded attempt that treats an absent button as the answer it
+is, and the control passes.
+
+**A regression was introduced and fixed inside this change, and is recorded
+because the numbers below would otherwise look better than the work was.** The
+first version of the fix replaced the flag with a whole-window text scan, polled
+every 50 ms. In phase I that walks four hundred result rows while they are still
+being added; elements vanished mid-enumeration and the read threw. Fifteen full
+runs gave one pass and fourteen phase I failures. Reading only the status bar's
+own subtree, and treating a lost race as "no evidence yet" rather than as a
+failure, is what fixed it.
+
+**Runs afterwards.** Fifteen consecutive full runs on the status-bar read, twelve
+more on the final shape with the bounded cancel, and five on the exact file
+committed here, which differs from those twelve by two comments. As with
+[EC-27](#ec-27), clean runs corroborate rather than prove; what closes this is
+that the dependency is gone from the driver, and that the controls which could
+have caught a mistake did.
 
 ### EC-27
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=65 fixed=54 open=7 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
+<!-- backlog-counts total=66 fixed=54 open=8 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
 
-**Derived count: 65 findings — 54 fixed, 7 open, 1 not reproduced, 1 withdrawn,
+**Derived count: 66 findings — 54 fixed, 8 open, 1 not reproduced, 1 withdrawn,
 1 intentional behavior, and 1 design decision.** Recompute and check these
 figures with:
 
@@ -52,6 +52,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 |---|---|---|---|---|---|
 | EC-17 | A comment describes the text check backwards | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | A file can change while EC is detecting its encoding | Open | Low | Rare | [EC-20](#ec-20) |
+| EC-26 | The smoke driver trusts an enabled flag that has been seen stale | Open | Low | Rare | [EC-26](#ec-26) |
 | CX-06 | EC checks for random-looking data before checking for a BOM | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a conversion can produce an error on exit | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | ASCII with many NUL bytes can be reported as UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
@@ -70,7 +71,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-08 | A constructed include pattern could hang a scan indefinitely | Fixed | — | — | [EC-08](#ec-08) |
 | EC-24 | The GUI smoke gate could select in the wrong combo | Fixed | — | — | [EC-24](#ec-24) |
 | EC-25 | The smoke suite never set the main window's target encoding | Fixed | — | — | [EC-25](#ec-25) |
-| EC-26 | The smoke driver read a status line the window had not written yet | Fixed | — | — | [EC-26](#ec-26) |
+| EC-27 | The smoke driver read a status line the window had not written yet | Fixed | — | — | [EC-27](#ec-27) |
 | EC-18 | EC repeated a BOM-less UTF-16 safety check unnecessarily | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application assumed a required path existed instead of checking it | Fixed | — | — | [EC-23](#ec-23) |
 | BL-27 | GUI smoke reports could show an empty or misleading build hash | Fixed | — | — | [BL-27](#bl-27) |
@@ -901,6 +902,31 @@ suite retires the evidence gathered for the previous one.
 
 ### EC-26
 
+**The driver treats an enabled flag as a readiness signal, and it has been seen
+stale.** `Current.IsEnabled` reported a control disabled for five seconds while
+that same control accepted `Invoke` and closed the review.
+
+Four readiness checks still rest on it: that a scan has finished, that writing has
+begun, whether cancellation is still possible, and that the main window has
+returned to idle. None of them confirms the thing it is waiting for; each asks the
+flag instead.
+
+What it means is that a phase could time out waiting for a control that was ready
+the whole time, and report a defect in EC that is not there - the same shape of
+wrong answer the preflight check exists to prevent.
+
+**This was briefly closed on the strength of [EC-27](#ec-27), and should not have
+been.** That fix stopped one phase reading a status the window had not written
+yet, by waiting for the text rather than the button. It removed a consequence of
+trusting the flag in one place; it did not remove the dependency, and the four
+checks above are unchanged. Twenty-five clean runs say nothing about a flag that
+was seen misreporting once.
+
+Closing it means readiness checks that confirm the operation rather than consult
+the flag. Nothing has been changed for that yet.
+
+### EC-27
+
 **Before:** the driver treated an enabled button as "the run has finished". The
 window enables its buttons before it assigns the final status text, so a phase
 that read the status the moment the buttons came back could read the previous
@@ -933,11 +959,8 @@ text being read, with the runs agreeing.
 assigns `actionStatus.Text` forty-five lines later. A driver polling every 50 ms
 lands between the two often enough to matter.
 
-The original observation has the same root and is kept: `Current.IsEnabled` was
-seen reporting a control disabled for five seconds while that control accepted
-`Invoke`. Whether the flag is stale or merely early, it answers a question the
-driver was not asking. A readiness check that confirms the thing being waited for
-does not have that problem, and that is now the rule this driver follows.
+This is one consequence of [EC-26](#ec-26) removed, not EC-26 itself. The driver
+still consults the flag in four other readiness checks.
 
 ## Decisions and mistakes that must remain visible
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=65 fixed=53 open=8 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
+<!-- backlog-counts total=65 fixed=54 open=7 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
 
-**Derived count: 65 findings — 53 fixed, 8 open, 1 not reproduced, 1 withdrawn,
+**Derived count: 65 findings — 54 fixed, 7 open, 1 not reproduced, 1 withdrawn,
 1 intentional behavior, and 1 design decision.** Recompute and check these
 figures with:
 
@@ -52,7 +52,6 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 |---|---|---|---|---|---|
 | EC-17 | A comment describes the text check backwards | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | A file can change while EC is detecting its encoding | Open | Low | Rare | [EC-20](#ec-20) |
-| EC-25 | The smoke suite never sets the main window's target encoding | Open | Low | Rare | [EC-25](#ec-25) |
 | CX-06 | EC checks for random-looking data before checking for a BOM | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a conversion can produce an error on exit | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | ASCII with many NUL bytes can be reported as UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
@@ -70,6 +69,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | BL-01 | Ambiguous BOM-less UTF-32 could be converted under the wrong byte order | Fixed | — | — | [BL-01](#bl-01) |
 | EC-08 | A constructed include pattern could hang a scan indefinitely | Fixed | — | — | [EC-08](#ec-08) |
 | EC-24 | The GUI smoke gate could select in the wrong combo | Fixed | — | — | [EC-24](#ec-24) |
+| EC-25 | The smoke suite never set the main window's target encoding | Fixed | — | — | [EC-25](#ec-25) |
 | EC-26 | The smoke driver read a status line the window had not written yet | Fixed | — | — | [EC-26](#ec-26) |
 | EC-18 | EC repeated a BOM-less UTF-16 safety check unnecessarily | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application assumed a required path existed instead of checking it | Fixed | — | — | [EC-23](#ec-23) |
@@ -870,19 +870,34 @@ ledger cannot give them a status: [EC-25](#ec-25) and [EC-26](#ec-26).
 
 ### EC-25
 
-**The smoke suite never exercises setting the main window's target encoding.**
-`ConfigureScan` asks for `utf-8` on `lstConvert` before scanning, while that
-control is still disabled. It succeeds only because `utf-8` is already selected,
-so `SelectCombo` returns before setting anything.
+**Before:** `ConfigureScan` asked for `utf-8` on `lstConvert` before scanning,
+while that control is still disabled. It succeeded only because `utf-8` was
+already selected, so the call returned before setting anything. The selection path
+[EC-24](#ec-24) replaced was therefore never driven on that combo, and a changed
+application default would have failed every phase during setup rather than in the
+phase that cares.
 
-Nothing is wrong with EC here; the gap is in the suite. Two consequences follow.
-The path [EC-24](#ec-24) replaced is never driven on that combo, so a defect in it
-would not be caught. And if the application's default target ever changed, every
-phase would fail during setup rather than in the phase that cares.
+**Now:** the suite states the assumption and exercises the path. `ConfigureScan`
+requires the window to open on `utf-8` and fails with one message naming that if
+it does not. Phase A sets the target to `us-ascii` and back after cancelling its
+review, where the run is over and the phase already proves no bytes moved.
 
-Closing it means asserting the default before the scan and exercising a
-non-default target after scanning enables the control. Neither was written,
-because doing so changes the suite that had just been stabilised.
+`us-ascii` rather than a BOM variant on purpose: `utf-8-bom` and `utf-16BE` share
+a prefix with other entries, so a setter that matched on prefix would have made
+the check pass while selecting something else.
+
+**EC is unchanged.** The gap was in the suite. It is worth noting what the
+assertion protects, though: `MainForm` selects `utf-8` only when
+`FindStringExact` finds it and falls back to the first entry otherwise, so the
+default every phase depends on is conditional in the product rather than
+guaranteed.
+
+**Both halves are load-bearing**, checked by mutation with the build required to
+succeed and the compiled binary's hash required to change first. Expecting a
+different default fails in 750 ms with `GuiDriverException`; making the setter a
+no-op is caught by the round trip. Fifteen consecutive full runs passed after the
+change - fewer than the twenty-five behind [EC-26](#ec-26), because altering the
+suite retires the evidence gathered for the previous one.
 
 ### EC-26
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -946,8 +946,27 @@ run ends, so the button leaves the automation tree altogether and the ordinary
 lookup waited the full thirty seconds and threw `TimeoutException: Control
 'btnCancel' was not found`. A run that finished between the check and the click
 would have failed the phase - the same flake the guard was written to prevent.
-Cancelling is now a bounded attempt that treats an absent button as the answer it
-is, and the control passes.
+
+**The replacement was wrong too, and review caught it rather than a control.** It
+treated a button it could not find as proof that the run had finished, and stopped
+looking after two seconds. A missing button has two meanings - the run beat the
+phase to it, or automation failed to see a button that is on screen - and only the
+window's own final status separates them. A driver that could never resolve the
+button would have reported phase I as passing while cancelling nothing: blinded to
+`btnCancel` permanently, that version passes twice out of two, converts all four
+hundred files, and still calls the result an interrupted run.
+
+Cancelling now races a real button against a confirmed final status, and reports
+when neither arrives. Blinded to both, it fails twice out of two with *"The run
+offered neither a Cancel button nor a final status"*. A button that disappears
+between being found and being clicked has to be confirmed by a final status before
+that disappearance is accepted, and a run already over when the cancel step is
+reached is accepted through that same confirmation, which two more runs show.
+
+What the controls could not settle is whether the two-second budget had ever been
+the limiting factor on this machine. Blinding the driver for three seconds ends
+identically on both versions, because the conversion finishes inside that window.
+That part of the correction rests on the reasoning, not on a measured difference.
 
 **A regression was introduced and fixed inside this change, and is recorded
 because the numbers below would otherwise look better than the work was.** The
@@ -958,9 +977,9 @@ runs gave one pass and fourteen phase I failures. Reading only the status bar's
 own subtree, and treating a lost race as "no evidence yet" rather than as a
 failure, is what fixed it.
 
-**Runs afterwards.** Fifteen consecutive full runs on the status-bar read, twelve
-more on the final shape with the bounded cancel, and five on the exact file
-committed here, which differs from those twelve by two comments. As with
+**Runs afterwards.** Fifteen consecutive full runs on the status-bar read,
+seventeen across the shape that preceded the raced cancel, and ten on the file
+committed here. As with
 [EC-27](#ec-27), clean runs corroborate rather than prove; what closes this is
 that the dependency is gone from the driver, and that the controls which could
 have caught a mistake did.

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -989,13 +989,20 @@ failure, is what fixed it.
 
 **Runs afterwards.** Earlier revisions completed fifteen consecutive full runs on
 the status-bar read, seventeen on the shape before cancellation was made strict,
-and ten on the raced-cancel shape. The final stricter phase passed five focused
-runs, converting 24-32 of the four hundred files and leaving the rest untouched
-each time, and then ten consecutive complete runs. That margin - roughly a twelfth
-of the workload converted before cancellation lands - is what keeps the new
-strictness from turning a fast machine into a failing gate, and it is worth
-re-checking on hardware quicker than this one. As with [EC-27](#ec-27), clean runs
-corroborate rather
+and ten on the raced-cancel shape. Those all ran against four hundred files; the
+phase now uses a thousand, where eight focused runs convert 72-93 before
+cancellation lands and three complete suite runs pass at about twenty seconds
+each.
+
+Raising the count buys less than it appears to. The trigger polls by counting
+converted files, so a larger directory costs more per probe and the click lands
+proportionally later - about a twelfth of the workload converted either way. What
+does improve is the absolute room left over: nine hundred unconverted files rather
+than three hundred and seventy, which is what a machine converting far faster
+would have to burn through while UI automation's round trip stays much the same.
+If one ever does, the phase fails and says so, and the answer is to raise the
+count again rather than to accept a completed run. As with [EC-27](#ec-27), clean
+runs corroborate rather
 than prove; what closes this is that the enabled-state dependency and the
 completion-as-cancellation false pass are both unreachable in the final code.
 

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -20,7 +20,7 @@ internal sealed class EcGuiDriver : IDisposable
         {
             UseShellExecute = false,
             WorkingDirectory = Path.GetDirectoryName(executable)!,
-        }) ?? throw new InvalidOperationException("EncodingChecker did not start.");
+        }) ?? throw new GuiDriverException("EncodingChecker did not start.");
 
         try
         {
@@ -353,7 +353,7 @@ internal sealed class EcGuiDriver : IDisposable
         if (edit is null ||
             !edit.TryGetCurrentPattern(ValuePattern.Pattern, out rawValue))
         {
-            throw new InvalidOperationException(
+            throw new GuiDriverException(
                 $"'{automationId}' does not support text input.");
         }
 
@@ -378,13 +378,13 @@ internal sealed class EcGuiDriver : IDisposable
             return;
 
         if (!combo.TryGetCurrentPattern(ValuePattern.Pattern, out object? rawValue))
-            throw new InvalidOperationException($"'{automationId}' cannot be set by value.");
+            throw new GuiDriverException($"'{automationId}' cannot be set by value.");
 
         var setter = (ValuePattern)rawValue;
 
         if (setter.Current.IsReadOnly)
         {
-            throw new InvalidOperationException(
+            throw new GuiDriverException(
                 $"'{automationId}' is read-only, so '{value}' cannot be set.");
         }
 
@@ -420,7 +420,7 @@ internal sealed class EcGuiDriver : IDisposable
         AutomationElement element = RequireById(root, automationId);
 
         if (!element.TryGetCurrentPattern(TogglePattern.Pattern, out object? rawToggle))
-            throw new InvalidOperationException($"'{automationId}' cannot be toggled.");
+            throw new GuiDriverException($"'{automationId}' cannot be toggled.");
 
         var toggle = (TogglePattern)rawToggle;
         bool current = toggle.Current.ToggleState == ToggleState.On;
@@ -443,7 +443,7 @@ internal sealed class EcGuiDriver : IDisposable
     private static void Invoke(AutomationElement element)
     {
         if (!element.TryGetCurrentPattern(InvokePattern.Pattern, out object? rawInvoke))
-            throw new InvalidOperationException($"'{element.Current.Name}' cannot be invoked.");
+            throw new GuiDriverException($"'{element.Current.Name}' cannot be invoked.");
 
         ((InvokePattern)rawInvoke).Invoke();
     }
@@ -649,6 +649,9 @@ internal sealed class EcGuiDriver : IDisposable
             {
                 lastError = ex;
             }
+            // GuiDriverException is deliberately absent from these: a control that
+            // cannot be toggled or set will not start working on the next attempt, and
+            // retrying it would turn a precise message into a generic timeout.
             catch (InvalidOperationException ex)
             {
                 lastError = ex;
@@ -688,6 +691,20 @@ internal sealed class EcGuiDriver : IDisposable
                 $"{message} Last retried automation error: "
                 + $"{lastError.GetType().Name}: {lastError.Message}",
                 lastError);
+
+    /// <summary>
+    /// A failure in the driver's contract with the window - a control that cannot be
+    /// toggled, set or invoked - rather than the transient automation errors WaitFor
+    /// retries. It deliberately does not derive from InvalidOperationException, which
+    /// that retry loop catches, so a deliberate failure surfaces at once with its own
+    /// message instead of expiring as an unrelated timeout.
+    /// </summary>
+    private sealed class GuiDriverException : Exception
+    {
+        internal GuiDriverException(string message) : base(message)
+        {
+        }
+    }
 
     private static void ClickAt(int x, int y)
     {

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -95,8 +95,8 @@ internal sealed class EcGuiDriver : IDisposable
     private void Scan(int expectedFiles)
     {
         Invoke(MainWindow, "btnView");
-        WaitUntil(
-            () => ResultCount() == expectedFiles && IsEnabled(MainWindow, "btnView"),
+        WaitForOperationOutcome(
+            () => ResultCount() == expectedFiles && ScanHasFinished(),
             $"View did not finish with {expectedFiles} result row(s).");
     }
 
@@ -210,10 +210,10 @@ internal sealed class EcGuiDriver : IDisposable
 
     /// <summary>Every piece of text the main window is showing, joined.</summary>
     /// <remarks>
-    /// The status line is a ToolStripStatusLabel, which is not a window and carries no
-    /// automation id, so it cannot be found the way ordinary controls are. Reading the
-    /// window's rendered text finds it without depending on how the toolstrip chooses
-    /// to expose its items.
+    /// This is for failure messages, where the whole window is what you want: an
+    /// unexpected dialog or an empty result list explains a timeout that the status line
+    /// alone would not. Waiting is a different job - see <see cref="StatusLine"/>, which
+    /// reads only the status bar and does not throw.
     /// </remarks>
     internal string StatusText() =>
         string.Join(
@@ -241,16 +241,51 @@ internal sealed class EcGuiDriver : IDisposable
         // Timed against real progress rather than a sleep, so the phase does not depend
         // on how fast the machine converts. Cancelling before the first write would
         // exercise the declined-review path instead, which phase A already covers.
-        WaitUntil(
-            () => writingHasBegun() || IsEnabled(MainWindow, "btnView"),
+        WaitForOperationOutcome(
+            () => writingHasBegun() || ConversionHasFinished(),
             "The conversion did not begin writing.");
 
         // A run short enough to finish first is not a failure; the phase then checks a
         // completed run instead, and its assertions still hold.
-        if (!IsEnabled(MainWindow, "btnView"))
-            Invoke(MainWindow, "btnCancel");
+        TryCancel();
 
         WaitForMainReady();
+    }
+
+    /// <summary>Clicks Cancel if there is still a Cancel to click.</summary>
+    /// <remarks>
+    /// The window hides the button when a run ends - <c>MainForm</c> sets
+    /// <c>btnCancel.Visible</c> - so by the time a finished run is noticed the control is
+    /// not disabled but absent, and the ordinary lookup would wait the full timeout for
+    /// something deliberately gone. Not finding it therefore means the run already
+    /// stopped, which is the outcome the caller wanted anyway.
+    ///
+    /// The short budget is for the live case, where the button is on screen throughout
+    /// the run and the first probe finds it. Nothing is reported when the wait comes back
+    /// empty: an absent button is an answer, not a failure.
+    /// </remarks>
+    private void TryCancel()
+    {
+        AutomationElement? cancel = WaitFor(
+            () => FindById(MainWindow, "btnCancel"),
+            TimeSpan.FromSeconds(2),
+            out Exception? _);
+
+        if (cancel is null)
+            return;
+
+        try
+        {
+            Invoke(cancel);
+        }
+        catch (ElementNotEnabledException)
+        {
+            // It stopped between finding the button and clicking it.
+        }
+        catch (ElementNotAvailableException)
+        {
+            // The button was hidden between the two.
+        }
     }
 
     /// <summary>Waits until the status line contains <paramref name="fragment"/>.</summary>
@@ -263,7 +298,7 @@ internal sealed class EcGuiDriver : IDisposable
     internal void WaitForStatus(string fragment)
     {
         if (WaitFor(
-                () => StatusText().Contains(fragment, StringComparison.Ordinal)
+                () => StatusLine()?.Contains(fragment, StringComparison.Ordinal) == true
                     ? new object()
                     : null,
                 Timeout,
@@ -283,9 +318,94 @@ internal sealed class EcGuiDriver : IDisposable
     }
 
     private void WaitForMainReady() =>
-        WaitUntil(
-            () => IsEnabled(MainWindow, "btnView") && FindReviewWindow() is null,
+        WaitForOperationOutcome(
+            () => FindReviewWindow() is null && ConversionHasFinished(),
             "EncodingChecker did not return to its idle state.");
+
+    /// <summary>
+    /// Waits for something the operation itself produced, rather than for a button.
+    /// </summary>
+    /// <remarks>
+    /// Whether a control is enabled is a different question from whether the work has
+    /// finished. The window re-enables its buttons before it writes the result, and its
+    /// enabled flag has been seen reporting a control disabled for five seconds while
+    /// that same control accepted a click. Rows in the list, bytes on disk and the
+    /// summary the window writes when it stops are evidence of the operation; a
+    /// control's state is not.
+    /// </remarks>
+    private void WaitForOperationOutcome(Func<bool> evidence, string what)
+    {
+        if (WaitFor(() => evidence() ? new object() : null, Timeout, out Exception? lastError)
+            is not null)
+        {
+            return;
+        }
+
+        throw Expired(
+            what + Safely(() => " The status showed: " + StatusText(),
+                          " The status could not be read"),
+            lastError);
+    }
+
+    /// <summary>The window writes "N files processed" when a scan ends.</summary>
+    private bool ScanHasFinished() =>
+        StatusLine() is string status &&
+        (status.Contains("files processed", StringComparison.Ordinal) ||
+         status.Contains("do not have the correct encoding", StringComparison.Ordinal));
+
+    /// <summary>
+    /// The status bar's text, or null when it cannot be read just now.
+    /// </summary>
+    /// <remarks>
+    /// Only the status bar's own subtree is read. Scanning the whole window means walking
+    /// every result row - four hundred of them in the interrupted-run phase, while they
+    /// are still being added - which is both slow to repeat every 50 ms and prone to
+    /// enumerating an element that disappears mid-walk.
+    ///
+    /// A read that loses that race returns null rather than throwing: not being able to
+    /// see the status is not evidence that an operation finished, so a caller waits on.
+    /// </remarks>
+    private string? StatusLine()
+    {
+        try
+        {
+            AutomationElement? bar = FindById(MainWindow, "statusBar");
+
+            if (bar is null)
+                return null;
+
+            return string.Join(
+                "\n",
+                bar.FindAll(TreeScope.Descendants, Condition.TrueCondition)
+                    .Cast<AutomationElement>()
+                    .Select(element => element.Current.Name)
+                    .Where(name => !string.IsNullOrWhiteSpace(name)));
+        }
+        catch (Exception ex) when (
+            ex is ElementNotAvailableException or InvalidOperationException or COMException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Every way a conversion or preview can end writes one of these, including the paths
+    /// where nothing was modified. Matching the headline rather than the counts keeps this
+    /// independent of what the run actually did.
+    /// </summary>
+    private bool ConversionHasFinished()
+    {
+        if (StatusLine() is not string status)
+            return false;
+
+        return status.Contains("Conversion complete", StringComparison.Ordinal) ||
+               status.Contains("Conversion stopped", StringComparison.Ordinal) ||
+               status.Contains("Conversion cancelled", StringComparison.Ordinal) ||
+               status.Contains("Conversion did not run", StringComparison.Ordinal) ||
+               status.Contains("Conversion failed", StringComparison.Ordinal) ||
+               status.Contains("Preview complete", StringComparison.Ordinal) ||
+               status.Contains("Preview cancelled", StringComparison.Ordinal);
+    }
 
     private AutomationElement WaitForReview(int previousHandle = 0)
     {
@@ -500,9 +620,6 @@ internal sealed class EcGuiDriver : IDisposable
             $"'{automationId}' did not reach the requested state.");
     }
 
-    private bool IsEnabled(AutomationElement root, string automationId) =>
-        FindById(root, automationId)?.Current.IsEnabled == true;
-
     private void Invoke(AutomationElement root, string automationId) =>
         Invoke(RequireById(root, automationId));
 
@@ -692,7 +809,10 @@ internal sealed class EcGuiDriver : IDisposable
     /// <param name="lastError">
     /// The last error retried before giving up. A probe that threw every time is the
     /// likeliest reason a wait expired, and it is what a bare timeout cannot report.
-    /// There is deliberately no overload without it: both wait paths must report the cause.
+    /// There is deliberately no overload without it, so a wait that reports a timeout
+    /// cannot leave the cause out by accident. Only a caller with nothing to report
+    /// discards it - see <see cref="TryCancel"/>, where an empty result is the answer
+    /// rather than a failure.
     /// </param>
     private static T? WaitFor<T>(Func<T?> probe, TimeSpan timeout, out Exception? lastError)
         where T : class

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -390,7 +390,7 @@ internal sealed class EcGuiDriver : IDisposable
     /// </summary>
     /// <remarks>
     /// Only the status bar's own subtree is read. Scanning the whole window means walking
-    /// every result row - four hundred of them in the interrupted-run phase, while they
+    /// every result row - a thousand of them in the interrupted-run phase, while they
     /// are still being added - which is both slow to repeat every 50 ms and prone to
     /// enumerating an element that disappears mid-walk.
     ///

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -61,8 +61,36 @@ internal sealed class EcGuiDriver : IDisposable
         SetToggle(MainWindow, "chkIncludeSubdirectories", false);
         SetToggle(MainWindow, "chkCreateBackup", true);
         SetToggle(MainWindow, "chkPreviewChanges", false);
-        SelectCombo(MainWindow, "lstConvert", "utf-8");
+        RequireDefaultTarget();
     }
+
+    /// <summary>Fails unless the window opens on utf-8, which every phase assumes.</summary>
+    /// <remarks>
+    /// The target list is disabled until a scan has run, so this cannot set it - and
+    /// asking for the value it already holds would quietly do nothing. MainForm selects
+    /// utf-8 only when it finds it, falling back to the first entry otherwise, so the
+    /// assumption is worth stating: one clear failure here beats every phase failing in
+    /// setup for a reason none of them mentions.
+    /// </remarks>
+    private void RequireDefaultTarget()
+    {
+        string target = TargetEncoding();
+
+        if (!target.Equals("utf-8", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new GuiDriverException(
+                $"The target encoding opens on '{target}', not 'utf-8'. Every phase "
+                + "converts to utf-8 and none of them sets it.");
+        }
+    }
+
+    /// <summary>The target encoding the main window currently shows.</summary>
+    internal string TargetEncoding() =>
+        SelectedName(RequireById(MainWindow, "lstConvert"));
+
+    /// <summary>Sets the target encoding, once a scan has enabled the list.</summary>
+    internal void SetTargetEncoding(string value) =>
+        SelectCombo(MainWindow, "lstConvert", value);
 
     private void Scan(int expectedFiles)
     {

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -241,11 +241,13 @@ internal sealed class EcGuiDriver : IDisposable
                     ? candidate
                     : null;
             },
-            Timeout);
+            Timeout,
+            out Exception? lastError);
 
-        return review ?? throw new TimeoutException(
+        return review ?? throw Expired(
             "The conversion review did not appear. EC exposed these windows: "
-            + DescribeTopLevelWindows());
+            + DescribeTopLevelWindows(),
+            lastError);
     }
 
     private AutomationElement? FindReviewWindow() =>
@@ -596,15 +598,14 @@ internal sealed class EcGuiDriver : IDisposable
     private static AutomationElement WaitForElement(
         Func<AutomationElement?> probe,
         string timeoutMessage) =>
-        WaitFor(probe, Timeout) ?? throw new TimeoutException(timeoutMessage);
-
-    private static T? WaitFor<T>(Func<T?> probe, TimeSpan timeout)
-        where T : class =>
-        WaitFor(probe, timeout, out _);
+        WaitFor(probe, Timeout, out Exception? lastError)
+        ?? throw Expired(timeoutMessage, lastError);
 
     /// <param name="lastError">
     /// The last error retried before giving up. A probe that threw every time is the
     /// likeliest reason a wait expired, and it is what a bare timeout cannot report.
+    /// There is deliberately no overload without it: three waits in this class were
+    /// written against one and each discarded the cause.
     /// </param>
     private static T? WaitFor<T>(Func<T?> probe, TimeSpan timeout, out Exception? lastError)
         where T : class
@@ -652,14 +653,20 @@ internal sealed class EcGuiDriver : IDisposable
             return;
         }
 
-        if (lastError is null)
-            throw new TimeoutException(timeoutMessage);
-
-        throw new TimeoutException(
-            $"{timeoutMessage} Last retried automation error: "
-            + $"{lastError.GetType().Name}: {lastError.Message}",
-            lastError);
+        throw Expired(timeoutMessage, lastError);
     }
+
+    /// <summary>
+    /// A timeout that names the error it kept retrying. A probe that threw every time is
+    /// the likeliest reason a wait expired, and every wait in this class reports it.
+    /// </summary>
+    private static TimeoutException Expired(string message, Exception? lastError) =>
+        lastError is null
+            ? new TimeoutException(message)
+            : new TimeoutException(
+                $"{message} Last retried automation error: "
+                + $"{lastError.GetType().Name}: {lastError.Message}",
+                lastError);
 
     private static void ClickAt(int x, int y)
     {

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -241,36 +241,66 @@ internal sealed class EcGuiDriver : IDisposable
         // Timed against real progress rather than a sleep, so the phase does not depend
         // on how fast the machine converts. Cancelling before the first write would
         // exercise the declined-review path instead, which phase A already covers.
-        WaitForOperationOutcome(
-            () => writingHasBegun() || ConversionHasFinished(),
-            "The conversion did not begin writing.");
+        bool nothingLeftToCancel = WaitForWritingOrCompletion(writingHasBegun);
 
         // A run short enough to finish first is not a failure; the phase then checks a
         // completed run instead, and its assertions still hold.
-        TryCancel();
+        if (!nothingLeftToCancel)
+            Cancel();
 
         WaitForMainReady();
     }
 
-    /// <summary>Clicks Cancel if there is still a Cancel to click.</summary>
+    /// <summary>
+    /// Waits for the conversion to start writing, or to report that it is already over.
+    /// </summary>
+    /// <returns>
+    /// True only when the run reported itself finished with no write observed - the one
+    /// case where there is nothing left to cancel. A run that wrote and then finished
+    /// returns false, so the cancel step still has to establish which happened.
+    /// </returns>
+    private bool WaitForWritingOrCompletion(Func<bool> writingHasBegun)
+    {
+        bool finished = false;
+
+        WaitForOperationOutcome(
+            () =>
+            {
+                if (writingHasBegun())
+                    return true;
+
+                finished = ConversionHasFinished();
+                return finished;
+            },
+            "The conversion did not begin writing.");
+
+        return finished;
+    }
+
+    /// <summary>Cancels the run, or establishes that it finished before it could be.</summary>
     /// <remarks>
     /// The window hides the button when a run ends - <c>MainForm</c> sets
-    /// <c>btnCancel.Visible</c> - so by the time a finished run is noticed the control is
-    /// not disabled but absent, and the ordinary lookup would wait the full timeout for
-    /// something deliberately gone. Not finding it therefore means the run already
-    /// stopped, which is the outcome the caller wanted anyway.
+    /// <c>btnCancel.Visible</c> - so an absent button has two meanings: the run beat the
+    /// phase to it, or automation failed to see a button that is on screen. Only the
+    /// window's own final status separates them, and accepting absence on its own would
+    /// let the phase pass without ever exercising cancellation.
     ///
-    /// The short budget is for the live case, where the button is on screen throughout
-    /// the run and the first probe finds it. Nothing is reported when the wait comes back
-    /// empty: an absent button is an answer, not a failure.
+    /// Both acceptable outcomes are therefore raced, and neither arriving is a failure
+    /// that carries whatever the probe kept throwing.
     /// </remarks>
-    private void TryCancel()
+    private void Cancel()
     {
-        AutomationElement? cancel = WaitFor(
-            () => FindById(MainWindow, "btnCancel"),
-            TimeSpan.FromSeconds(2),
-            out Exception? _);
+        AutomationElement? cancel = null;
 
+        WaitUntil(
+            () =>
+            {
+                cancel = FindById(MainWindow, "btnCancel");
+                return cancel is not null || ConversionHasFinished();
+            },
+            "The run offered neither a Cancel button nor a final status.");
+
+        // Conversion won the race, and said so.
         if (cancel is null)
             return;
 
@@ -278,13 +308,14 @@ internal sealed class EcGuiDriver : IDisposable
         {
             Invoke(cancel);
         }
-        catch (ElementNotEnabledException)
+        catch (Exception ex) when (
+            ex is ElementNotEnabledException or ElementNotAvailableException)
         {
-            // It stopped between finding the button and clicking it.
-        }
-        catch (ElementNotAvailableException)
-        {
-            // The button was hidden between the two.
+            // The button went between finding it and clicking it. That is only acceptable
+            // if the run stopped on its own, which the window has to say for itself.
+            WaitForOperationOutcome(
+                () => ConversionHasFinished(),
+                "Cancel became unavailable without the run reporting that it had stopped.");
         }
     }
 
@@ -811,8 +842,7 @@ internal sealed class EcGuiDriver : IDisposable
     /// likeliest reason a wait expired, and it is what a bare timeout cannot report.
     /// There is deliberately no overload without it, so a wait that reports a timeout
     /// cannot leave the cause out by accident. Only a caller with nothing to report
-    /// discards it - see <see cref="TryCancel"/>, where an empty result is the answer
-    /// rather than a failure.
+    /// discards it, and no wait in this driver currently does.
     /// </param>
     private static T? WaitFor<T>(Func<T?> probe, TimeSpan timeout, out Exception? lastError)
         where T : class

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -247,14 +247,29 @@ internal sealed class EcGuiDriver : IDisposable
         if (review is not null)
             return review;
 
-        string message = "The conversion review did not appear.";
+        throw Expired(
+            "The conversion review did not appear." + DescribeWindowsSafely(),
+            lastError);
+    }
 
-        // A repeated automation error is already the strongest available diagnostic.
-        // Do not make another automation query that could hide it while building the message.
-        if (lastError is null)
-            message += " EC exposed these windows: " + DescribeTopLevelWindows();
-
-        throw Expired(message, lastError);
+    /// <summary>
+    /// The window list explains an unexpected modal dialog; the retried error explains why
+    /// normal discovery failed. Both are wanted, so listing the windows must never throw:
+    /// it is itself an automation call, and the failure it would replace is the more
+    /// important one. A listing that fails says why, alongside that error rather than
+    /// instead of it.
+    /// </summary>
+    private string DescribeWindowsSafely()
+    {
+        try
+        {
+            return " EC exposed these windows: " + DescribeTopLevelWindows();
+        }
+        catch (Exception ex)
+        {
+            return " The windows could not be listed either: "
+                   + $"{ex.GetType().Name}: {ex.Message}";
+        }
     }
 
     private AutomationElement? FindReviewWindow() =>

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -273,9 +273,12 @@ internal sealed class EcGuiDriver : IDisposable
         }
 
         // Read once more here rather than in the message passed in, so the failure shows
-        // what was on screen when the wait gave up.
+        // what was on screen when the wait gave up - and safely, because reading it is
+        // another automation call and must not replace the timeout it is describing.
         throw Expired(
-            $"The status line never showed '{fragment}'. It showed: {StatusText()}",
+            $"The status line never showed '{fragment}'."
+            + Safely(() => " It showed: " + StatusText(),
+                     " The status could not be read either"),
             lastError);
     }
 
@@ -313,16 +316,25 @@ internal sealed class EcGuiDriver : IDisposable
     /// important one. A listing that fails says why, alongside that error rather than
     /// instead of it.
     /// </summary>
-    private string DescribeWindowsSafely()
+    private string DescribeWindowsSafely() =>
+        Safely(() => " EC exposed these windows: " + DescribeTopLevelWindows(),
+               " The windows could not be listed either");
+
+    /// <summary>
+    /// Builds a piece of a failure message that is itself an automation call, and never
+    /// throws. When automation is what failed, the call gathering detail about it is
+    /// likely to fail too, and the detail must never replace the failure it describes.
+    /// A part that cannot be gathered says so instead.
+    /// </summary>
+    private static string Safely(Func<string> describe, string whenItFails)
     {
         try
         {
-            return " EC exposed these windows: " + DescribeTopLevelWindows();
+            return describe();
         }
         catch (Exception ex)
         {
-            return " The windows could not be listed either: "
-                   + $"{ex.GetType().Name}: {ex.Message}";
+            return $"{whenItFails}: {ex.GetType().Name}: {ex.Message}";
         }
     }
 

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -244,10 +244,17 @@ internal sealed class EcGuiDriver : IDisposable
             Timeout,
             out Exception? lastError);
 
-        return review ?? throw Expired(
-            "The conversion review did not appear. EC exposed these windows: "
-            + DescribeTopLevelWindows(),
-            lastError);
+        if (review is not null)
+            return review;
+
+        string message = "The conversion review did not appear.";
+
+        // A repeated automation error is already the strongest available diagnostic.
+        // Do not make another automation query that could hide it while building the message.
+        if (lastError is null)
+            message += " EC exposed these windows: " + DescribeTopLevelWindows();
+
+        throw Expired(message, lastError);
     }
 
     private AutomationElement? FindReviewWindow() =>
@@ -604,8 +611,7 @@ internal sealed class EcGuiDriver : IDisposable
     /// <param name="lastError">
     /// The last error retried before giving up. A probe that threw every time is the
     /// likeliest reason a wait expired, and it is what a bare timeout cannot report.
-    /// There is deliberately no overload without it: three waits in this class were
-    /// written against one and each discarded the cause.
+    /// There is deliberately no overload without it: both wait paths must report the cause.
     /// </param>
     private static T? WaitFor<T>(Func<T?> probe, TimeSpan timeout, out Exception? lastError)
         where T : class

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -241,54 +241,30 @@ internal sealed class EcGuiDriver : IDisposable
         // Timed against real progress rather than a sleep, so the phase does not depend
         // on how fast the machine converts. Cancelling before the first write would
         // exercise the declined-review path instead, which phase A already covers.
-        bool nothingLeftToCancel = WaitForWritingOrCompletion(writingHasBegun);
+        WaitForOperationOutcome(
+            () => writingHasBegun() || ConversionHasFinished(),
+            "The conversion neither began writing nor reported that it had finished.");
 
-        // A run short enough to finish first is not a failure; the phase then checks a
-        // completed run instead, and its assertions still hold.
-        if (!nothingLeftToCancel)
-            Cancel();
+        RequestCancel();
 
-        WaitForMainReady();
+        WaitForStoppedConversion();
     }
 
     /// <summary>
-    /// Waits for the conversion to start writing, or to report that it is already over.
+    /// Requests cancellation, or fails if the run finishes before it can be cancelled.
     /// </summary>
-    /// <returns>
-    /// True only when the run reported itself finished with no write observed - the one
-    /// case where there is nothing left to cancel. A run that wrote and then finished
-    /// returns false, so the cancel step still has to establish which happened.
-    /// </returns>
-    private bool WaitForWritingOrCompletion(Func<bool> writingHasBegun)
-    {
-        bool finished = false;
-
-        WaitForOperationOutcome(
-            () =>
-            {
-                if (writingHasBegun())
-                    return true;
-
-                finished = ConversionHasFinished();
-                return finished;
-            },
-            "The conversion did not begin writing.");
-
-        return finished;
-    }
-
-    /// <summary>Cancels the run, or establishes that it finished before it could be.</summary>
     /// <remarks>
     /// The window hides the button when a run ends - <c>MainForm</c> sets
     /// <c>btnCancel.Visible</c> - so an absent button has two meanings: the run beat the
     /// phase to it, or automation failed to see a button that is on screen. Only the
-    /// window's own final status separates them, and accepting absence on its own would
-    /// let the phase pass without ever exercising cancellation.
+    /// window's own final status separates them. Either meaning prevents this phase from
+    /// proving cancellation, so neither is accepted as a successful test.
     ///
-    /// Both acceptable outcomes are therefore raced, and neither arriving is a failure
-    /// that carries whatever the probe kept throwing.
+    /// The button and final status are raced so a fast completion produces a clear failure
+    /// instead of a misleading timeout. If neither appears, the wait retains the last
+    /// automation error.
     /// </remarks>
-    private void Cancel()
+    private void RequestCancel()
     {
         AutomationElement? cancel = null;
 
@@ -300,9 +276,11 @@ internal sealed class EcGuiDriver : IDisposable
             },
             "The run offered neither a Cancel button nor a final status.");
 
-        // Conversion won the race, and said so.
         if (cancel is null)
-            return;
+        {
+            throw new GuiDriverException(
+                "The conversion finished before cancellation could be exercised.");
+        }
 
         try
         {
@@ -311,11 +289,34 @@ internal sealed class EcGuiDriver : IDisposable
         catch (Exception ex) when (
             ex is ElementNotEnabledException or ElementNotAvailableException)
         {
-            // The button went between finding it and clicking it. That is only acceptable
-            // if the run stopped on its own, which the window has to say for itself.
+            // Confirm why the button vanished, but do not count ordinary completion as a
+            // cancellation test.
             WaitForOperationOutcome(
                 () => ConversionHasFinished(),
                 "Cancel became unavailable without the run reporting that it had stopped.");
+
+            throw new GuiDriverException(
+                "The conversion finished before cancellation could be exercised.");
+        }
+    }
+
+    /// <summary>Requires the cancellation request to produce an interrupted run.</summary>
+    private void WaitForStoppedConversion()
+    {
+        string? finalStatus = null;
+
+        WaitForOperationOutcome(
+            () =>
+            {
+                finalStatus = StatusLine();
+                return finalStatus is not null && IsFinalConversionStatus(finalStatus);
+            },
+            "The conversion did not report a final result after cancellation.");
+
+        if (!finalStatus!.Contains("Conversion stopped", StringComparison.Ordinal))
+        {
+            throw new GuiDriverException(
+                "Cancellation was not exercised. EC instead reported: " + finalStatus);
         }
     }
 
@@ -429,14 +430,17 @@ internal sealed class EcGuiDriver : IDisposable
         if (StatusLine() is not string status)
             return false;
 
-        return status.Contains("Conversion complete", StringComparison.Ordinal) ||
-               status.Contains("Conversion stopped", StringComparison.Ordinal) ||
-               status.Contains("Conversion cancelled", StringComparison.Ordinal) ||
-               status.Contains("Conversion did not run", StringComparison.Ordinal) ||
-               status.Contains("Conversion failed", StringComparison.Ordinal) ||
-               status.Contains("Preview complete", StringComparison.Ordinal) ||
-               status.Contains("Preview cancelled", StringComparison.Ordinal);
+        return IsFinalConversionStatus(status);
     }
+
+    private static bool IsFinalConversionStatus(string status) =>
+        status.Contains("Conversion complete", StringComparison.Ordinal) ||
+        status.Contains("Conversion stopped", StringComparison.Ordinal) ||
+        status.Contains("Conversion cancelled", StringComparison.Ordinal) ||
+        status.Contains("Conversion did not run", StringComparison.Ordinal) ||
+        status.Contains("Conversion failed", StringComparison.Ordinal) ||
+        status.Contains("Preview complete", StringComparison.Ordinal) ||
+        status.Contains("Preview cancelled", StringComparison.Ordinal);
 
     private AutomationElement WaitForReview(int previousHandle = 0)
     {

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -225,6 +225,32 @@ internal sealed class EcGuiDriver : IDisposable
         WaitForMainReady();
     }
 
+    /// <summary>Waits until the status line contains <paramref name="fragment"/>.</summary>
+    /// <remarks>
+    /// The window enables its buttons before it assigns the final status, so a run that
+    /// has returned to idle may still be showing the previous message. A phase that reads
+    /// the status the moment the buttons come back can therefore read the old one. Waiting
+    /// for the text itself closes that window; a sleep would only make it less likely.
+    /// </remarks>
+    internal void WaitForStatus(string fragment)
+    {
+        if (WaitFor(
+                () => StatusText().Contains(fragment, StringComparison.Ordinal)
+                    ? new object()
+                    : null,
+                Timeout,
+                out Exception? lastError) is not null)
+        {
+            return;
+        }
+
+        // Read once more here rather than in the message passed in, so the failure shows
+        // what was on screen when the wait gave up.
+        throw Expired(
+            $"The status line never showed '{fragment}'. It showed: {StatusText()}",
+            lastError);
+    }
+
     private void WaitForMainReady() =>
         WaitUntil(
             () => IsEnabled(MainWindow, "btnView") && FindReviewWindow() is null,

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -173,6 +173,18 @@ internal sealed class SmokeSuite
             "The mixed review did not offer a source-encoding choice.");
         gui.CancelReview(review);
 
+        // The suite converts to utf-8 everywhere and never sets the target, so nothing
+        // otherwise drives that control. Exercise it here, where the run is over and this
+        // phase is about to prove no bytes moved: a target that could not be changed would
+        // pass every other phase unnoticed.
+        gui.SetTargetEncoding("us-ascii");
+        Check(gui.TargetEncoding() == "us-ascii",
+            $"The target encoding did not change: {gui.TargetEncoding()}");
+
+        gui.SetTargetEncoding("utf-8");
+        Check(gui.TargetEncoding() == "utf-8",
+            $"The target encoding did not change back: {gui.TargetEncoding()}");
+
         AssertSameFiles(before, Snapshot(directory));
         AssertNoArtifacts(directory);
     }

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -410,7 +410,10 @@ internal sealed class SmokeSuite
     private void PhaseI(PhaseContext phase)
     {
         string directory = phase.Directory;
-        const int count = 400;
+        // Large enough that a fast machine cannot finish converting before the cancel
+        // click lands. If one ever does, the phase says so rather than passing, and the
+        // answer is to raise this again rather than to accept a completed run.
+        const int count = 1000;
         string body = string.Concat(Enumerable.Repeat("Ligne accentuee: cafe resume. ", 200));
 
         for (int i = 1; i <= count; i++)

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -409,9 +409,19 @@ internal sealed class SmokeSuite
 
         gui.ProceedThenCancel(review, () => RewrittenCount(directory) >= 5);
 
-        string status = gui.StatusText();
         int rewritten = RewrittenCount(directory);
         int untouched = count - rewritten;
+
+        // The run is over - the files are written and the buttons are back - but the
+        // window assigns its final status after re-enabling them, so the status read here
+        // could still be the previous one. Wait for the figures this phase is about to
+        // assert, then read once.
+        gui.WaitForStatus($"{rewritten} converted");
+
+        if (untouched > 0)
+            gui.WaitForStatus($"{untouched} not attempted");
+
+        string status = gui.StatusText();
 
         Check(
             status.Contains($"{rewritten} converted", StringComparison.Ordinal),

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -427,6 +427,17 @@ internal sealed class SmokeSuite
         int rewritten = RewrittenCount(directory);
         int untouched = count - rewritten;
 
+        // Printed on every run, before the checks, so a failing run shows the figures
+        // that failed it. This is the margin between cancellation landing and the run
+        // finishing unaided, and the report cannot carry it: this phase records no
+        // before-snapshot, because a thousand hashes would swamp the evidence file for
+        // a phase that compares counts rather than bytes. Reading it from a CI log is
+        // the only way to see a faster machine approaching the point where there is
+        // nothing left to interrupt.
+        Console.WriteLine(
+            $"[INFO] I: cancelled after {rewritten} of {count} file(s) were converted; "
+            + $"{untouched} left untouched");
+
         Check(rewritten > 0,
             "Cancellation was requested before any file was converted.");
         Check(untouched > 0,

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -419,10 +419,15 @@ internal sealed class SmokeSuite
         using var gui = new EcGuiDriver(_app);
         System.Windows.Automation.AutomationElement review = gui.OpenReview(directory, count);
 
-        gui.ProceedThenCancel(review, () => RewrittenCount(directory) >= 5);
+        gui.ProceedThenCancel(review, () => RewrittenCount(directory) >= 1);
 
         int rewritten = RewrittenCount(directory);
         int untouched = count - rewritten;
+
+        Check(rewritten > 0,
+            "Cancellation was requested before any file was converted.");
+        Check(untouched > 0,
+            "All files were converted, so this phase did not exercise an interrupted run.");
 
         // The run is over - the files are written and the buttons are back - but the
         // window assigns its final status after re-enabling them, so the status read here
@@ -430,8 +435,7 @@ internal sealed class SmokeSuite
         // assert, then read once.
         gui.WaitForStatus($"{rewritten} converted");
 
-        if (untouched > 0)
-            gui.WaitForStatus($"{untouched} not attempted");
+        gui.WaitForStatus($"{untouched} not attempted");
 
         string status = gui.StatusText();
 
@@ -439,17 +443,13 @@ internal sealed class SmokeSuite
             status.Contains($"{rewritten} converted", StringComparison.Ordinal),
             $"The status line disagrees with the {rewritten} file(s) actually rewritten: {status}");
 
-        // Present whenever the run stopped early, and the count that used to vanish.
-        if (untouched > 0)
-        {
-            Check(
-                status.Contains("stopped", StringComparison.OrdinalIgnoreCase),
-                $"An interrupted run was not reported as stopped: {status}");
+        Check(
+            status.Contains("Conversion stopped", StringComparison.Ordinal),
+            $"An interrupted run was not reported as stopped: {status}");
 
-            Check(
-                status.Contains($"{untouched} not attempted", StringComparison.Ordinal),
-                $"The {untouched} unreached file(s) are missing from the status: {status}");
-        }
+        Check(
+            status.Contains($"{untouched} not attempted", StringComparison.Ordinal),
+            $"The {untouched} unreached file(s) are missing from the status: {status}");
     }
 
     /// <summary>

--- a/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
+++ b/sources/EncodingChecker.Tests/PathAwarePatternTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Text.RegularExpressions;
 
 namespace EncodingChecker.Tests;
 
@@ -112,20 +111,5 @@ public sealed class PathAwarePatternTests : IDisposable
 
         Assert.DoesNotContain("Properties/AssemblyInfo.cs", found);
         Assert.Contains("Properties/AssemblyInfoHelper.cs", found);
-    }
-
-    [Fact]
-    public void WildcardPatternsUseTheNonBacktrackingEngine()
-    {
-        string hostileMask = string.Concat(Enumerable.Repeat("*a", 12)) + "b";
-
-        Regex pattern = Assert.Single(
-            DirectoryTraversal.CompilePatterns([hostileMask], defaultToMatchAll: false));
-
-        // Asserted before the match below, so restoring the old engine fails here
-        // instead of hanging the test run.
-        Assert.True(pattern.Options.HasFlag(RegexOptions.NonBacktracking));
-
-        Assert.DoesNotMatch(pattern, new string('a', 40));
     }
 }

--- a/sources/EncodingChecker.Tests/PatternSafetyTests.cs
+++ b/sources/EncodingChecker.Tests/PatternSafetyTests.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+
+namespace EncodingChecker.Tests;
+
+/// <summary>
+/// A constructed include mask must not be able to stall a scan. Nothing here touches the
+/// disk, and the class deliberately carries no fixture, so the assertion can only fail for
+/// the reason it exists rather than because a temporary directory misbehaved.
+/// </summary>
+public sealed class PatternSafetyTests
+{
+    [Fact]
+    public void WildcardPatternsUseTheNonBacktrackingEngine()
+    {
+        string hostileMask = string.Concat(Enumerable.Repeat("*a", 12)) + "b";
+
+        Regex pattern = Assert.Single(
+            DirectoryTraversal.CompilePatterns([hostileMask], defaultToMatchAll: false));
+
+        // Asserted before the match below, so restoring the old engine fails here
+        // instead of hanging the test run.
+        Assert.True(pattern.Options.HasFlag(RegexOptions.NonBacktracking));
+
+        Assert.DoesNotMatch(pattern, new string('a', 40));
+    }
+}


### PR DESCRIPTION
The GUI smoke suite is a required check, so a wrong answer from it is as costly as
a wrong answer from EC. This branch fixes the instrument, not the product: **no
production code changes.** `MainForm` was read and not edited.

## What was wrong

**Readiness was inferred from button state (EC-26).** Four waits asked whether a
control was enabled and treated the answer as "the work has finished". That flag
had been seen reporting a control disabled for five seconds while the same control
accepted a click, so a phase could time out on a window that was ready the whole
time and report a defect in EC that was not there. `IsEnabled` is now gone from the
driver, so the compiler rather than a convention keeps it out of the next
readiness check.

**Phase I could pass without ever cancelling anything.** Once cancellation stopped
depending on the enabled flag, a Cancel button the driver could not find was taken
as proof the run had finished. Blinded only to `btnCancel` - with the final status
still readable, which is the shape of the original defect - the phase waited for
every file to convert and passed, calling a completed run an interrupted one.
Cancelling now races a real button against a confirmed final status, and phase I
requires an interrupted run: at least one file converted, at least one untouched,
a final status of `Conversion stopped`, and counts matching the bytes on disk.

Also here: a scan-hang fix's test moved to its own fixture-free class, deliberate
driver failures given their own exception type, diagnostics that could replace the
error they were describing, the target encoding the suite only ever assumed, and a
`gui-smoke` job bounded at ten minutes.

## Evidence

| Control | Result |
|---|---|
| Hide only `btnCancel`, status readable | **Fails 2/2** - the defect shape, closed |
| Hide both button and status | **Fails 2/2**, retaining the last automation error |
| Run already over at the cancel step | Fails, saying cancellation was not exercised |
| Focused phase I x8 | 8/8, always partial: 72-93 of 1000 converted |
| Full suite x3 at the final workload | 3/3, ~21s per run |
| Unit tests | 756 passed |

Every mutation required the build to succeed and the compiled binary's hash to
change before anything ran, and the source restored byte-for-byte afterwards.

## Recorded honestly

Two mistakes were made and fixed inside this branch, and the ledger says so rather
than showing only the final numbers:

- A first attempt replaced the enabled flag with a whole-window text scan polled
  every 50 ms. It walked the result rows while they were still being added and
  gave **one pass in fifteen runs**. Reading only the status bar's subtree fixed it.
- The replacement for that introduced the false pass above. **Review caught it, not
  a control.**

One limitation is stated rather than smoothed over: raising phase I from 400 to
1000 files buys less than the count suggests, because the trigger polls by counting
converted files and the click lands proportionally later. About a twelfth of the
workload converts either way; what improves is the absolute room left. If a faster
runner still finishes first, phase I fails and says so, and the count goes up again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
