### PR TITLE
Make phase I's cancellation reliable, and cheap enough not to fight itself

### DIFF
--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -272,11 +272,13 @@ internal sealed class EcGuiDriver : IDisposable
     ///
     /// The two ways a click can fail mean different things. A refusal - the control
     /// reporting itself not-enabled - happens before anything is delivered, so trying
-    /// again is safe and right. An element that disappears mid-call, or a COM failure,
-    /// is what a click that *did* land looks like when the window hides the button in
-    /// response; it may equally have failed before delivering. Clicking again there
-    /// would be a fresh action rather than a retry, so the attempt stops and the status
-    /// is left to say what happened.
+    /// again is safe and right, and it is left to the shared retry loop, which repeats it
+    /// and keeps it as the cause a timeout would name.
+    ///
+    /// Any other automation failure might have followed a click that did land: an element
+    /// disappearing mid-call is what a successful cancel looks like when the window hides
+    /// the button in response. Clicking again there would be a fresh action rather than a
+    /// retry, so the attempt stops and the status is left to say what happened.
     /// </remarks>
     private void RequestCancel()
     {
@@ -299,13 +301,18 @@ internal sealed class EcGuiDriver : IDisposable
                             Invoke(cancel);
                             clickMayHaveLanded = true;
                         }
-                        catch (ElementNotEnabledException)
-                        {
-                            // Refused outright, so nothing was delivered. Try again.
-                            return false;
-                        }
+                        // A refusal is the one failure that certainly delivered nothing,
+                        // and it is deliberately not caught: the shared loop retries it
+                        // and keeps it, so a wait that expires on repeated refusals can
+                        // name them. Answering "not ready" here would clear that cause.
+                        //
+                        // Every other automation failure might have followed a click that
+                        // landed, so the attempt stops and the status is left to say.
                         catch (Exception ex) when (
-                            ex is ElementNotAvailableException or COMException)
+                            ex is not ElementNotEnabledException &&
+                            ex is ElementNotAvailableException
+                                or COMException
+                                or InvalidOperationException)
                         {
                             clickMayHaveLanded = true;
                         }

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -263,38 +263,45 @@ internal sealed class EcGuiDriver : IDisposable
     /// The button and final status are raced so a fast completion produces a clear failure
     /// instead of a misleading timeout. If neither appears, the wait retains the last
     /// automation error.
+    ///
+    /// A refused click is retried rather than believed. A control reporting itself
+    /// not-enabled is the same flag this driver stopped trusting for readiness, and one
+    /// refusal says nothing about whether the run is over; only the window's own final
+    /// status does. So each attempt reacquires the button, and the wait ends on a click
+    /// that was accepted, a run that reported itself finished, or the timeout.
     /// </remarks>
     private void RequestCancel()
     {
-        AutomationElement? cancel = null;
+        bool cancelled = false;
 
         WaitUntil(
             () =>
             {
-                cancel = FindById(MainWindow, "btnCancel");
-                return cancel is not null || ConversionHasFinished();
+                AutomationElement? cancel = FindById(MainWindow, "btnCancel");
+
+                // Gone means the window hid it, which it does only when a run ends - but
+                // that has to come from the status, not from the button's absence.
+                if (cancel is null)
+                    return ConversionHasFinished();
+
+                try
+                {
+                    Invoke(cancel);
+                    cancelled = true;
+                    return true;
+                }
+                catch (Exception ex) when (
+                    ex is ElementNotEnabledException or ElementNotAvailableException)
+                {
+                    // Refused this time. The next attempt looks the button up again; if
+                    // the run really has ended, the branch above sees the status say so.
+                    return false;
+                }
             },
-            "The run offered neither a Cancel button nor a final status.");
+            "Cancel was never accepted, and the run never reported that it had stopped.");
 
-        if (cancel is null)
+        if (!cancelled)
         {
-            throw new GuiDriverException(
-                "The conversion finished before cancellation could be exercised.");
-        }
-
-        try
-        {
-            Invoke(cancel);
-        }
-        catch (Exception ex) when (
-            ex is ElementNotEnabledException or ElementNotAvailableException)
-        {
-            // Confirm why the button vanished, but do not count ordinary completion as a
-            // cancellation test.
-            WaitForOperationOutcome(
-                () => ConversionHasFinished(),
-                "Cancel became unavailable without the run reporting that it had stopped.");
-
             throw new GuiDriverException(
                 "The conversion finished before cancellation could be exercised.");
         }

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -261,8 +261,7 @@ internal sealed class EcGuiDriver : IDisposable
     /// proving cancellation, so neither is accepted as a successful test.
     ///
     /// The button and final status are raced so a fast completion produces a clear failure
-    /// instead of a misleading timeout. If neither appears, the wait retains the last
-    /// automation error.
+    /// instead of a misleading timeout.
     ///
     /// A refused click is retried rather than believed. A control reporting itself
     /// not-enabled is the same flag this driver stopped trusting for readiness, and one
@@ -270,10 +269,10 @@ internal sealed class EcGuiDriver : IDisposable
     /// status does. So each attempt reacquires the button, and the wait ends on a click
     /// that was accepted, a run that reported itself finished, or the timeout.
     ///
-    /// The refusal is left to that shared loop rather than caught here. It already
-    /// retries these errors and keeps the last one, so a wait that does expire can name
-    /// the refusal it kept hitting; catching it here would retry just as often and
-    /// report nothing.
+    /// The refusal is left to that shared loop rather than caught here. The loop retries
+    /// it and can report it if refusals continue until the timeout. Catching it here
+    /// would turn every refusal into a clean "not ready" answer, which is what makes the
+    /// loop drop the cause.
     /// </remarks>
     private void RequestCancel()
     {
@@ -847,8 +846,10 @@ internal sealed class EcGuiDriver : IDisposable
         ?? throw Expired(timeoutMessage, lastError);
 
     /// <param name="lastError">
-    /// The last error retried before giving up. A probe that threw every time is the
-    /// likeliest reason a wait expired, and it is what a bare timeout cannot report.
+    /// The last error retried, when the probe was still failing at the end. A poll that
+    /// answers cleanly clears it, so this reports the cause of a wait that kept throwing
+    /// rather than one that simply never became true - which is the case a bare timeout
+    /// cannot explain by itself.
     /// There is deliberately no overload without it, so a wait that reports a timeout
     /// cannot leave the cause out by accident. Only a caller with nothing to report
     /// discards it, and no wait in this driver currently does.

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -76,7 +76,7 @@ internal sealed class EcGuiDriver : IDisposable
     {
         string target = TargetEncoding();
 
-        if (!target.Equals("utf-8", StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(target, "utf-8", StringComparison.OrdinalIgnoreCase))
         {
             throw new GuiDriverException(
                 $"The target encoding opens on '{target}', not 'utf-8'. Every phase "
@@ -263,45 +263,58 @@ internal sealed class EcGuiDriver : IDisposable
     /// The button and final status are raced so a fast completion produces a clear failure
     /// instead of a misleading timeout.
     ///
-    /// A refused click is retried rather than believed. A control reporting itself
-    /// not-enabled is the same flag this driver stopped trusting for readiness, and one
-    /// refusal says nothing about whether the run is over; only the window's own final
-    /// status does. So each attempt reacquires the button, and the wait ends on a click
-    /// that was accepted, a run that reported itself finished, or the timeout.
+    /// Whether cancellation happened is not decided here. Delivering a click is not
+    /// proof it took effect, and failing to deliver one is not proof it did not: the
+    /// window's own final status is the only thing that separates a run that was stopped
+    /// from one that finished on its own, and <see cref="WaitForStoppedConversion"/>
+    /// reads it. This method's job is to ask, and to wait until the run has reported
+    /// something.
     ///
-    /// The refusal is left to that shared loop rather than caught here. The loop retries
-    /// it and can report it if refusals continue until the timeout. Catching it here
-    /// would turn every refusal into a clean "not ready" answer, which is what makes the
-    /// loop drop the cause.
+    /// The two ways a click can fail mean different things. A refusal - the control
+    /// reporting itself not-enabled - happens before anything is delivered, so trying
+    /// again is safe and right. An element that disappears mid-call, or a COM failure,
+    /// is what a click that *did* land looks like when the window hides the button in
+    /// response; it may equally have failed before delivering. Clicking again there
+    /// would be a fresh action rather than a retry, so the attempt stops and the status
+    /// is left to say what happened.
     /// </remarks>
     private void RequestCancel()
     {
-        bool cancelled = false;
+        bool clickMayHaveLanded = false;
 
         WaitUntil(
             () =>
             {
-                AutomationElement? cancel = FindById(MainWindow, "btnCancel");
+                // Once a click may be in flight, stop pressing the button and just watch.
+                if (!clickMayHaveLanded)
+                {
+                    AutomationElement? cancel = FindById(MainWindow, "btnCancel");
 
-                // Gone means the window hid it, which it does only when a run ends - but
-                // that has to come from the status, not from the button's absence.
-                if (cancel is null)
-                    return ConversionHasFinished();
+                    // Gone means the window hid it, which it does only when a run ends -
+                    // but that has to come from the status, not the button's absence.
+                    if (cancel is not null)
+                    {
+                        try
+                        {
+                            Invoke(cancel);
+                            clickMayHaveLanded = true;
+                        }
+                        catch (ElementNotEnabledException)
+                        {
+                            // Refused outright, so nothing was delivered. Try again.
+                            return false;
+                        }
+                        catch (Exception ex) when (
+                            ex is ElementNotAvailableException or COMException)
+                        {
+                            clickMayHaveLanded = true;
+                        }
+                    }
+                }
 
-                // A refusal throws out of here into the retry loop, which reacquires the
-                // button on the next attempt. If the run really has ended by then, the
-                // branch above sees the status say so.
-                Invoke(cancel);
-                cancelled = true;
-                return true;
+                return ConversionHasFinished();
             },
-            "Cancel was never accepted, and the run never reported that it had stopped.");
-
-        if (!cancelled)
-        {
-            throw new GuiDriverException(
-                "The conversion finished before cancellation could be exercised.");
-        }
+            "The run never reported a final status after cancellation was requested.");
     }
 
     /// <summary>Requires the cancellation request to produce an interrupted run.</summary>
@@ -599,7 +612,7 @@ internal sealed class EcGuiDriver : IDisposable
     {
         AutomationElement combo = RequireById(root, automationId);
 
-        if (SelectedName(combo).Equals(value, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(SelectedName(combo), value, StringComparison.OrdinalIgnoreCase))
             return;
 
         if (!combo.TryGetCurrentPattern(ValuePattern.Pattern, out object? rawValue))
@@ -616,7 +629,7 @@ internal sealed class EcGuiDriver : IDisposable
         setter.SetValue(value);
 
         WaitUntil(
-            () => SelectedName(combo).Equals(value, StringComparison.OrdinalIgnoreCase),
+            () => string.Equals(SelectedName(combo), value, StringComparison.OrdinalIgnoreCase),
             $"'{value}' was not selected in '{automationId}'.");
     }
 
@@ -628,11 +641,14 @@ internal sealed class EcGuiDriver : IDisposable
                 ((SelectionPattern)rawSelection).Current.GetSelection();
 
             if (selected.Length > 0)
-                return selected[0].Current.Name;
+                return selected[0].Current.Name ?? string.Empty;
         }
 
+        // A provider may hand back null for either of these. Absorbing it here means
+        // callers can compare the result without guarding, and an unreadable selection
+        // fails their assertion rather than their null check.
         if (combo.TryGetCurrentPattern(ValuePattern.Pattern, out object? rawValue))
-            return ((ValuePattern)rawValue).Current.Value;
+            return ((ValuePattern)rawValue).Current.Value ?? string.Empty;
 
         return string.Empty;
     }

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -269,6 +269,11 @@ internal sealed class EcGuiDriver : IDisposable
     /// refusal says nothing about whether the run is over; only the window's own final
     /// status does. So each attempt reacquires the button, and the wait ends on a click
     /// that was accepted, a run that reported itself finished, or the timeout.
+    ///
+    /// The refusal is left to that shared loop rather than caught here. It already
+    /// retries these errors and keeps the last one, so a wait that does expire can name
+    /// the refusal it kept hitting; catching it here would retry just as often and
+    /// report nothing.
     /// </remarks>
     private void RequestCancel()
     {
@@ -284,19 +289,12 @@ internal sealed class EcGuiDriver : IDisposable
                 if (cancel is null)
                     return ConversionHasFinished();
 
-                try
-                {
-                    Invoke(cancel);
-                    cancelled = true;
-                    return true;
-                }
-                catch (Exception ex) when (
-                    ex is ElementNotEnabledException or ElementNotAvailableException)
-                {
-                    // Refused this time. The next attempt looks the button up again; if
-                    // the run really has ended, the branch above sees the status say so.
-                    return false;
-                }
+                // A refusal throws out of here into the retry loop, which reacquires the
+                // button on the next attempt. If the run really has ended by then, the
+                // branch above sees the status say so.
+                Invoke(cancel);
+                cancelled = true;
+                return true;
             },
             "Cancel was never accepted, and the run never reported that it had stopped.");
 

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -184,12 +184,12 @@ internal sealed class SmokeSuite
         // over a control label's casing.
         gui.SetTargetEncoding("us-ascii");
         string changed = gui.TargetEncoding();
-        Check(changed.Equals("us-ascii", StringComparison.OrdinalIgnoreCase),
+        Check(string.Equals(changed, "us-ascii", StringComparison.OrdinalIgnoreCase),
             $"The target encoding did not change: {changed}");
 
         gui.SetTargetEncoding("utf-8");
         string restored = gui.TargetEncoding();
-        Check(restored.Equals("utf-8", StringComparison.OrdinalIgnoreCase),
+        Check(string.Equals(restored, "utf-8", StringComparison.OrdinalIgnoreCase),
             $"The target encoding did not change back: {restored}");
 
         AssertSameFiles(before, Snapshot(directory));

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -422,7 +422,7 @@ internal sealed class SmokeSuite
         using var gui = new EcGuiDriver(_app);
         System.Windows.Automation.AutomationElement review = gui.OpenReview(directory, count);
 
-        gui.ProceedThenCancel(review, () => RewrittenCount(directory) >= 1);
+        gui.ProceedThenCancel(review, () => AnyRewritten(directory));
 
         int rewritten = RewrittenCount(directory);
         int untouched = count - rewritten;
@@ -512,6 +512,18 @@ internal sealed class SmokeSuite
     }
 
     /// <summary>Files whose byte-order mark has been stripped, so they were written.</summary>
+    /// <summary>Whether EC has rewritten anything yet.</summary>
+    /// <remarks>
+    /// Asked every 50 ms while the conversion is running, so it stops at the first
+    /// rewritten file rather than counting them all. Counting opens every file in the
+    /// directory on each probe, which delays the cancellation this triggers and eats the
+    /// margin phase I depends on - the count is wanted once, after the run has stopped.
+    /// </remarks>
+    private static bool AnyRewritten(string directory) =>
+        Directory.EnumerateFiles(directory, "file-*.txt")
+            .Any(path => !StartsWithUtf8Bom(path));
+
+    /// <summary>How many files EC rewrote. Taken after the run, never during it.</summary>
     private static int RewrittenCount(string directory) =>
         Directory.EnumerateFiles(directory, "file-*.txt")
             .Count(path => !StartsWithUtf8Bom(path));

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -177,13 +177,20 @@ internal sealed class SmokeSuite
         // otherwise drives that control. Exercise it here, where the run is over and this
         // phase is about to prove no bytes moved: a target that could not be changed would
         // pass every other phase unnoticed.
+        // Read once and report that same reading: Check takes a message that is built
+        // whether or not it fails, so asking the window again inside it would drive the
+        // control on every passing run and could describe a value the assertion never
+        // tested. Compared the way the driver compares it, so the two cannot disagree
+        // over a control label's casing.
         gui.SetTargetEncoding("us-ascii");
-        Check(gui.TargetEncoding() == "us-ascii",
-            $"The target encoding did not change: {gui.TargetEncoding()}");
+        string changed = gui.TargetEncoding();
+        Check(changed.Equals("us-ascii", StringComparison.OrdinalIgnoreCase),
+            $"The target encoding did not change: {changed}");
 
         gui.SetTargetEncoding("utf-8");
-        Check(gui.TargetEncoding() == "utf-8",
-            $"The target encoding did not change back: {gui.TargetEncoding()}");
+        string restored = gui.TargetEncoding();
+        Check(restored.Equals("utf-8", StringComparison.OrdinalIgnoreCase),
+            $"The target encoding did not change back: {restored}");
 
         AssertSameFiles(before, Snapshot(directory));
         AssertNoArtifacts(directory);

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -511,7 +511,6 @@ internal sealed class SmokeSuite
         AssertNoArtifacts(phase.Directory);
     }
 
-    /// <summary>Files whose byte-order mark has been stripped, so they were written.</summary>
     /// <summary>Whether EC has rewritten anything yet.</summary>
     /// <remarks>
     /// Asked every 50 ms while the conversion is running, so it stops at the first


### PR DESCRIPTION
Follow-ups from reviewing PR #95, which made phase I fail when it cannot prove it
interrupted a run. That is the right rule, but it left the phase depending on two
things that were not reliable. **No production code changes**; `MainForm` was read
and not edited.

## What was wrong

**One refused click was read as "the run finished".** `RequestCancel` caught the
first `ElementNotEnabledException` and then waited for the run to report itself
finished - which it could not do for another ten seconds, because the run was
still going. The click is now retried, each attempt reacquiring the button, and
the wait ends on a click that was accepted, a status saying the run finished on
its own, or the timeout.

The refusal is no longer caught at the call site either. `ElementNotEnabledException`
derives from `InvalidOperationException`, which the shared retry loop already
handles, so catching it locally only turned every refusal into a clean "not ready"
answer - which is exactly what makes that loop drop the cause it would otherwise
report.

**The trigger opened a thousand files, twenty times a second.** `writingHasBegun`
asked `RewrittenCount(...) >= 1`, which counts the whole directory, while EC was
rewriting those same files. It now asks `AnyRewritten`, which stops at the first
one. The count is still taken once, after the run has stopped, where the
assertions compare it.

**Phase A read the target encoding twice per assertion.** `Check` builds its
message whether or not it fails, so the interpolated message drove the control on
every passing run, could fail a check whose condition had held, and could report a
value the assertion never tested. Both assertions now read once into a local and
compare with `OrdinalIgnoreCase`, matching what `SelectCombo` and
`RequireDefaultTarget` already use - an ordinal comparison would have let a
control reporting `UTF-8` satisfy the driver and fail the phase.

## Evidence

| Control | Result |
|---|---|
| Cancel refuses 5 clicks, then accepts | **Passes 2/2**, still interrupts (135, 189 of 1000) |
| Same refusal against the previous shape | **Fails 2/2** - and blames completion for a refused click |
| `SetTargetEncoding` reduced to a no-op | **Fails 2/2**: "The target encoding did not change: utf-8" |
| Phase A | 3/3 |
| Full suite | 3/3, then 5/5 |
| Unit tests | 756 passed |

Every mutation required a successful build and a changed binary hash before it ran,
with the source restored byte-for-byte afterwards.

The cheaper probe shows up in the phase's own line: cancellation used to land after
38-93 of the thousand files and now lands after 16-66.

## What is not shown

No control here demonstrates the improved timeout message. Staging one needs a
conversion that outlives the thirty-second wait, and this workload ends in about
ten seconds - the run finishes, the button hides, and the wait leaves through the
"finished first" branch instead of expiring. A first attempt at such a control was
invalid and is recorded as such: blinding the completion check made the predicate
answer cleanly for the rest of the wait, which cleared the retained error in both
shapes and would have shown no difference for the wrong reason. That part rests on
the compiler rejecting a redundant `catch` with CS0160, and on the five lines of
`WaitFor` that clear the error on a clean poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
