### PR TITLE
Refuse a run that lost sight of EC, instead of blaming EC

### DIFF
--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -1063,34 +1063,50 @@ Close` - with no status bar text and no result rows among it, so at that moment
 the driver could see the window frame but nothing inside it.
 
 **It did not reproduce.** Phase A alone passed twelve times out of twelve on the
-build that failed, and twelve out of twelve on `master`. The full suite passed
-eight times out of eight afterwards. Isolated runs may simply be the wrong shape
-to catch it: the failure appeared in a sequence where nine other phases had
-already driven the same window.
+build that failed, and twelve out of twelve on `master`; the full suite passed
+eight times out of eight afterwards. The phase-alone figures carry little weight:
+the failure appeared in a sequence where nine other phases had already driven the
+same window, so running the phase by itself is probably the wrong shape to catch
+it.
 
 **It is not attributable to the change being validated.** Phase A cancels a review
 and never enters the cancellation path that change rewrote, and the patch was
 checked to have removed only the two methods it intended to remove. `master`
-carries the same `WaitForMainReady`, so the flake most likely predates it.
+carried the same `WaitForMainReady` at the time, so the flake most likely
+predates it - that rests on the code, not on the run counts above.
 
-Where to look, in the order that would settle it fastest:
+**Two of the original leads have been acted on, and neither explained it.**
+`WaitForMainReady` accepted any final conversion status rather than evidence of
+the action just performed - [EC-26](#ec-26)'s shape in the one helper that fix
+did not reach - and each caller now names the headline its own action produces.
+The timeout also now records whether the process is alive, whether the
+main-window handle reads, whether the review is gone, and whether the status bar
+can be found and read. Both were real weaknesses in the failing path. Removing
+them makes the next occurrence legible; it does not show that either was the
+cause, and nothing since has reproduced the failure.
 
-- `WaitForMainReady` waits for *any* final conversion status rather than evidence
-  of the action just performed. That is [EC-26](#ec-26)'s shape reappearing in a
-  helper the fix did not reach, and it is recorded there as still open.
-- The timeout reports what the window showed but not whether the process is still
-  alive, whether the main-window handle is still valid, whether the review is
-  genuinely gone, or whether `statusBar` can be found at all. A failure that
-  cannot distinguish those is hard to diagnose from CI alone.
-- The driver holds the `AutomationElement` for the main window from startup. If
-  that element goes stale, every later read fails while the window is perfectly
-  healthy; reacquiring it on failure would tell the two apart.
-- Reproduction should run the whole suite rather than the phase alone.
+What is left:
 
-Until then this is one unexplained red on a required check. It is recorded rather
-than waited out because a gate that fails for reasons nobody can name is the
-problem this project keeps returning to - [EC-24](#ec-24), [EC-26](#ec-26) and
-[EC-27](#ec-27) are all the same story, and each of them looked like noise first.
+- The driver holds one `AutomationElement` for the main window from startup. If
+  that object goes stale, every later read through it fails while the window is
+  perfectly healthy - which matches a diagnostic that saw window chrome and
+  nothing inside it. This is still only a theory: nothing has tested it. The test
+  is to compare the held object against a freshly found one at the moment of
+  failure, and reacquisition is worth adding only if that comparison shows they
+  disagree.
+- Reproduction needs the whole ten-phase suite. The failure appeared in a
+  sequence where nine other phases had already driven the same window, and
+  running phase A alone has never produced it.
+
+**How this closes.** A cause reproduced and controlled closes it as fixed, with a
+control showing the old behaviour fails. Runs that merely pass do not: a defined
+stress run without recurrence is recorded as not reproduced and left under
+watch, because that is what the evidence supports.
+
+This is one unexplained red on a required check, and a required check that fails
+for reasons nobody can name is the problem this project keeps returning to -
+[EC-24](#ec-24), [EC-26](#ec-26) and [EC-27](#ec-27) are all the same story, and
+each of them looked like noise first.
 
 ## Decisions and mistakes that must remain visible
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -4,9 +4,9 @@ This is the current ledger for defects and review findings in EncodingChecker.
 It is organised by status, not discovery date, so the open work is visible in
 one place. Longer evidence and history follow the ledger.
 
-<!-- backlog-counts total=67 fixed=55 open=8 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
+<!-- backlog-counts total=67 fixed=56 open=7 not-reproduced=1 withdrawn=1 intentional-behavior=1 decision=1 -->
 
-**Derived count: 67 findings — 55 fixed, 8 open, 1 not reproduced, 1 withdrawn,
+**Derived count: 67 findings — 56 fixed, 7 open, 1 not reproduced, 1 withdrawn,
 1 intentional behavior, and 1 design decision.** Recompute and check these
 figures with:
 
@@ -52,7 +52,6 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 |---|---|---|---|---|---|
 | EC-17 | A comment describes the text check backwards | Open | Low | Common | [EC-17](#ec-17) |
 | EC-20 | A file can change while EC is detecting its encoding | Open | Low | Rare | [EC-20](#ec-20) |
-| EC-28 | Phase A once timed out waiting for the window to go idle | Open | Medium | Rare | [EC-28](#ec-28) |
 | CX-06 | EC checks for random-looking data before checking for a BOM | Open | Medium | Theoretical | [CX-06](#cx-06) |
 | BL-05 | Force-closing during a conversion can produce an error on exit | Open | Low | Rare | [BL-05](#bl-05) |
 | BL-19 | ASCII with many NUL bytes can be reported as UTF-16 | Open | Medium | Rare | [BL-19](#bl-19) |
@@ -73,6 +72,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-25 | The smoke suite never set the main window's target encoding | Fixed | — | — | [EC-25](#ec-25) |
 | EC-26 | The smoke driver trusted an enabled flag that had been seen stale | Fixed | — | — | [EC-26](#ec-26) |
 | EC-27 | The smoke driver read a status line the window had not written yet | Fixed | — | — | [EC-27](#ec-27) |
+| EC-28 | The smoke driver can lose access to EC's controls while the process and window are alive | Fixed | — | — | [EC-28](#ec-28) |
 | EC-18 | EC repeated a BOM-less UTF-16 safety check unnecessarily | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application assumed a required path existed instead of checking it | Fixed | — | — | [EC-23](#ec-23) |
 | BL-27 | GUI smoke reports could show an empty or misleading build hash | Fixed | — | — | [BL-27](#bl-27) |
@@ -1052,61 +1052,63 @@ itself.
 
 ### EC-28
 
-**Phase A failed once with `TimeoutException: EncodingChecker did not return to
-its idle state`, and the cause is not known.** It happened on 2026-09-10 in one
-full-suite run out of thirteen, while validating the cancellation state machine.
+**Before:** a wait could expire because the driver had lost access to EC's
+controls, and the suite reported that as a phase failure - which reads as EC
+failing to finish work it had in fact finished.
 
-`WaitForMainReady` waits for the review window to be gone and for the status to
-show a final conversion result. The diagnostic it printed listed only the window's
-chrome - `File Encoding Checker | System Menu Bar | System | Minimize | Maximize |
-Close` - with no status bar text and no result rows among it, so at that moment
-the driver could see the window frame but nothing inside it.
+**Now:** when a wait for the window to go idle expires, the driver first asks
+whether EC is still running and whether its window can be found from the desktop
+at all. If the process lives and the window cannot be reached, the run is refused
+rather than failed: `GuiEnvironmentException` carries a message saying nothing
+about EC was measured and naming the likely reasons, `Program` reports it with
+exit 2 alongside the other refused prerequisites, and no phase verdict is
+printed. A phase deliberately does not absorb it, because a phase result would be
+a verdict the run never earned.
 
-**It did not reproduce.** Phase A alone passed twelve times out of twelve on the
-build that failed, and twelve out of twelve on `master`; the full suite passed
-eight times out of eight afterwards. The phase-alone figures carry little weight:
-the failure appeared in a sequence where nine other phases had already driven the
-same window, so running the phase by itself is probably the wrong shape to catch
-it.
+**Reproduced on purpose, which is what closed it.** Sending EC's window to a
+non-active virtual desktop produces the fingerprint exactly. The excursion was
+verified with `IVirtualDesktopManager::IsWindowOnCurrentVirtualDesktop` rather
+than assumed - an early attempt read the state too soon after the hotkey and got
+the pre-switch answer, which would have made the whole experiment a control that
+could not fail.
 
-**It is not attributable to the change being validated.** Phase A cancels a review
-and never enters the cancellation path that change rewrote, and the patch was
-checked to have removed only the two methods it intended to remove. `master`
-carried the same `WaitForMainReady` at the time, so the flake most likely
-predates it - that rests on the code, not on the run counts above.
+Hidden for longer than the thirty-second wait, phase C failed with the status
+showing only `File Encoding Checker | System Menu Bar | System | Minimize |
+Maximize | Close` and `status bar found: no`. Hidden briefly and returned inside
+the wait, the same phase passed - so access comes back when the window does.
 
-**Two of the original leads have been acted on, and neither explained it.**
-`WaitForMainReady` accepted any final conversion status rather than evidence of
-the action just performed - [EC-26](#ec-26)'s shape in the one helper that fix
-did not reach - and each caller now names the headline its own action produces.
-The timeout also now records whether the process is alive, whether the
-main-window handle reads, whether the review is gone, and whether the status bar
-can be found and read. Both were real weaknesses in the failing path. Removing
-them makes the next occurrence legible; it does not show that either was the
-cause, and nothing since has reproduced the failure.
+**It is not a stale automation object.** The held element answered
+`NativeWindowHandle` without throwing, and looking the window up again from the
+desktop found nothing either: `window found afresh: no`. Reacquiring the element,
+which was the standing theory, would not have helped. `IsOffscreen` is no use as
+a signal either - it reads false for a window on another desktop, which is why
+the check is that the window cannot be found from the desktop while the process
+is alive.
 
-What is left:
+**EC is unchanged, and was never at fault.** The workspace preserved from the
+first spontaneous failure shows the conversion completed correctly: `french.txt`
+converted with a backup and a sidecar, `russian.txt` left in its legacy encoding
+exactly as the phase requires. The application did its work; the instrument went
+blind and blamed it.
 
-- The driver holds one `AutomationElement` for the main window from startup. If
-  that object goes stale, every later read through it fails while the window is
-  perfectly healthy - which matches a diagnostic that saw window chrome and
-  nothing inside it. This is still only a theory: nothing has tested it. The test
-  is to compare the held object against a freshly found one at the moment of
-  failure, and reacquisition is worth adding only if that comparison shows they
-  disagree.
-- Reproduction needs the whole ten-phase suite. The failure appeared in a
-  sequence where nine other phases had already driven the same window, and
-  running phase A alone has never produced it.
+**What remains unproven.** The original occurrence, one full-suite run in
+thirteen on 2026-09-10, happened with nobody switching desktops. A deliberate
+desktop excursion reproduces the fingerprint, but that does not establish it was
+the trigger that time; a locked session or a lost interactive desktop would look
+the same. The fix does not depend on knowing which: any occurrence now becomes a
+refusal rather than a false accusation, which is the harm that mattered on a
+required gate.
 
-**How this closes.** A cause reproduced and controlled closes it as fixed, with a
-control showing the old behaviour fails. Runs that merely pass do not: a defined
-stress run without recurrence is recorded as not reproduced and left under
-watch, because that is what the evidence supports.
+**Controls.** With the window hidden past the timeout, the suite exits 2, prints
+the environment message, and prints no phase verdict at all - where the previous
+build printed `[FAIL] C`. On the active desktop, six consecutive full runs passed
+with no spurious refusal, so the check does not fire when the window is simply
+slow.
 
-This is one unexplained red on a required check, and a required check that fails
-for reasons nobody can name is the problem this project keeps returning to -
-[EC-24](#ec-24), [EC-26](#ec-26) and [EC-27](#ec-27) are all the same story, and
-each of them looked like noise first.
+**Setup this settles:** the suite drives a real window and must run on the active
+desktop of an interactive Windows session. Unattended runs need a dedicated
+interactive session, not a background one.
+
 
 ## Decisions and mistakes that must remain visible
 

--- a/docs/DEFECT-BACKLOG.md
+++ b/docs/DEFECT-BACKLOG.md
@@ -72,7 +72,7 @@ the 2026-09-08 reformat to findings that previously had only a sentence.
 | EC-25 | The smoke suite never set the main window's target encoding | Fixed | — | — | [EC-25](#ec-25) |
 | EC-26 | The smoke driver trusted an enabled flag that had been seen stale | Fixed | — | — | [EC-26](#ec-26) |
 | EC-27 | The smoke driver read a status line the window had not written yet | Fixed | — | — | [EC-27](#ec-27) |
-| EC-28 | The smoke driver can lose access to EC's controls while the process and window are alive | Fixed | — | — | [EC-28](#ec-28) |
+| EC-28 | The smoke driver blamed EC when its idle wait lost access to the window | Fixed | — | — | [EC-28](#ec-28) |
 | EC-18 | EC repeated a BOM-less UTF-16 safety check unnecessarily | Fixed | — | — | [EC-18](#ec-18) |
 | EC-23 | Plan application assumed a required path existed instead of checking it | Fixed | — | — | [EC-23](#ec-23) |
 | BL-27 | GUI smoke reports could show an empty or misleading build hash | Fixed | — | — | [BL-27](#bl-27) |
@@ -1056,14 +1056,32 @@ itself.
 controls, and the suite reported that as a phase failure - which reads as EC
 failing to finish work it had in fact finished.
 
-**Now:** when a wait for the window to go idle expires, the driver first asks
+**Now:** when the wait for the window to go idle expires, the driver first asks
 whether EC is still running and whether its window can be found from the desktop
 at all. If the process lives and the window cannot be reached, the run is refused
-rather than failed: `GuiEnvironmentException` carries a message saying nothing
-about EC was measured and naming the likely reasons, `Program` reports it with
-exit 2 alongside the other refused prerequisites, and no phase verdict is
-printed. A phase deliberately does not absorb it, because a phase result would be
-a verdict the run never earned.
+rather than failed: `GuiEnvironmentException` says the phase could not be verified
+and that no verdict about EC is reported - it may already have converted files -
+and names the likely reasons. `Program` reports it with exit 2 alongside the other
+refused prerequisites, and no phase verdict is printed. A phase deliberately does
+not absorb it, because a phase result would be a verdict the run never earned.
+
+**The check began on the idle wait alone, and that was not enough.** A desktop
+excursion timed during phase C's source confirmation expired in a control lookup
+instead, so the check never ran and the phase blamed EC exactly as before. Every
+timeout in the driver is constructed in one place, so the question is asked there
+now and covers every wait.
+
+The exception is startup: before the main window has ever been found, a window
+that cannot be found means EC failed to show one, which is EC's failure and keeps
+its own message. A flag set once the window is first seen separates the two.
+
+**What this does not do.** It does not stop access being lost. The suite still
+cannot drive a window it cannot see; it just no longer reports that as EC
+failing.
+
+The lookup the check depends on is itself an automation call, and it is wrapped:
+a lookup that throws is reported inside the refusal rather than escaping to become
+the phase failure this exists to prevent.
 
 **Reproduced on purpose, which is what closed it.** Sending EC's window to a
 non-active virtual desktop produces the fingerprint exactly. The excursion was

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -426,11 +426,51 @@ internal sealed class EcGuiDriver : IDisposable
             return;
         }
 
+        RequireWindowStillReachable();
+
         throw Expired(
             $"EncodingChecker did not go idle: no '{expectedHeadline}' was reported."
             + DescribeStatusSafely()
             + DescribeIdleState(),
             lastError);
+    }
+
+    /// <summary>
+    /// Refuses the run when EC is alive but its window can no longer be reached.
+    /// </summary>
+    /// <remarks>
+    /// A wait that expires because the window went out of reach has measured nothing
+    /// about EC, and reporting it as a phase failure says the opposite. The check is
+    /// that the window cannot be found from the desktop at all while the process is
+    /// still running: a held element going stale would still leave a fresh lookup
+    /// working, and a genuinely hung EC would still leave the window findable.
+    ///
+    /// IsOffscreen is not the signal - it reads false for a window on another
+    /// virtual desktop.
+    /// </remarks>
+    private void RequireWindowStillReachable()
+    {
+        bool alive;
+
+        try
+        {
+            alive = !_process.HasExited;
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        if (!alive || FindTopLevelWindow("MainForm") is not null)
+            return;
+
+        throw new GuiEnvironmentException(
+            "EncodingChecker is still running, but its window can no longer be reached "
+            + "through UI Automation, so nothing about EC was measured. This is what "
+            + "happens when the window is moved to another virtual desktop, or the "
+            + "interactive session goes away. Run the suite on the active desktop of an "
+            + "interactive Windows session."
+            + DescribeIdleState());
     }
 
     /// <summary>
@@ -444,6 +484,12 @@ internal sealed class EcGuiDriver : IDisposable
     /// window was healthy, or the status bar simply could not be found. These four
     /// separate those, and each is gathered on its own so one unreadable answer does not
     /// cost the others.
+    ///
+    /// The window is also looked up again from the desktop, because the held element
+    /// answering while its subtree holds only chrome has two very different
+    /// explanations: the element went stale and a fresh one would work, or the window
+    /// itself is unreachable - not on the active desktop, or offscreen - in which case a
+    /// fresh lookup fails the same way and retrying anything is pointless.
     /// </remarks>
     private string DescribeIdleState() =>
         " Process alive: " + Ask(() => _process.HasExited ? "no" : "yes")
@@ -451,7 +497,21 @@ internal sealed class EcGuiDriver : IDisposable
         + "; review present: " + Ask(() => FindReviewWindow() is not null ? "yes" : "no")
         + "; status bar found: "
         + Ask(() => FindById(MainWindow, "statusBar") is not null ? "yes" : "no")
-        + "; status bar readable: " + Ask(() => StatusLine() is null ? "no" : "yes") + ".";
+        + "; status bar readable: " + Ask(() => StatusLine() is null ? "no" : "yes")
+        + "; window found afresh: " + Ask(() => FindTopLevelWindow("MainForm") is null
+            ? "no"
+            : "yes")
+        + "; handle afresh: " + Ask(() =>
+            FindTopLevelWindow("MainForm") is AutomationElement fresh
+                ? fresh.Current.NativeWindowHandle.ToString()
+                : "n/a")
+        + "; status bar via fresh window: " + Ask(() =>
+            FindTopLevelWindow("MainForm") is AutomationElement fresh
+                && FindById(fresh, "statusBar") is not null
+                    ? "yes"
+                    : "no")
+        + "; window offscreen: " + Ask(() => MainWindow.Current.IsOffscreen ? "yes" : "no")
+        + ".";
 
     /// <summary>One fact for a diagnostic, or why it could not be had.</summary>
     private static string Ask(Func<string> fact)

--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -12,6 +12,13 @@ internal sealed class EcGuiDriver : IDisposable
 
     private readonly Process _process;
 
+    /// <summary>
+    /// Whether the main window has ever been found. Before it has, a window that
+    /// cannot be found is EC failing to show one - which is EC's problem, and must
+    /// keep its own failure. Afterwards, the same answer means the window went away.
+    /// </summary>
+    private readonly bool _windowWasFound;
+
     internal AutomationElement MainWindow { get; }
 
     internal EcGuiDriver(string executable)
@@ -34,6 +41,8 @@ internal sealed class EcGuiDriver : IDisposable
         MainWindow = WaitForElement(
             () => FindTopLevelWindow("MainForm"),
             "EncodingChecker's main window did not appear.");
+
+        _windowWasFound = true;
     }
 
     internal AutomationElement OpenReview(string directory, int expectedFiles)
@@ -426,8 +435,6 @@ internal sealed class EcGuiDriver : IDisposable
             return;
         }
 
-        RequireWindowStillReachable();
-
         throw Expired(
             $"EncodingChecker did not go idle: no '{expectedHeadline}' was reported."
             + DescribeStatusSafely()
@@ -450,6 +457,9 @@ internal sealed class EcGuiDriver : IDisposable
     /// </remarks>
     private void RequireWindowStillReachable()
     {
+        if (!_windowWasFound)
+            return;
+
         bool alive;
 
         try
@@ -461,15 +471,38 @@ internal sealed class EcGuiDriver : IDisposable
             return;
         }
 
-        if (!alive || FindTopLevelWindow("MainForm") is not null)
+        // EC having exited is EC's business, and the ordinary timeout reports it.
+        if (!alive)
+            return;
+
+        string lookupFailure = string.Empty;
+        bool found;
+
+        try
+        {
+            found = FindTopLevelWindow("MainForm") is not null;
+        }
+        catch (Exception ex)
+        {
+            // The lookup is itself an automation call. Letting it throw would turn the
+            // very condition this exists to report back into a phase failure, and a
+            // lookup that cannot run is no basis for a verdict about EC either.
+            found = false;
+            lookupFailure =
+                $" Looking the window up again also failed: {ex.GetType().Name}: {ex.Message}.";
+        }
+
+        if (found)
             return;
 
         throw new GuiEnvironmentException(
             "EncodingChecker is still running, but its window can no longer be reached "
-            + "through UI Automation, so nothing about EC was measured. This is what "
+            + "through UI Automation, so this phase could not be verified and no verdict "
+            + "about EC is reported - it may already have converted files. This is what "
             + "happens when the window is moved to another virtual desktop, or the "
             + "interactive session goes away. Run the suite on the active desktop of an "
             + "interactive Windows session."
+            + lookupFailure
             + DescribeIdleState());
     }
 
@@ -997,7 +1030,7 @@ internal sealed class EcGuiDriver : IDisposable
 
     private bool WindowExists(int handle) => FindWindow(handle) is not null;
 
-    private static AutomationElement WaitForElement(
+    private AutomationElement WaitForElement(
         Func<AutomationElement?> probe,
         string timeoutMessage) =>
         WaitFor(probe, Timeout, out Exception? lastError)
@@ -1051,7 +1084,7 @@ internal sealed class EcGuiDriver : IDisposable
         return null;
     }
 
-    private static void WaitUntil(Func<bool> predicate, string timeoutMessage) =>
+    private void WaitUntil(Func<bool> predicate, string timeoutMessage) =>
         WaitUntil(predicate, () => timeoutMessage);
 
     /// <summary>
@@ -1064,7 +1097,7 @@ internal sealed class EcGuiDriver : IDisposable
     /// gave up. Building it here fixes both, and routes it through Safely so a
     /// description that throws cannot replace the timeout it exists to explain.
     /// </remarks>
-    private static void WaitUntil(Func<bool> predicate, Func<string> timeoutMessage)
+    private void WaitUntil(Func<bool> predicate, Func<string> timeoutMessage)
     {
         if (WaitFor(
                 () => predicate() ? new object() : null,
@@ -1083,13 +1116,21 @@ internal sealed class EcGuiDriver : IDisposable
     /// A timeout that names the error it kept retrying. A probe that threw every time is
     /// the likeliest reason a wait expired, and every wait in this class reports it.
     /// </summary>
-    private static TimeoutException Expired(string message, Exception? lastError) =>
-        lastError is null
+    private TimeoutException Expired(string message, Exception? lastError)
+    {
+        // Every timeout in this driver is built here, which makes it the one place that
+        // can ask whether EC's window was still reachable when the wait gave up. Asking
+        // only in the idle wait was not enough: a desktop excursion during phase C timed
+        // out in a control lookup instead, so the check never ran and the phase blamed EC.
+        RequireWindowStillReachable();
+
+        return lastError is null
             ? new TimeoutException(message)
             : new TimeoutException(
                 $"{message} Last retried automation error: "
                 + $"{lastError.GetType().Name}: {lastError.Message}",
                 lastError);
+    }
 
     /// <summary>
     /// A failure in the driver's contract with the window - a control that cannot be

--- a/sources/EncodingChecker.GuiSmoke/Program.cs
+++ b/sources/EncodingChecker.GuiSmoke/Program.cs
@@ -73,6 +73,13 @@ internal static class Program
             Console.Error.WriteLine(ex.Message);
             return 2;
         }
+        catch (GuiEnvironmentException ex)
+        {
+            // Exit 2, with the other refused prerequisites: the run did not fail, it
+            // never took place, and calling it a failure would blame EC for the machine.
+            Console.Error.WriteLine(ex.Message);
+            return 2;
+        }
         catch (ArgumentException ex)
         {
             Console.Error.WriteLine(ex.Message);

--- a/sources/EncodingChecker.GuiSmoke/Program.cs
+++ b/sources/EncodingChecker.GuiSmoke/Program.cs
@@ -75,8 +75,8 @@ internal static class Program
         }
         catch (GuiEnvironmentException ex)
         {
-            // Exit 2, with the other refused prerequisites: the run did not fail, it
-            // never took place, and calling it a failure would blame EC for the machine.
+            // Exit 2, with the other refused prerequisites: the phase could not be
+            // verified, so there is no verdict about EC to report either way.
             Console.Error.WriteLine(ex.Message);
             return 2;
         }

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -11,6 +11,23 @@ namespace EncodingChecker.GuiSmoke;
 /// </summary>
 internal sealed class IncompatibleBuildException(string message) : Exception(message);
 
+/// <summary>
+/// The window stopped being reachable while EC carried on running - the machine
+/// took it away, rather than EC misbehaving.
+/// </summary>
+/// <remarks>
+/// Sending EC to a non-active virtual desktop produces exactly this: the process
+/// lives, the conversion completes and writes correct files, and every control
+/// inside the window becomes unreachable through UI Automation - the held element
+/// answers but its subtree holds only the title bar, and looking the window up
+/// again from the desktop finds nothing. Locking the session or losing the
+/// interactive desktop would look the same.
+///
+/// It is a distinct type because the alternative is reporting it as a phase
+/// failure, which accuses EC of not finishing work it in fact finished.
+/// </remarks>
+internal sealed class GuiEnvironmentException(string message) : Exception(message);
+
 internal sealed record SmokePhaseResult(
     string Id,
     string Name,
@@ -102,6 +119,12 @@ internal sealed class SmokeSuite
         try
         {
             body(phase);
+        }
+        catch (GuiEnvironmentException)
+        {
+            // Not this phase's verdict to record: nothing was measured, so let it reach
+            // the top rather than filing it as EC having failed.
+            throw;
         }
         catch (Exception ex)
         {

--- a/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
+++ b/sources/EncodingChecker.GuiSmoke/SmokeSuite.cs
@@ -12,8 +12,8 @@ namespace EncodingChecker.GuiSmoke;
 internal sealed class IncompatibleBuildException(string message) : Exception(message);
 
 /// <summary>
-/// The window stopped being reachable while EC carried on running - the machine
-/// took it away, rather than EC misbehaving.
+/// The window stopped being reachable while EC carried on running, so the phase could
+/// not be verified.
 /// </summary>
 /// <remarks>
 /// Sending EC to a non-active virtual desktop produces exactly this: the process
@@ -23,8 +23,9 @@ internal sealed class IncompatibleBuildException(string message) : Exception(mes
 /// again from the desktop finds nothing. Locking the session or losing the
 /// interactive desktop would look the same.
 ///
-/// It is a distinct type because the alternative is reporting it as a phase
-/// failure, which accuses EC of not finishing work it in fact finished.
+/// It is a distinct type because the alternative is reporting it as a phase failure,
+/// which accuses EC of not finishing work it may well have finished. This says only
+/// that the check could not be made - not that EC did nothing.
 /// </remarks>
 internal sealed class GuiEnvironmentException(string message) : Exception(message);
 
@@ -122,8 +123,9 @@ internal sealed class SmokeSuite
         }
         catch (GuiEnvironmentException)
         {
-            // Not this phase's verdict to record: nothing was measured, so let it reach
-            // the top rather than filing it as EC having failed.
+            // Not this phase's verdict to record: the phase could not be verified, so let
+            // it reach the top rather than filing it as EC having failed. EC may well have
+            // converted files - what is missing is the ability to check.
             throw;
         }
         catch (Exception ex)


### PR DESCRIPTION
Closes [EC-28](docs/DEFECT-BACKLOG.md). **No production code changes**; `MainForm`
was read and not edited.

**What this does:** the smoke suite stops blaming EC when it loses access to the
GUI. **What it does not do:** prevent access from being lost.

## Reproduced

Thirty bounded full-suite runs were started on the final master build, stopping at
the first failure with its workspace preserved. Run 5 failed - in phase **C**, not
phase A, so the finding was never phase-specific.

The preserved workspace shows **EC did the work correctly**: `french.txt`
converted 39 to 45 bytes with a `.bak` and a sidecar, `russian.txt` left in
KOI8-R exactly as the phase requires. The application finished; the driver then
spent thirty seconds blind to it and reported that as EC failing.

Sending EC's window to a non-active virtual desktop reproduces the fingerprint on
demand. The excursion was verified with
`IVirtualDesktopManager::IsWindowOnCurrentVirtualDesktop` rather than assumed - an
early attempt read the state too soon after the hotkey and got the pre-switch
answer, which would have made the experiment a control that could not fail.

## The standing theory was wrong

It is **not** a stale automation object. The held element answered
`NativeWindowHandle` without throwing, and looking the window up again from the
desktop found nothing either (`window found afresh: no`). Reacquisition, the
theory this branch set out to test, would not have helped. `IsOffscreen` is no
signal either - it reads `false` for a window on another desktop.

## The fix

When a wait expires, the driver asks whether EC is still running and whether its
window can be found at all. Process alive and window unreachable is refused, not
failed: `GuiEnvironmentException` says the phase could not be verified and no
verdict about EC is reported - it may already have converted files - `Program`
returns exit 2 beside the other refused prerequisites, and no phase verdict is
printed.

The check began on the idle wait alone and **that was not enough**: an excursion
timed during phase C's source confirmation expired in a control lookup instead, so
it never ran and EC was blamed again. Every timeout is built in one place, so the
question is asked there and covers every wait. Startup keeps its own meaning -
before the window has ever been found, not finding it means EC failed to show one.

## Controls

| Control | Result |
|---|---|
| Hidden past the timeout, during source confirmation | exit 2, environment message, **no phase verdict** - previously `[FAIL] C` |
| Hidden briefly, returned inside the wait | Phase passes; access returns with the window |
| Active desktop, 6 full runs | All pass, no spurious refusal |
| Unit tests | 756 |

Two earlier runs of the widened control passed and proved nothing, because the
desktop verification had been dropped from the script and the switch had not taken
effect. Recorded in the commit: an unverified control cannot fail.

## Unproven

The original occurrence had nobody switching desktops, so its trigger is still
unknown; a locked session or lost interactive desktop would look identical. The
fix does not depend on which - any occurrence now becomes a refusal rather than a
false accusation, which is the harm that mattered on a required gate.

**Setup this settles:** the suite must run on the active desktop of an interactive
Windows session. Unattended runs need a dedicated interactive session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
