### PR TITLE
Look for the review where it lives, not across the whole desktop

### DIFF
--- a/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
+++ b/sources/EncodingChecker.GuiSmoke/EcGuiDriver.cs
@@ -696,9 +696,30 @@ internal sealed class EcGuiDriver : IDisposable
         }
     }
 
-    private AutomationElement? FindReviewWindow() =>
-        FindProcessElementById("ConversionConfirmationForm") ??
-        FindProcessElementByTitle("Review conversion");
+    /// <summary>The conversion review, if EC currently has one open.</summary>
+    /// <remarks>
+    /// The review is an immediate child of the main window, so it is looked for there.
+    /// Searching the desktop instead means repeatedly walking unrelated applications, on
+    /// every poll of several waits.
+    ///
+    /// Automation errors are deliberately not caught: returning null for one would say
+    /// the review is absent when the truth is that nothing could be read, and the waits
+    /// that call this already retry and keep the error.
+    /// </remarks>
+    private AutomationElement? FindReviewWindow()
+    {
+        var condition = new AndCondition(
+            new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Window),
+            new OrCondition(
+                new PropertyCondition(
+                    AutomationElement.AutomationIdProperty,
+                    "ConversionConfirmationForm"),
+                new PropertyCondition(
+                    AutomationElement.NameProperty,
+                    "Review conversion")));
+
+        return MainWindow.FindFirst(TreeScope.Children, condition);
+    }
 
     private int ResultCount() =>
         FindById(MainWindow, "lstResults") is AutomationElement list
@@ -891,36 +912,6 @@ internal sealed class EcGuiDriver : IDisposable
                 automationId));
 
         return AutomationElement.RootElement.FindFirst(TreeScope.Children, condition);
-    }
-
-    private AutomationElement? FindProcessElementById(string automationId)
-    {
-        var condition = new AndCondition(
-            new PropertyCondition(
-                AutomationElement.ProcessIdProperty,
-                _process.Id),
-            new PropertyCondition(
-                AutomationElement.AutomationIdProperty,
-                automationId));
-
-        return AutomationElement.RootElement.FindFirst(
-            TreeScope.Descendants,
-            condition);
-    }
-
-    private AutomationElement? FindProcessElementByTitle(string title)
-    {
-        var condition = new AndCondition(
-            new PropertyCondition(
-                AutomationElement.ProcessIdProperty,
-                _process.Id),
-            new PropertyCondition(
-                AutomationElement.NameProperty,
-                title));
-
-        return AutomationElement.RootElement.FindFirst(
-            TreeScope.Descendants,
-            condition);
     }
 
     private AutomationElement? FindProcessWindowByTitle(string title)


### PR DESCRIPTION
One commit, one method. Independent of #101 - both touch `EcGuiDriver.cs` in
different places, so whichever merges second may want a rebase. **No production
code changes.**

## The cost

`FindReviewWindow` searched `TreeScope.Descendants` from the desktop root, walking
every window of every running application - twice whenever the review was absent,
since it tried the identifier and then the title. It runs on every 50 ms poll of
several waits.

Measured directly, by timing the lookups rather than inferring from total runtime:

| Desktop | Review lookups | Lookup time | Suite wall clock |
|---|---|---|---|
| 10 windows open | 27 | **7900 / 7774 ms** | 22.7 / 22.3s |
| 5 windows open | 27 | **4148 / 4208 ms** | 18.9 / 19.1s |

Same number of lookups either way. About 35% of a run was spent walking other
applications' window trees, and the price tracked what else the machine had on
screen - not something a test result should depend on. The measurement was
prompted by noticing that runs went faster with EC alone on a desktop.

## Where the review actually lives

Measured, not assumed - after a first attempt scoped to the desktop's immediate
children found nothing and failed six runs out of six. An owned dialog is not a
top-level window. Probing all four scopes with a review open:

```
root/children=no   root/descendants=YES   main/children=YES   main/descendants=YES
```

It sits among the main window's own children, so that is where it is looked for,
with identifier or title in one condition instead of two searches. Scoping to the
main window makes the process filter redundant.

Automation errors are deliberately **not** caught here: returning null for one
would report the review as absent when the truth is that nothing could be read,
and the waits that call this already retry and keep the error. That erasure has
had to be fixed twice before in this driver.

## Result

| | Before | After |
|---|---|---|
| Cluttered desktop (10 windows) | 22.7 / 22.3s | **17.3 / 17.6s** |
| Fresh desktop | 18.9 / 19.1s | **17.8 / 17.7s** |

The gap that tracked desktop clutter is gone, and it beats the old best case -
roughly 24% off the suite. Six consecutive full runs pass, four more standalone on
master after the split, and the unit suite is unchanged at 756.

Other descendant searches are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
