### PR TITLE
Wait for this action's report, not any run's

### DIFF
--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -160,7 +160,7 @@ internal sealed class EcGuiDriver : IDisposable
         int handle = review.Current.NativeWindowHandle;
         Invoke(review, "btnCancelConversionReview");
         WaitUntil(() => !WindowExists(handle), "The conversion review did not close.");
-        WaitForMainReady();
+        WaitForMainReady("Conversion cancelled");
     }
 
     internal void Proceed(AutomationElement review)
@@ -168,7 +168,7 @@ internal sealed class EcGuiDriver : IDisposable
         int handle = review.Current.NativeWindowHandle;
         Invoke(review, "btnProceedConversion");
         WaitUntil(() => !WindowExists(handle), "The conversion review did not close.");
-        WaitForMainReady();
+        WaitForMainReady("Conversion complete");
     }
 
     internal void ProceedExpectingWarning(AutomationElement review)
@@ -188,7 +188,7 @@ internal sealed class EcGuiDriver : IDisposable
         Invoke(ok);
 
         WaitUntil(() => !WindowExists(warningHandle), "The warning did not close.");
-        WaitForMainReady();
+        WaitForMainReady("Conversion did not run");
     }
 
     internal bool ReviewContainsControl(AutomationElement review, string automationId) =>
@@ -387,10 +387,72 @@ internal sealed class EcGuiDriver : IDisposable
             lastError);
     }
 
-    private void WaitForMainReady() =>
-        WaitForOperationOutcome(
-            () => FindReviewWindow() is null && ConversionHasFinished(),
-            "EncodingChecker did not return to its idle state.");
+    /// <summary>
+    /// Waits for the window to finish the action just performed and go idle.
+    /// </summary>
+    /// <remarks>
+    /// The caller names the headline its own action produces, rather than this accepting
+    /// any final conversion status. A status outlives the action that wrote it - the
+    /// window clears it only when the next action starts - so accepting any of them lets
+    /// a wait be satisfied by the previous action's report and return before the current
+    /// one has finished. Every phase drives one action per window today, which is the
+    /// only reason that has not bitten; it is the shape EC-26 was about, in the one
+    /// helper that fix did not reach.
+    /// </remarks>
+    private void WaitForMainReady(string expectedHeadline)
+    {
+        if (WaitFor(
+                () => FindReviewWindow() is null
+                      && StatusLine() is string status
+                      && status.Contains(expectedHeadline, StringComparison.Ordinal)
+                    ? new object()
+                    : null,
+                Timeout,
+                out Exception? lastError) is not null)
+        {
+            return;
+        }
+
+        throw Expired(
+            $"EncodingChecker did not go idle: no '{expectedHeadline}' was reported."
+            + Safely(() => " The status showed: " + StatusText(),
+                     " The status could not be read")
+            + DescribeIdleState(),
+            lastError);
+    }
+
+    /// <summary>
+    /// What could still be established about the window when a wait for idle gave up.
+    /// </summary>
+    /// <remarks>
+    /// A timeout otherwise says only that something expected did not arrive, which is the
+    /// position EC-28 left: a phase A failure whose diagnostic showed window chrome and
+    /// nothing else, with no way to tell afterwards whether the process had died, the
+    /// review was still open, the held main-window element had gone stale while the
+    /// window was healthy, or the status bar simply could not be found. These four
+    /// separate those, and each is gathered on its own so one unreadable answer does not
+    /// cost the others.
+    /// </remarks>
+    private string DescribeIdleState() =>
+        " Process alive: " + Ask(() => _process.HasExited ? "no" : "yes")
+        + "; main window handle: " + Ask(() => MainWindow.Current.NativeWindowHandle.ToString())
+        + "; review present: " + Ask(() => FindReviewWindow() is not null ? "yes" : "no")
+        + "; status bar found: "
+        + Ask(() => FindById(MainWindow, "statusBar") is not null ? "yes" : "no")
+        + "; status bar readable: " + Ask(() => StatusLine() is null ? "no" : "yes") + ".";
+
+    /// <summary>One fact for a diagnostic, or why it could not be had.</summary>
+    private static string Ask(Func<string> fact)
+    {
+        try
+        {
+            return fact();
+        }
+        catch (Exception ex)
+        {
+            return "unknown (" + ex.GetType().Name + ")";
+        }
+    }
 
     /// <summary>
     /// Waits for something the operation itself produced, rather than for a button.


### PR DESCRIPTION
First lead on [EC-28](docs/DEFECT-BACKLOG.md), the unexplained phase A timeout.
**This does not close it** - the original failure was never reproduced, so this
removes a known weakness in the failing path and makes the next occurrence
legible. It does not show that this was the cause, and the entry stays open.

**No production code changes**; `MainForm` was read and not edited.

## What was wrong

`WaitForMainReady` accepted any of the seven headlines `IsFinalConversionStatus`
matches, so it asked *has some run ended* rather than *has the one just started
ended*. A status outlives the action that wrote it - the window clears it only
when the next action starts - so the wait could be satisfied by the previous
action's report and return before the current one had finished.

Every phase drives one action per window today, which is the only reason that has
not bitten. It is [EC-26](docs/DEFECT-BACKLOG.md)'s shape in the one helper that
fix did not reach, sitting directly in the path that failed.

## Now

Each caller names the headline its own action produces. That mapping was measured
rather than assumed, by instrumenting the helper and reading a full suite run:

| Caller | Expects |
|---|---|
| `CancelReview` | `Conversion cancelled` |
| `Proceed` | `Conversion complete` |
| `ProceedExpectingWarning` | `Conversion did not run` |

The warning path reporting `Conversion did not run` rather than `Conversion
stopped` is the sort of thing reasoning alone would have got wrong.

The timeout also records what could still be established - whether the process is
alive, whether the main-window handle reads, whether the review is gone, and
whether the status bar can be found and read. EC-28's one failure showed window
chrome and nothing else and left none of those knowable afterwards. Each fact is
gathered separately so one unreadable answer does not cost the others.

## Evidence

| Control | Result |
|---|---|
| Expect a headline EC never writes | Times out against a status reading `Conversion cancelled. No files were modified.` - which the previous code accepted as idle |
| Same control's diagnostics | `Process alive: yes; main window handle: 26610754; review present: no; status bar found: yes; status bar readable: yes.` |
| Full suite | 10/10 |
| Unit tests | 756 passed |

The mutation required a successful build before running, and the source was
restored byte-for-byte afterwards.

## Not in this PR

Three findings against the cancellation state machine merged in #97 are being
handled separately, in order: reading the final status before attempting another
press, reporting `Conversion failed` as a conversion failure rather than as
"cancellation was not exercised", and renaming `pressed` so an uncertain delivery
is described as attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
