### PR TITLE
Read the status before pressing again, and report what EC actually said

### DIFF
--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -274,13 +274,21 @@ internal sealed class EcGuiDriver : IDisposable
     /// </remarks>
     private void CancelAndConfirmStopped()
     {
-        bool pressed = false;
+        bool pressAttempted = false;
         Exception? uncertainPress = null;
 
         string? finalStatus = WaitFor(
             () =>
             {
-                if (!pressed)
+                // The status is read first because a refusal throws out of the press
+                // below, which would end the attempt before the status was ever looked
+                // at. Progress would then depend on the button disappearing rather than
+                // on the run reporting, and a button that lingered after the run ended
+                // would keep being refused with the answer already on screen.
+                if (StatusLine() is string status && IsFinalConversionStatus(status))
+                    return status;
+
+                if (!pressAttempted)
                 {
                     AutomationElement? cancel = FindById(MainWindow, "btnCancel");
 
@@ -289,7 +297,7 @@ internal sealed class EcGuiDriver : IDisposable
                         try
                         {
                             Invoke(cancel);
-                            pressed = true;
+                            pressAttempted = true;
                         }
                         catch (Exception ex) when (
                             ex is not ElementNotEnabledException &&
@@ -298,14 +306,12 @@ internal sealed class EcGuiDriver : IDisposable
                                 or InvalidOperationException)
                         {
                             uncertainPress = ex;
-                            pressed = true;
+                            pressAttempted = true;
                         }
                     }
                 }
 
-                return StatusLine() is string status && IsFinalConversionStatus(status)
-                    ? status
-                    : null;
+                return null;
             },
             Timeout,
             out Exception? lastError);
@@ -315,19 +321,32 @@ internal sealed class EcGuiDriver : IDisposable
             // Only the uncertain press is added here: Expired already names whatever
             // the wait was still retrying, which is where a refusal shows up.
             throw Expired(
-                (pressed
-                    ? "Cancel was pressed but the run never reported a final status."
-                    : "No Cancel button appeared and the run never reported a final status.")
+                (pressAttempted
+                    ? "A Cancel press was attempted but the run never reported a final status."
+                    : "The driver could not find a Cancel button and the run never "
+                      + "reported a final status.")
                 + Blame(uncertainPress, null),
                 lastError);
         }
 
-        if (!finalStatus.Contains("Conversion stopped", StringComparison.Ordinal))
+        // Three outcomes, and only one of them is about cancellation. Collapsing the
+        // rest into "cancellation was not exercised" would report a conversion that
+        // failed - which EC says outright - as a problem with this phase's timing.
+        if (finalStatus.Contains("Conversion stopped", StringComparison.Ordinal))
+            return;
+
+        if (finalStatus.Contains("Conversion complete", StringComparison.Ordinal))
         {
             throw new GuiDriverException(
-                "Cancellation was not exercised. EC instead reported: " + finalStatus
+                "Cancellation was not exercised: the run finished before it could be "
+                + "stopped. EC reported: " + finalStatus
                 + Blame(uncertainPress, lastError));
         }
+
+        throw new GuiDriverException(
+            "The conversion neither stopped nor completed, so this phase proved nothing "
+            + "about cancellation. EC reported: " + finalStatus
+            + Blame(uncertainPress, lastError));
     }
 
     /// <summary>


### PR DESCRIPTION
Three findings from reviewing the cancellation state machine merged in #97, in
the order they matter. **No production code changes**; `MainForm` was read and
not edited. Rebased onto the #98 merge and revalidated as a combination.

## 1. A refused press could starve the status check

The press sat above the status read, and a refusal throws out of the press - so
on a refusing iteration the status was never examined. Progress depended on the
button disappearing rather than on the run reporting.

The status is now read first. With a button that stays visible and refuses, the
previous order runs the full thirty seconds and then claims no Cancel button
appeared, while the button was present throughout and the run had already
reported; reading first, the same conditions classify correctly.

## 2. A failed conversion was reported as a cancellation problem

Any final status other than `Conversion stopped` produced "Cancellation was not
exercised", including `Conversion failed.`, which `MainForm` writes when a
genuine error occurs mid-run. That reports a real EC defect as an instrument
timing problem, in the phase whose purpose is checking EC's reporting.

Three outcomes now get three answers: `Conversion stopped` passes, `Conversion
complete` says the run finished before it could be stopped, and anything else
says the run neither stopped nor completed and this phase proved nothing about
cancellation.

## 3. Two messages claimed more than they knew

`pressed` was set for a press whose delivery is unknown as well as one that
succeeded, and the timeout said "Cancel was pressed" - which the next clause
retracted. It is now `pressAttempted`, and says a press was attempted.

The other branch said "No Cancel button appeared"; it now says the driver could
not find one. Automation failing to see a control is not evidence about the
control.

## Evidence

| Control | Corrected | Previous |
|---|---|---|
| Button always present, always refusing | Classifies from the status | 30s timeout, then claims no button appeared |
| EC reports `Conversion failed.` | "neither stopped nor completed... proved nothing about cancellation" | "Cancellation was not exercised" |
| Press lands, no final status | "A Cancel press was attempted..." | "Cancel was pressed..." |
| Full suite, after rebase | 8/8 | |
| Unit tests | 756 passed | |

Mutations required a successful build before running, with the source restored
byte-for-byte afterwards.

[EC-28](docs/DEFECT-BACKLOG.md) remains open: none of this explains the phase A
failure that opened it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
